### PR TITLE
FLUID-4355: UIO FatPanel slider icon out of place when non-default colour-contrast is selected

### DIFF
--- a/src/webapp/components/uiOptions/css/UIOptions.css
+++ b/src/webapp/components/uiOptions/css/UIOptions.css
@@ -148,7 +148,7 @@
 .fl-theme-hc .ui-slider-horizontal .ui-slider-handle,
 .fl-theme-hci .ui-slider-horizontal .ui-slider-handle,
 .fl-theme-blackYellow .ui-slider-horizontal .ui-slider-handle,
-.fl-theme-yellowBlack .ui-slider-horizontal .ui-slider-handle { margin-top: -5px; }
+.fl-theme-yellowBlack .ui-slider-horizontal .ui-slider-handle { margin-top: -0.3em; }
 
 .fl-theme-hc .fl-uiOptions .fl-slider { background: none; background-color:#000;}
 .fl-theme-hc .fl-uiOptions .fl-slider .fl-handle, 

--- a/src/webapp/components/uiOptions/html/FatPanelUIOptionsFrame.html
+++ b/src/webapp/components/uiOptions/html/FatPanelUIOptionsFrame.html
@@ -16,8 +16,8 @@
         <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-hci/hci.css" />
         <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-hc/hc.css" />
         <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-hci/hci.css" />        
-        <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-blackyellow/blackYellow.css" />
-        <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-yellowblack/yellowBlack.css" />
+        <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-blackYellow/blackYellow.css" />
+        <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-yellowBlack/yellowBlack.css" />
 
         <link rel="stylesheet" type="text/css" href="../css/UIOptions.css" />
         <link rel="stylesheet" type="text/css" href="../css/FatPanelUIOptionsFrame.css" />

--- a/src/webapp/integration-demos/sakai/html/ui-options-fss-sakai.html
+++ b/src/webapp/integration-demos/sakai/html/ui-options-fss-sakai.html
@@ -14,7 +14,6 @@
         <link rel="stylesheet" type="text/css" href="../../../framework/fss/css/fss-theme-slate.css" />
         <link rel="stylesheet" type="text/css" href="../../../framework/fss/css/fss-theme-coal.css" />
         <link rel="stylesheet" type="text/css" href="../../../components/uiOptions/css/UIOptions.css" />
-        <link rel="stylesheet" type="text/css" href="../../../components/uiOptions/css/Slider.css" />
         <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-coal/coal.css" />
         <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-mist/mist.css" />
         <link rel="stylesheet" type="text/css" href="../../../lib/jquery/ui/css/fl-theme-slate/slate.css" />

--- a/src/webapp/tests/manual-tests/html/SomeKindOfNews.html
+++ b/src/webapp/tests/manual-tests/html/SomeKindOfNews.html
@@ -26,7 +26,6 @@
 
         <link rel="stylesheet" type="text/css" href="../../../components/uiOptions/css/UIOptions.css" />
         <link rel="stylesheet" type="text/css" href="../../../components/uiOptions/css/FatPanelUIOptions.css" />
-        <link rel="stylesheet" type="text/css" href="../../../components/uiOptions/css/Slider.css" />
         <link rel="stylesheet" type="text/css" href="../css/SomeKindOfNews.css" />
 
         <title>Some Kind Of News - UI Options Demo</title>


### PR DESCRIPTION
Changed margin -5px to -0.3em so the slider remains in the center.  Also fixed path name for the blackYellow and yellowBlack css.  I have also removed Slider.css from SomeKindOfNews.html and sakai demo since it's no longer in used.
