### PR TITLE
FLUID-4375: The relative indentation should be the default for ToC

### DIFF
--- a/src/webapp/components/tableOfContents/js/TableOfContents.js
+++ b/src/webapp/components/tableOfContents/js/TableOfContents.js
@@ -191,7 +191,7 @@ var fluid_1_4 = fluid_1_4 || {};
                 funcName: "fluid.tableOfContents.modelBuilder.toModel",
                 args: ["{arguments}.0", "{modelBuilder}.modelLevelFn"]
             },
-            modelLevelFn: "fluid.tableOfContents.modelBuilder.skippedModelLevelFn"
+            modelLevelFn: "fluid.tableOfContents.modelBuilder.gradualModelLevelFn"
         }
     });
     

--- a/src/webapp/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
+++ b/src/webapp/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
@@ -353,9 +353,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             assembleModelTests(createElms(linearHeadings.headingTags), linearHeadings.anchorInfo, linearHeadings.model);
         });
         tocMBTests.test("assembleModel: skipped headings", function () {
-            // test assembleModel with default toModel invoker - skippedHeadingsForSkippedIndentationModel
-            assembleModelTests(createElms(skippedHeadingsForSkippedIndentationModel.headingTags), 
-                skippedHeadingsForSkippedIndentationModel.anchorInfo, skippedHeadingsForSkippedIndentationModel.model);
+            // test assembleModel with default toModel invoker - skippedHeadingsForGradualIndentationModel
+            assembleModelTests(createElms(skippedHeadingsForGradualIndentationModel.headingTags), 
+                skippedHeadingsForGradualIndentationModel.anchorInfo, skippedHeadingsForGradualIndentationModel.model);
         });
         
         tocMBTests.test("Test gradualModelLevelFn", function () {


### PR DESCRIPTION
The default model generation in the defaults' invokers: modelLevelFn is now set to use "fluid.tableOfContents.modelBuilder.gradualModelLevelFn" instead of "fluid.tableOfContents.modelBuilder.skippedModelLevelFn".  Unit test has been adjusted accordingly.
