### PR TITLE
FLUID-4369: Removed dashed underline from headers

### DIFF
--- a/src/webapp/framework/fss/css/fss-theme-blackYellow.css
+++ b/src/webapp/framework/fss/css/fss-theme-blackYellow.css
@@ -24,7 +24,7 @@
 .fl-theme-blackYellow h3,
 .fl-theme-blackYellow h4,
 .fl-theme-blackYellow h5,
-.fl-theme-blackYellow h6 {color:#000; background-color:#ff0; border-color:#000; border-bottom:0.1em dashed #000000;}
+.fl-theme-blackYellow h6 {color:#000; background-color:#ff0; border-color:#000;}
 
 /* Tables */
 .fl-theme-blackYellow th {border:0.1em solid #000; background-color:#000; color:#ff0;}

--- a/src/webapp/framework/fss/css/fss-theme-hc.css
+++ b/src/webapp/framework/fss/css/fss-theme-hc.css
@@ -24,7 +24,7 @@
 .fl-theme-hc h3,
 .fl-theme-hc h4,
 .fl-theme-hc h5,
-.fl-theme-hc h6 {color:#000; background-color:#fff; border-color:#000; border-bottom:0.1em dashed #000000;}
+.fl-theme-hc h6 {color:#000; background-color:#fff; border-color:#000;}
 
 /* Tables */
 .fl-theme-hc th {border:0.1em solid #000; background-color:#000; color:#fff;}

--- a/src/webapp/framework/fss/css/fss-theme-hci.css
+++ b/src/webapp/framework/fss/css/fss-theme-hci.css
@@ -24,7 +24,7 @@
 .fl-theme-hci h3,
 .fl-theme-hci h4,
 .fl-theme-hci h5,
-.fl-theme-hci h6 {color:#ffffff; background-color:#000000; border-color:#ffffff; border-bottom:0.1em dashed #ffffff;}
+.fl-theme-hci h6 {color:#ffffff; background-color:#000000; border-color:#ffffff;}
 
 /* Tables */
 .fl-theme-hci th {border:0.1em solid #ffffff; background-color:#ffffff; color:#000000;}

--- a/src/webapp/framework/fss/css/fss-theme-yellowBlack.css
+++ b/src/webapp/framework/fss/css/fss-theme-yellowBlack.css
@@ -24,7 +24,7 @@
 .fl-theme-yellowBlack h3,
 .fl-theme-yellowBlack h4,
 .fl-theme-yellowBlack h5,
-.fl-theme-yellowBlack h6 {color:#ffff00; background-color:#000000; border-color:#ffff00; border-bottom:0.1em dashed #ffff00;}
+.fl-theme-yellowBlack h6 {color:#ffff00; background-color:#000000; border-color:#ffff00;}
 
 /* Tables */
 .fl-theme-yellowBlack th {border:0.1em solid #ffff00; background-color:#ffff00; color:#000000;}


### PR DESCRIPTION
Removed the dashed bottom borders that were applied to all heading
levels in the contrast themes.

http://issues.fluidproject.org/browse/FLUID-4369
