### PR TITLE
FLUID-4396: Better diagnostics in case where markup is missing for a view, "that is null"

### DIFF
--- a/src/webapp/framework/core/js/Fluid.js
+++ b/src/webapp/framework/core/js/Fluid.js
@@ -1384,6 +1384,24 @@ var fluid = fluid || fluid_1_4;
         delete options.initFunction; 
     };
     
+    // unsupported, NON-API function
+    // NOTE: this function represents a temporary strategy until we have more integrated IoC debugging.
+    // It preserves the current framework behaviour for the 1.4 release, but provides a more informative
+    // diagnostic - in fact, it is perfectly acceptable for a component's creator to return no value and
+    // the failure is really in assumptions in fluid.initComponent. Revisit this issue for 1.5
+    fluid.diagnoseFailedView = function(componentName, that, options, args) {
+        if (!that && fluid.hasGrade(options, "fluid.viewComponent")) {
+            var container = fluid.wrap(args[1]);
+            var message1 = "Instantiation of autoInit component with type " + componentName + " failed, since "
+            if (container.length === 0) {
+                fluid.fail(message1 + "selector \"", args[1], "\" did not match any markup in the document");
+            }
+            else {
+                fluid.fail(message1 + " component creator function did not return a value");
+            }  
+        }  
+    };
+    
     fluid.initComponent = function (componentName, initArgs) {
         var options = fluid.defaults(componentName);
         if (!options.gradeNames) {
@@ -1391,6 +1409,7 @@ var fluid = fluid || fluid_1_4;
         }
         var args = [componentName].concat(fluid.makeArray(initArgs)); // TODO: support different initFunction variants
         var that = fluid.invokeGlobalFunction(options.initFunction, args);
+        fluid.diagnoseFailedView(componentName, that, options, args);
         that.options.postInitFunction.fire(that);
         if (fluid.initDependents) {
             fluid.initDependents(that);


### PR DESCRIPTION
FLUID-4396: Better diagnostics in case where markup is missing for a view component, "that is null". Temporary strategy for 1.4 release which preserves framework behaviour with better diagnostic.
@jobara, @colinbdclark
