### PR TITLE
FLUID-4344: Fixes to UIO manual-test page and sakai demo.

### DIFF
--- a/src/webapp/integration-demos/sakai/html/ui-options-fss-sakai.html
+++ b/src/webapp/integration-demos/sakai/html/ui-options-fss-sakai.html
@@ -66,7 +66,7 @@
     <body class="fl-theme-mist fl-focus">
 
         <div class="lookNfeel fl-container flc-uiOptions-fatPanel">
-            <div class="ui_options flc-slidingPanel-panel"></div>
+            <div class="ui_options flc-slidingPanel-panel flc-uiOptions-iframe"></div>
 
             <a href="#_bottom" class="flc-slidingPanel-toggleButton skin_ fl-linearEnabled"></a>
         </div>
@@ -254,6 +254,14 @@
             fluid.demands("fluid.uiOptionsTemplateLoader", "fluid.FssSakaiUIOptions", {
                 options: {
                     prefix: "../../../components/uiOptions/html/"
+                }
+            });
+        
+            fluid.demands("fluid.renderIframe", ["fluid.FssSakaiUIOptions"], {
+                options: {
+                    markupProps: {
+                        src: "../../../components/uiOptions/html/FatPanelUIOptionsFrame.html"
+                    }
                 }
             });
         

--- a/src/webapp/tests/manual-tests/html/SomeKindOfNews.html
+++ b/src/webapp/tests/manual-tests/html/SomeKindOfNews.html
@@ -66,7 +66,7 @@
     <body class="skon-theme-basic">
 
 		<div class="flc-uiOptions-fatPanel fl-uiOptions-fatPanel">
-			<div id="myUIOptions" class="flc-slidingPanel-panel"></div>
+			<div id="myUIOptions" class="flc-slidingPanel-panel flc-uiOptions-iframe"></div>
 			
 			<div class="fl-panelBar">
 				<button class="flc-slidingPanel-toggleButton fl-toggleButton">Show/Hide</button>

--- a/src/webapp/tests/manual-tests/js/someKindOfNews.js
+++ b/src/webapp/tests/manual-tests/js/someKindOfNews.js
@@ -28,6 +28,14 @@ var skon = skon || {};
             }
         });
 
+        fluid.demands("fluid.renderIframe", ["skon.demo"], {
+            options: {
+                markupProps: {
+                    src: "../../../components/uiOptions/html/FatPanelUIOptionsFrame.html"
+                }
+            }
+        });
+    
         // Supply the table of contents' template URL
         fluid.demands("fluid.tableOfContents", ["fluid.uiEnhancer", "skon.demo"], {
             options: {


### PR DESCRIPTION
@michelled, this was a small fix, involving 1) adding the iframe selector and 2) adding a demands block for the frame template.
