### PR TITLE
FLUID-4185: Fixed the HTML5 remote argumentMap options value

### DIFF
--- a/src/webapp/components/uploader/js/HTML5UploaderSupport.js
+++ b/src/webapp/components/uploader/js/HTML5UploaderSupport.js
@@ -169,7 +169,7 @@ var fluid_1_4 = fluid_1_4 || {};
     fluid.defaults("fluid.uploader.html5Strategy.remote", {
         gradeNames: ["fluid.eventedComponent"],
         argumentMap: {
-            options: 2  
+            options: 1  
         },                
         invokers: {
             doUpload: "fluid.uploader.html5Strategy.doUpload"


### PR DESCRIPTION
@colinbdclark:   Simple fix to use the correct options value in the argumentMap for the HTML5 remote uploader component.
