### PR TITLE
FLUID-4366: fixing the styling of the sliders with the contrast themes

### DIFF
--- a/src/webapp/components/uiOptions/css/FatPanelUIOptionsFrame.css
+++ b/src/webapp/components/uiOptions/css/FatPanelUIOptionsFrame.css
@@ -48,8 +48,8 @@
 .fl-uiOptions-fatPanel.ui-tabs .ui-state-default { border: none; }
 .fl-uiOptions-fatPanel.ui-tabs .ui-helper-reset { line-height: 1em; }
 .fl-uiOptions-fatPanel.ui-tabs .ui-tabs-nav li.ui-tabs-selected { padding-bottom: 0px; }
-.fl-uiOptions-fatPanel .ui-corner-top { -moz-border-radius-topleft: 0px; -moz-border-radius-topright: 0px; }
-.fl-uiOptions-fatPanel .ui-corner-all { -moz-border-radius: 0px; }
+.fl-uiOptions-fatPanel .fl-tabs .ui-corner-top { -moz-border-radius-topleft: 0px; -moz-border-radius-topright: 0px; }
+.fl-uiOptions-fatPanel .fl-tabs .ui-corner-all { -moz-border-radius: 0px; }
 .fl-uiOptions-fatPanel.ui-widget { font-family: "Myriad Pro",Helvetica,Arial,sans-serif; font-size: 0.85em; } /* fix a jquery theme bugs where font-size was set to 1.1em or 1.2em. */
 .fl-uiOptions-fatPanel.ui-widget-content { border: none; }
 .fl-uiOptions-fatPanel.ui-tabs .ui-widget-header { background: none; border: 0px; background-color: #333333; }
@@ -109,10 +109,10 @@ ul.fl-pane li {
 
 /* Theming */
 /* Override theme tab rounding */
-.fl-theme-hc .fl-uiOptions-fatPanel .ui-corner-all, 
-.fl-theme-hci .fl-uiOptions-fatPanel .ui-corner-all, 
-.fl-theme-blackYellow .fl-uiOptions-fatPanel .ui-corner-all, 
-.fl-theme-yellowBlack .fl-uiOptions-fatPanel .ui-corner-all { -moz-border-radius: 0px; border: 0px; }
+.fl-theme-hc .fl-uiOptions-fatPanel .fl-tab .ui-corner-all, 
+.fl-theme-hci .fl-uiOptions-fatPanel .fl-tab .ui-corner-all, 
+.fl-theme-blackYellow .fl-uiOptions-fatPanel .fl-tab .ui-corner-all, 
+.fl-theme-yellowBlack .fl-uiOptions-fatPanel .fl-tab .ui-corner-all { -moz-border-radius: 0px; border: 0px; }
 
 /* Tab images - black on white */
 .fl-theme-hc .fl-uiOptions-fatPanel .fl-tab-text { background-image: url('../images/hc/uio_icon_textanddisplay_hcInverted_16x16.png'); }

--- a/src/webapp/components/uiOptions/js/UIEnhancer.js
+++ b/src/webapp/components/uiOptions/js/UIEnhancer.js
@@ -123,10 +123,10 @@ var fluid_1_4 = fluid_1_4 || {};
             },
             "theme": {
                 "default": "",
-                "bw": "fl-theme-uio-hc",
-                "wb": "fl-theme-uio-hci",
-                "by": "fl-theme-uio-blackYellow",
-                "yb": "fl-theme-uio-yellowBlack"
+                "bw": "fl-theme-uio-hc fl-theme-hc",
+                "wb": "fl-theme-uio-hci fl-theme-hci",
+                "by": "fl-theme-uio-blackYellow fl-theme-blackYellow",
+                "yb": "fl-theme-uio-yellowBlack fl-theme-yellowBlack"
             },
             "layout": "fl-layout-linear",
             "links": "fl-text-underline fl-text-bold fl-text-larger", 


### PR DESCRIPTION
The sliders weren't showing up properly when themes were applied because
the jQuery UI themes were not scoped to the new generated themes class
name. To work around this we are adding both classnames when the theme
is chosen. Fat panel also had an issue caused by the overrides to the
jQuery UI tabs. I've scoped these to the .fl-tabs class now.

http://issues.fluidproject.org/browse/FLUID-4366
