### PR TITLE
FLUID-4309: Set default background colour of fat panel to white

### DIFF
--- a/src/webapp/components/uiOptions/css/FatPanelUIOptions.css
+++ b/src/webapp/components/uiOptions/css/FatPanelUIOptions.css
@@ -2,6 +2,7 @@
 
 .fl-uiOptions-fatPanel {
     min-width: 960px;
+    background-color: #fff;
 }
 
 /* Panel bar */


### PR DESCRIPTION
@jobara literally one line of css added:  background-color: #fff;
