### PR TITLE
FLUID-4109: Edited buildRegExpression() to generate the regular expression

### DIFF
--- a/build-scripts/build.js
+++ b/build-scripts/build.js
@@ -251,7 +251,6 @@ var globalObj = this;
                         regExpStr += "|";
                     }
                     convertedStr = currentFiles[j].replace(/\./g, "\\."); //this is to escape the "." character which is a wildcard in ant regex.
-                    convertedStr = '\\/' + convertedStr;  //FLUID-4109: Allow only the exact component name with a URL separator prefix 
                     regExpStr += (regStart + convertedStr + regEnd);
                 }
             }

--- a/build-scripts/build.xml
+++ b/build-scripts/build.xml
@@ -15,7 +15,7 @@
     <property name="base-dir" location=".." />
     <property file="build.properties"/>
     <!-- properties for URL rewriting - these should be moved to the build.properties file -->
-    <property name="regexStartJS" value="&lt;script{1,1}?.*" />
+    <property name="regexStartJS" value="&lt;script{1,1}?.*\/" />
     <property name="regexEndJS" value="{1,1}?.*script>" />
     <property name="replaceRegexStartJS" value="[\/-z]*" />
     <property name="replaceRegexEndJS" value="&quot;" />


### PR DESCRIPTION
FLUID-4109: Edited buildRegExpression() to generate the regular expression with a directory separator in front of the module, so then the (.*) is only comparing the path, but not the filename itself.  Allowing us to have more control over which file to be replaced.
