### PR TITLE
FLUID-4412: Fixing the min-width for fat panel UIO that would not let the

### DIFF
--- a/src/webapp/components/uiOptions/css/FatPanelUIOptionsFrame.css
+++ b/src/webapp/components/uiOptions/css/FatPanelUIOptionsFrame.css
@@ -1,6 +1,6 @@
 /* UI Options Fat Panel styles */
 .fl-uiOptions-fatPanel {
-	min-width: 960px;
+	min-width: inherit;
     background-color: #fff;
 }
 


### PR DESCRIPTION
FLUID-4412: Fixing the min-width for fat panel UIO that would not let the user see RESET ALL button when viewing the demo.
