### PR TITLE
FLUID-4203: Adding more types of form controls.

### DIFF
--- a/src/webapp/tests/manual-tests/html/SomeKindOfNews.html
+++ b/src/webapp/tests/manual-tests/html/SomeKindOfNews.html
@@ -116,16 +116,40 @@
 
                     <div class="skon-newsletter-signup">
                         <p>Get all the news, right in your in-box! Sign up for our newsletter:</p>
-                        <ul class="fl-controls-right">
-                            <li>
-                                <label class="fl-label">Name</label>
-                                <input type="text" value="John Smith">
-                            </li>
-                            <li>
-                                <label class="fl-label">Email Address</label>
-                                <input type="text" value="john@smith.com">
-                            </li>
-                        </ul>
+                        <div class="fl-container-flex100 fl-centered">
+                            <div class="fl-col-flex2">
+                                <div class="fl-col">
+                                    <ul class="fl-controls-left">
+                                        <li>
+                                            <label class="fl-label">Name</label>
+                                            <input type="text" value="John Smith">
+                                        </li>
+                                        <li>
+                                            <label class="fl-label">Email Address</label>
+                                            <input type="text" value="john@smith.com">
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div class="fl-col">
+                                    <ul class="fl-controls-right">
+                                        <li>
+                                            <label class="fl-label">Language</label>
+                                            <select>
+                                                <option>English</option>
+                                                <option>Esperanto</option>
+                                                <option>Pig Latin</option>
+                                            </select>
+                                        </li>
+                                        <li>
+                                            <label class="fl-label">Format</label>
+                                            <input type="radio" value="html">HTML</input>
+                                            <input type="radio" value="html">plain text</input>
+                                        </li>
+                                    </ul>
+                                    <button>Click me, it tickles!</button>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="fl-container-flex95 fl-centered">


### PR DESCRIPTION
I've noticed that the 'make buttons and inputs larger' option is not working on some types of inputs. I've modified the test page (SomeKindOfNews.html in the manual-tests folder) to include more types of inputs, so that this issue can be easily observed.
