### PR TITLE
FLUID-4357: Changed from fss-reset to the new fss-reset-global

### DIFF
--- a/src/webapp/components/uiOptions/html/FatPanelUIOptionsFrame.html
+++ b/src/webapp/components/uiOptions/html/FatPanelUIOptionsFrame.html
@@ -4,7 +4,7 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../framework/fss/css/fss-reset.css" />
+        <link rel="stylesheet" type="text/css" href="../../../framework/fss/css/fss-reset-global.css" />
         <link rel="stylesheet" type="text/css" href="../../../framework/fss/css/fss-layout.css" />
         <link rel="stylesheet" type="text/css" href="../../../framework/fss/css/fss-text.css" />
         <link rel="stylesheet" type="text/css" href="../css/fss/fss-theme-hc-uio.css" />


### PR DESCRIPTION
It seems that the base styles were setting the font to be too small.
Switching to just using the reset instead of the old combined reset and
base styles resolves the issue.

http://issues.fluidproject.org/browse/FLUID-4357
