### PR TITLE
FLUID-4319: Additional style over-rides for jq ui tabs in fat panel

### DIFF
--- a/src/webapp/components/uiOptions/css/FatPanelUIOptions.css
+++ b/src/webapp/components/uiOptions/css/FatPanelUIOptions.css
@@ -70,8 +70,10 @@
 .fl-uiOptions-fatPanel.ui-tabs .ui-helper-reset { line-height: 1em; }
 .fl-uiOptions-fatPanel.ui-tabs .ui-tabs-nav li.ui-tabs-selected { padding-bottom: 0px; }
 .fl-uiOptions-fatPanel .ui-corner-top { -moz-border-radius-topleft: 0px; -moz-border-radius-topright: 0px; }
-.fl-uiOptions-fatPanel.ui-widget-content { border: none; }
+.fl-uiOptions-fatPanel .ui-corner-all { -moz-border-radius: 0px; }
 .fl-uiOptions-fatPanel.ui-widget { font-family: "Myriad Pro",Helvetica,Arial,sans-serif; font-size: 1em; } /* fix a jquery theme bugs where font-size was set to 1.1em or 1.2em. */
+.fl-uiOptions-fatPanel.ui-widget-content { border: none; }
+.fl-uiOptions-fatPanel.ui-tabs .ui-widget-header { background: none; border: 0px; background-color: #333333; }
 
 /* Tab images */
 .fl-uiOptions-fatPanel .fl-tab-text, .fl-uiOptions-fatPanel .fl-tab-layout, .fl-uiOptions-fatPanel .fl-tab-links, .fl-uiOptions-fatPanel #reset {


### PR DESCRIPTION
Sets background, border, radius of Fat Panel tabs - overrides needed when jq ui tab styling used elsewhere in page
