### PR TITLE
FLUID-4275: Fixed demands block for XHR creator so that tests are passing

### DIFF
--- a/src/webapp/tests/component-tests/uploader/js/UploaderTests.js
+++ b/src/webapp/tests/component-tests/uploader/js/UploaderTests.js
@@ -222,7 +222,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             }            
         });        
         
-        fluid.demands("fluid.uploader.html5Strategy.createFileUploadXHR", ["fluid.uploader.html5Strategy.remote", "fluid.uploader.tests"], {
+        fluid.demands("fluid.uploader.html5Strategy.createXHR", ["fluid.uploader.html5Strategy.remote", "fluid.uploader.tests"], {
             funcName: "fluid.tests.uploader.createMockXHR"
         });    
         


### PR DESCRIPTION
FLUID-4275: Fixed demands block for XHR creator so that tests are passing again in FF3.6.

@amb26, can you do the honours?
