### PR TITLE
FLUID-4263: Added "afterRender" event as requested by DAHLQUIST

### DIFF
--- a/src/webapp/components/pager/js/Pager.js
+++ b/src/webapp/components/pager/js/Pager.js
@@ -638,6 +638,7 @@ var fluid_1_4 = fluid_1_4 || {};
                         options.renderOptions = options.renderOptions || {};
                         options.renderOptions.model = expOpts.dataModel;
                         fluid.reRender(template, root, fullTree, options.renderOptions);
+                        overallThat.events.afterRender.fire(overallThat);
                         setModelSortHeaderClass(newModel, expOpts); // TODO, should this not be actually renderable?
                     }
                 }
@@ -923,7 +924,8 @@ var fluid_1_4 = fluid_1_4 || {};
             initiatePageChange: null,
             initiatePageSizeChange: null,
             onModelChange: null,
-            onRenderPageLinks: null
+            onRenderPageLinks: null,
+            afterRender: null
         },
         
         markup: {

--- a/src/webapp/tests/component-tests/pager/js/PagerTests.js
+++ b/src/webapp/tests/component-tests/pager/js/PagerTests.js
@@ -289,12 +289,21 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         
         tests.test("Pager bodyRenderer: fluid.pager.selfRender with default columnDefs (FLUID-3793)", function () {
             // without a fix to FLUID-3793, pager creation will fail with the default selfRender configuration
-            expect(1);
+            jqUnit.expect(2);
+            var afterRenderThat;
+            var pager;
+            function afterRenderListener(overallThat) {
+                afterRenderThat = overallThat;
+            }
             var pager = markupPager("#plants", {
                 bodyRenderer: "fluid.pager.selfRender",
-                dataModel: {}
+                dataModel: {},
+                listeners: {
+                    afterRender: afterRenderListener
+                }
             });
             jqUnit.assertTrue("Pager has been successfully created", pager);
+            jqUnit.assertTrue("AfterRender event fired with pager", pager, afterRenderThat);
         });
 
         tests.test("Pager tooltip", function () {


### PR DESCRIPTION
@jobara - This is a minor fix which is really urgent for the uPortal folks - they are using the Pager extensively throughout uPortal and have some terrible hacks to get around this issue
