### PR TITLE
FLUID-4401: Waiting for the document to be ready before init ToC

### DIFF
--- a/src/webapp/components/uiOptions/js/UIEnhancer.js
+++ b/src/webapp/components/uiOptions/js/UIEnhancer.js
@@ -46,7 +46,7 @@ var fluid_1_4 = fluid_1_4 || {};
             if (that.tableOfContents) {
                 that.tableOfContents.show();
             } else {
-                that.events.onReady.fire();
+                $(document).ready(that.events.onReady.fire);
             }
         } else {
             if (that.tableOfContents) {


### PR DESCRIPTION
By waiting for the document to be ready the ToC container should be in
place and all relevant headers as well.

http://issues.fluidproject.org:18080/browse/FLUID-4401

The uncaught exception that  happens when you turn off the ToC using the Fat Panel is fixed in @amb26's branch for FLUID-4397
