### PR TITLE
FLUID-4299: opts for the cookie in the cookieStore

### DIFF
--- a/src/webapp/components/uiOptions/js/Store.js
+++ b/src/webapp/components/uiOptions/js/Store.js
@@ -52,13 +52,11 @@ var fluid_1_4 = fluid_1_4 || {};
             },
             save: {
                 funcName: "fluid.cookieStore.save",
-                args: ["{arguments}.0", "{cookieStore}.options.strings.cookie", "{cookieStore}.options.cookie"]
+                args: ["{arguments}.0", "{cookieStore}.options.cookie"]
             }
         },
-        strings: {
-            cookie: "%name=%data; expires=%expires; path=%path"
-        },
         cookie: {
+            template: "%name=%data; expires=%expires; path=%path",
             name: "fluid-ui-settings",
             path: "/",
             expires: ""
@@ -91,12 +89,11 @@ var fluid_1_4 = fluid_1_4 || {};
     /**
      * Saves the settings into a cookie
      * @param {Object} settings
-     * @param {String} cookieTemplate
      * @param {Object} cookieOptions
      */
-    fluid.cookieStore.save = function (settings, cookieTemplate, cookieOptions) {
+    fluid.cookieStore.save = function (settings, cookieOptions) {
         cookieOptions.data = encodeURIComponent(JSON.stringify(settings));
-        document.cookie = fluid.stringTemplate(cookieTemplate, cookieOptions);
+        document.cookie = fluid.stringTemplate(cookieOptions.template, cookieOptions);
     };
     
 

--- a/src/webapp/tests/component-tests/uiOptions/js/StoreTests.js
+++ b/src/webapp/tests/component-tests/uiOptions/js/StoreTests.js
@@ -24,10 +24,21 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             layout: false
         };
         
+        var cookieName = "fluid-cookieStore-test";
+        
+        var dropCookie = function (cookieName) {
+            var date = new Date();
+            document.cookie = cookieName + "=; expires=" + date.toGMTString() + "; path=/";
+        };
+        
         var tests = new jqUnit.TestCase("Store Tests");
                 
         tests.test("Cookie", function () {
-            var store = fluid.cookieStore();
+            var store = fluid.cookieStore({
+                cookie: {
+                    name: cookieName
+                }
+            });
             store.save(testSettings);
             
             // Check that we get back the test settings correctly.
@@ -47,9 +58,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             jqUnit.assertTrue("Our cookie should contain the textSize 2.",
                                document.cookie.indexOf("2") > cookieNameIndex);
                                            
-            // Reset the cookie settings
-            store.save(store.options.defaultSiteSettings);
-            
+            // Remove test cookie
+            dropCookie(store.options.cookie.name);
         });
 
         tests.test("Temp store", function () {


### PR DESCRIPTION
The cookieStore can now take in options such as expires and path on top of the name for the cookie. There is also now a default path specified, which will prevent a bug that had the cookie not accessible when to a parent page when it was set in an iframe (e.g. for fat panel uio).

http://issues.fluidproject.org/browse/FLUID-4299
