### PR TITLE
Fluid 4053

### DIFF
--- a/src/webapp/tests/component-tests/uploader/js/FileQueueTests.js
+++ b/src/webapp/tests/component-tests/uploader/js/FileQueueTests.js
@@ -237,8 +237,8 @@ https://source.fluidproject.org/svn/LICENSE.txt
             jqUnit.assertEquals("testQueue previous uploaded files byte should be 0",
                                 0, 
                                 testQueue.currentBatch.previousBytesUploadedForFile);
-            jqUnit.assertEquals("testQueue file index should be 0",
-                                0, 
+            jqUnit.assertEquals("testQueue file index should be 1",
+                                1, 
                                 testQueue.currentBatch.fileIdx);
             jqUnit.assertEquals("testQueue number of files finished should be 0",
                                 0, 


### PR DESCRIPTION
Fix broken file queue unit test that was introduced in a patch for FLUID-4017.  The default value of fileIdx in the current batch has changed from -1 to 0.
