### PR TITLE
FLUID-4301: Fix and test case for provocation of circular expansion detec

### DIFF
--- a/src/webapp/framework/core/js/FluidIoC.js
+++ b/src/webapp/framework/core/js/FluidIoC.js
@@ -1111,13 +1111,14 @@ outer:  for (var i = 0; i < exist.length; ++i) {
     
     fluid.defaults("fluid.resolveEnvironment", {
         ELstyle:     "${}",
+        seenIds:     {},
         bareContextRefs: true
     });
     
     fluid.resolveEnvironment = function(obj, options) {
-        options = fluid.merge(null, fluid.defaults("fluid.resolveEnvironment"), options);
-        options.seenIds = {};
-        
+        // Don't create a component here since this function is itself used in the 
+        // component expansion pathway - avoid all expansion in any case to head off FLUID-4301
+        var options = $.extend(true, {}, fluid.rawDefaults("fluid.resolveEnvironment"), options);
         return resolveEnvironmentImpl(obj, options);
     };
 

--- a/src/webapp/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
+++ b/src/webapp/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
@@ -1356,10 +1356,15 @@ fluid.registerNamespace("fluid.tests");
                     here: {
                         href: "#here",
                         name: "messagekey"
-                    }
+                    },
+                    "FLUID-4301": [ 
+                        { id: 1 },
+                        { id: 1 }  
+                    ]
                 }
             };
-            var expopts = {ELstyle: "${}", model: model};
+            var applier = fluid.makeChangeApplier(model);
+            var expopts = {ELstyle: "${}", model: model, applier: applier};
             var expander = fluid.renderer.makeProtoExpander(expopts);
             var protoTree = {
                 expander: {


### PR DESCRIPTION
FLUID-4301: Fix and test case for provocation of circular expansion detection caused by attempt to expand options supplied to protoComponent expander (within "fluid.resolveEnvironment") - these should really just be merged simply

@colinbdclark, @jobara
