### PR TITLE
FLUID-4367: Fixing border colours in contrast themes

### DIFF
--- a/build-scripts/uiOptions/js/StylesheetImportant.js
+++ b/build-scripts/uiOptions/js/StylesheetImportant.js
@@ -28,7 +28,21 @@ var fluid = fluid || {};
             {
                 type: fluid.build.cssGenerator.prioritize,
                 options: {
-                    "fluid-cssGenerator-allRules": "background-color"
+                    "fluid-cssGenerator-allRules": [
+                        "font-size", 
+                        "line-height", 
+                        "font-family", 
+                        "color", 
+                        "background-color", 
+                        "background-image", 
+                        "background", 
+                        "border", 
+                        "border-color",
+                        "border-bottom-color",
+                        "border-top-color",
+                        "border-left-color",
+                        "border-right-color"
+                    ]
                 }
             },
             {

--- a/src/webapp/framework/fss/css/fss-theme-blackYellow.css
+++ b/src/webapp/framework/fss/css/fss-theme-blackYellow.css
@@ -15,6 +15,9 @@
 /* Divs, inputs */
 .fl-theme-blackYellow div, .fl-theme-blackYellow input {color:#000000; background-color:#ffff00; border-color:#000;}
 
+/* iframes */
+.fl-theme-blackYellow iframe {border-color:#000;}
+
 /* Links */
 .fl-theme-blackYellow a  {color: #000; font-weight:bold; background-color:#ff0;}
 

--- a/src/webapp/framework/fss/css/fss-theme-hc.css
+++ b/src/webapp/framework/fss/css/fss-theme-hc.css
@@ -15,6 +15,9 @@
 /* Divs, inputs */
 .fl-theme-hc div, .fl-theme-hc input {color:#000000; background-color:#ffffff; border-color:#000;}
 
+/* iframes */
+.fl-theme-hc iframe {border-color:#000;}
+
 /* Links */
 .fl-theme-hc a  {color: #000; font-weight:bold; background-color:#fff;}
 

--- a/src/webapp/framework/fss/css/fss-theme-hci.css
+++ b/src/webapp/framework/fss/css/fss-theme-hci.css
@@ -13,7 +13,10 @@
 .fl-theme-hci {color:#fff; background-color:#000;}
 
 /* Divs, inputs */
-.fl-theme-hci div, .fl-theme-hci input {color:#fff; background-color:#000;}
+.fl-theme-hci div, .fl-theme-hci input {color:#fff; background-color:#000; border-color:#fff}
+
+/* iframes */
+.fl-theme-hci iframe {border-color:#fff;}
 
 /* Links */
 .fl-theme-hci a  {color: #ffffff; font-weight:bold; background-color:#000000;}

--- a/src/webapp/framework/fss/css/fss-theme-yellowBlack.css
+++ b/src/webapp/framework/fss/css/fss-theme-yellowBlack.css
@@ -13,7 +13,10 @@
 .fl-theme-yellowBlack {color:#ff0; background-color:#000;}  
 
 /* Divs, inputs */
-.fl-theme-yellowBlack div, .fl-theme-yellowBlack input {color:#ff0; background-color:#000;}
+.fl-theme-yellowBlack div, .fl-theme-yellowBlack input {color:#ff0; background-color:#000; border-color:#ff0}
+
+/* iframes */
+.fl-theme-yellowBlack iframe {border-color:#ff0;}
 
 /* Links */
 .fl-theme-yellowBlack a  {color: #ffff00; font-weight:bold; background-color:#000000;}


### PR DESCRIPTION
There were a few things needed to get the border colours to work with
the themes. 1) a couple of the themes were missing the border-color
property for inputs and divs 2) the borders on iframes weren't
considered in the contrast themes, 3) the border-color properties needed
to have !important.  I also added in the missing properties that are
supposed to get !important injection in the generation code.

http://issues.fluidproject.org/browse/FLUID-4367
