### PR TITLE
Fluid 4078

### DIFF
--- a/src/webapp/components/uploader/js/HTML5UploaderSupport.js
+++ b/src/webapp/components/uploader/js/HTML5UploaderSupport.js
@@ -49,8 +49,7 @@ var fluid_1_3 = fluid_1_3 || {};
         // Used for browsers that rely on File.getAsBinary(), such as Firefox 3.6,
         // which load the entire file to be loaded into memory.
         // Set this option to a sane limit (100MB) so your users won't experience crashes or slowdowns (FLUID-3937).
-        // File limits in the HTML5 strategy are in bytes.
-        legacyBrowserFileLimit: 100000000,
+        legacyBrowserFileLimit: 100000,
         
         mergePolicy: {
             "components.local.options.events": "preserve",
@@ -255,10 +254,10 @@ var fluid_1_3 = fluid_1_3 || {};
         that.queueSettings = that.options.queueSettings;
 
         // Add files to the file queue without exceeding the fileUploadLimit and the fileSizeLimit
-        // NOTE:  fileSizeLimit set to bytes for HTML5 Uploader (MB for SWF Uploader).  
+        // NOTE:  fileSizeLimit set to bytes for HTML5 Uploader (KB for SWF Uploader).  
         that.addFiles = function (files) {
             // TODO: These look like they should be part of a real model.
-            var sizeLimit = legacyBrowserFileLimit || (that.queueSettings.fileSizeLimit * 1000);
+            var sizeLimit = (legacyBrowserFileLimit || that.queueSettings.fileSizeLimit) * 1024;
             var fileLimit = that.queueSettings.fileUploadLimit;
             var uploaded = that.queue.getUploadedFiles().length;
             var queued = that.queue.getReadyFiles().length;

--- a/src/webapp/tests/component-tests/uploader/js/HTML5UploaderSupportTests.js
+++ b/src/webapp/tests/component-tests/uploader/js/HTML5UploaderSupportTests.js
@@ -78,7 +78,7 @@ https://source.fluidproject.org/svn/LICENSE.txt
 
         var file3 =  {
             id: "file3",
-            size: 1001
+            size: 200000
         };
         
         html5UploaderTests.test("Ensure multipart content is correctly built", function () {
@@ -213,7 +213,7 @@ https://source.fluidproject.org/svn/LICENSE.txt
             var listeners = makeListeners();
             tracker.interceptAll(listeners);
             
-            var localUploader = getLocalUploader(1, 0, listeners, 100000000);
+            var localUploader = getLocalUploader(1, 0, listeners, 100000);
             localUploader.addFiles(files);
             
             // Test #1: One out of three files should have been added to the queue.
@@ -239,7 +239,7 @@ https://source.fluidproject.org/svn/LICENSE.txt
              var listeners = makeListeners();
              tracker.interceptAll(listeners);
                                                   
-             var localUploader = getLocalUploader(0, 0, listeners, 100000000);
+             var localUploader = getLocalUploader(0, 0, listeners, 100000);
              localUploader.addFiles(files);
              
              // Test #1: All three files should have been added to the queue.
@@ -265,7 +265,7 @@ https://source.fluidproject.org/svn/LICENSE.txt
              var listeners = makeListeners();
              tracker.interceptAll(listeners);
                                                   
-             var localUploader = getLocalUploader(null, 0, listeners, 100000000);
+             var localUploader = getLocalUploader(null, 0, listeners, 100000);
              localUploader.addFiles(files);
              
              // Test #1: All three files should have been added to the queue.
@@ -291,7 +291,7 @@ https://source.fluidproject.org/svn/LICENSE.txt
              var listeners = makeListeners();
              tracker.interceptAll(listeners);
                                                   
-             var localUploader = getLocalUploader(undefined, 0, listeners, 100000000);
+             var localUploader = getLocalUploader(undefined, 0, listeners, 100000);
              localUploader.addFiles(files);
              
              // Test #1: All three files should have been added to the queue.


### PR DESCRIPTION
Colin,

The fileSizeLimit has now been correctly converted from KB to bytes.  The tests have been repaired to reflect the conversion.  The default value of legacyBrowserLimit has also been converted to bytes.  The HTML5 strategy now consistently uses bytes to avoid file unit size confusion.  
