### PR TITLE
FLUID-4428: Revised version of botched options munging scheme for FLUID-4409

### DIFF
--- a/src/webapp/components/uiOptions/js/FatPanelUIOptions.js
+++ b/src/webapp/components/uiOptions/js/FatPanelUIOptions.js
@@ -246,46 +246,48 @@ var fluid_1_4 = fluid_1_4 || {};
         gradeNames: ["fluid.uiOptions.inline", "autoInit"],
         // TODO: This material is not really transformation, but would be better expressed by
         // FLUID-4392 additive demands blocks
-        uiOptionsTransform: {
-            config: {
-                "!*.uiOptionsLoader.*.uiOptions.*.uiEnhancer.options": "uiEnhancer.options",
-                "*.uiOptionsLoader.*.uiOptions": {
-                    options: {
-                        events: {
-                            onSignificantDOMChange: null  
+        derivedDefaults: {
+            uiOptions: {
+                options: {
+                    events: {
+                        onSignificantDOMChange: null  
+                    },
+                    components: {
+                        uiEnhancer: {
+                            type: "fluid.uiEnhancer",
+                            container: "body",
+                            priority: "first",
+                            options: {
+                                tocTemplate: "../../tableOfContents/html/TableOfContents.html"
+                            }
                         },
-                        components: {
-                            uiEnhancer: {
-                                type: "fluid.uiEnhancer",
-                                container: "body",
-                                priority: "first",
-                                options: {
-                                    tocTemplate: "../../tableOfContents/html/TableOfContents.html"
-                                }
-                            },
-                            settingsStore: "{uiEnhancer}.settingsStore",
-                            preview: {
-                                type: "fluid.emptySubcomponent"
-                            },
-                            tabs: {
-                                type: "fluid.tabs",
-                                container: "body",
-                                createOnEvent: "onUIOptionsComponentReady",
-                                options: {
-                                    events: { // TODO: this mess required through lack of FLUID-4398
-                                        boiledTabShow: {
-                                            event: "tabsshow",
-                                            args: ["{uiOptions}"]
-                                        }
-                                    },
-                                    listeners: { // FLUID-4337 bug again
-                                        boiledTabShow: fluid.uiOptions.tabSelectRelay
+                        settingsStore: "{uiEnhancer}.settingsStore",
+                        preview: {
+                            type: "fluid.emptySubcomponent"
+                        },
+                        tabs: {
+                            type: "fluid.tabs",
+                            container: "body",
+                            createOnEvent: "onUIOptionsComponentReady",
+                            options: {
+                                events: { // TODO: this mess required through lack of FLUID-4398
+                                    boiledTabShow: {
+                                        event: "tabsshow",
+                                        args: ["{uiOptions}"]
                                     }
+                                },
+                                listeners: { // FLUID-4337 bug again
+                                    boiledTabShow: fluid.uiOptions.tabSelectRelay
                                 }
                             }
                         }
                     }
                 }
+            }
+        },
+        uiOptionsTransform: {
+            config: { // For FLUID-4409
+                "!*.uiOptionsLoader.*.uiOptions.*.uiEnhancer.options": "uiEnhancer.options",
             }
         }
     });
@@ -310,9 +312,7 @@ var fluid_1_4 = fluid_1_4 || {};
         
         // Swap the mapping for easier extraction on FatPanelOtherWorldLoader options
         fluid.each(bridgeMapping, function (value, key) {
-            if (typeof value === "string") {
-                swappedBridgeMapping[value] = key;
-            }
+           swappedBridgeMapping[value] = key;
         });
 
         // Extracts the mappings that only belong to FatPanelOtherWorldLoader
@@ -329,7 +329,8 @@ var fluid_1_4 = fluid_1_4 || {};
         // Hack for FLUID-4409: Capabilities of our ad hoc "mapOptions" function have been exceeded - put weak priority instance of outer
         // merged options into the inner world
         fluid.set(overallOptions, "uiEnhancer.options", that.uiEnhancer.options.originalUserOptions);
-        var mappedOptions = fluid.uiOptions.mapOptions(overallOptions, defaults.uiOptionsTransform.config, defaults.mergePolicy);
+        var mappedOptions = fluid.uiOptions.mapOptions(overallOptions, defaults.uiOptionsTransform.config, defaults.mergePolicy, 
+            fluid.copy(defaults.derivedDefaults));
         var component = innerFluid.invokeGlobalFunction("fluid.uiOptions.FatPanelOtherWorldLoader", [container, mappedOptions]);
         that.uiOptionsLoader = component.uiOptionsLoader;
     };

--- a/src/webapp/components/uiOptions/js/FullNoPreviewUIOptions.js
+++ b/src/webapp/components/uiOptions/js/FullNoPreviewUIOptions.js
@@ -25,46 +25,33 @@ var fluid_1_4 = fluid_1_4 || {};
     fluid.defaults("fluid.uiOptions.fullNoPreview", {
         gradeNames: ["fluid.uiOptions.inline"],
         container: "{fullNoPreview}.container",
-        uiOptionsTransform: {
-            config: {
-                "*.templateLoader": {
-                    options: {
-                        templates: {
-                            uiOptions: "%prefix/FullNoPreviewUIOptions.html"
-                        }
+        derivedDefaults: {
+            templateLoader: {
+                options: {
+                    templates: {
+                        uiOptions: "%prefix/FullNoPreviewUIOptions.html"
                     }
-                },
-                "*.uiOptionsLoader.*.uiOptions": {
-                    options: {
-                        components: {
-                            preview: {
-                                type: "fluid.emptySubcomponent"
-                            },
-                            settingsStore: "{uiEnhancer}.settingsStore"
+                }
+            },
+            uiOptions: {
+                options: {
+                    components: {
+                        preview: {
+                            type: "fluid.emptySubcomponent"
                         },
-                        listeners: {
-                            onReset: function (uiOptions) {
-                                uiOptions.save();
-                            },
-                            onUIOptionsRefresh: "{uiEnhancer}.updateFromSettingsStore"
-                        }
+                        settingsStore: "{uiEnhancer}.settingsStore"
+                    },
+                    listeners: {
+                        onReset: function (uiOptions) {
+                            uiOptions.save();
+                        },
+                        onUIOptionsRefresh: "{uiEnhancer}.updateFromSettingsStore"
                     }
                 }
             }
         }
     });
     
-    fluid.uiOptions.fullNoPreview = function (container, options) {
-        // make "container" one of the options so it can be munged by the uiOptions.mapOptions.
-        // This container is passed down to be used as uiOptionsLoader.container 
-        var componentConfig = fluid.defaults("fluid.uiOptions.fullNoPreview").uiOptionsTransform.config;
-        var mergePolicy = fluid.defaults("fluid.uiOptions.fullNoPreview").mergePolicy;
-        options.container = container;
-        
-        var mappedOptions = fluid.uiOptions.mapOptions(options, componentConfig, mergePolicy);
-        var that = fluid.initView("fluid.uiOptions.fullNoPreview", container, mappedOptions);
-        fluid.initDependents(that);
-        return that;
-    };
+    fluid.uiOptions.inline.makeCreator("fluid.uiOptions.fullNoPreview", fluid.identity); 
     
 })(jQuery, fluid_1_4);

--- a/src/webapp/components/uiOptions/js/FullPreviewUIOptions.js
+++ b/src/webapp/components/uiOptions/js/FullPreviewUIOptions.js
@@ -28,42 +28,37 @@ var fluid_1_4 = fluid_1_4 || {};
         uiOptionsTransform: {
             config: {
                 "!*.uiOptionsLoader.*.uiOptions.*.preview.*.enhancer.options": "outerPreviewEnhancerOptions",
-                "*.templateLoader": {
-                    options: {
-                        templates: {
-                            uiOptions: "%prefix/FullPreviewUIOptions.html"
-                        }
+            }
+        },
+        derivedDefaults: {
+            templateLoader: {
+                options: {
+                    templates: {
+                        uiOptions: "%prefix/FullPreviewUIOptions.html"
                     }
-                },
-                "*.uiOptionsLoader.*.uiOptions": {
-                    options: {
-                        components: {
-                            settingsStore: "{uiEnhancer}.settingsStore"
-                        },
-                        listeners: {
-                            onUIOptionsRefresh: "{uiEnhancer}.updateFromSettingsStore"
-                        }
+                }
+            },
+            uiOptions: {
+                options: {
+                    components: {
+                        settingsStore: "{uiEnhancer}.settingsStore"
+                    },
+                    listeners: {
+                        onUIOptionsRefresh: "{uiEnhancer}.updateFromSettingsStore"
                     }
                 }
             }
         }
     });
     
-    fluid.uiOptions.fullPreview = function (container, options) {
-        // make "container" one of the options so it can be munged by the uiOptions.mapOptions.
-        // This container is passed down to be used as uiOptionsLoader.container 
-        var componentConfig = fluid.defaults("fluid.uiOptions.fullPreview").uiOptionsTransform.config;
-        var mergePolicy = fluid.defaults("fluid.uiOptions.fullPreview").mergePolicy;
-        options.container = container;
+    fluid.uiOptions.inline.makeCreator("fluid.uiOptions.fullPreview", function(options) {
         // This is a terrible hack for FLUID-4409. Since it is impossible for us to be invoked via IoC, the only
         // source of this configuration could be the static pageEnhancer
+        // The correct way to resolve the problem is to refactor UIEnhancer so that all of its configuration other than
+        // the container to be bound to be enhanced is kept in a separate, shared component, "UIEnhancerConfig".
         var enhancerOptions = fluid.get(fluid, "staticEnvironment.uiEnhancer.options.originalUserOptions");
         options.outerPreviewEnhancerOptions = enhancerOptions;
-        
-        var mappedOptions = fluid.uiOptions.mapOptions(options, componentConfig, mergePolicy);
-        var that = fluid.initView("fluid.uiOptions.fullPreview", container, mappedOptions);
-        fluid.initDependents(that);
-        return that;
-    };
-
+        return options;
+    });
+    
 })(jQuery, fluid_1_4);

--- a/src/webapp/framework/core/js/FluidIoC.js
+++ b/src/webapp/framework/core/js/FluidIoC.js
@@ -201,7 +201,7 @@ var fluid_1_4 = fluid_1_4 || {};
                 var ref = fluid.renderContextReference(parsed);
                 fluid.log("Failed to resolve reference " + ref + ": thatStack contains\n" + fluid.dumpThatStack(thatStack, instantiator));
                 fluid.fail("Failed to resolve reference " + ref + " - could not match context with name " 
-                    + context + " from component root of type " + thatStack[0].typeName);
+                    + context + " from component root of type " + thatStack[0].typeName, "\ninstantiator contents: ", instantiator);
             }
             return fluid.get(foundComponent, parsed.path, fetchStrategies);
         };

--- a/src/webapp/tests/component-tests/uiOptions/js/FullNoPreviewUIOptionsTests.js
+++ b/src/webapp/tests/component-tests/uiOptions/js/FullNoPreviewUIOptionsTests.js
@@ -74,6 +74,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             fluid.pageEnhancer({
                 tocTemplate: "../../../../components/tableOfContents/html/TableOfContents.html"
             });
+            var savedSelections;
+            function testSave(selections) {
+                savedSelections = selections;
+            }
             
             function testComponent(uiOptionsLoader, uiOptions) {
                 var defaultSiteSettings = uiOptions.settingsStore.options.defaultSiteSettings;
@@ -84,6 +88,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 var saveButton = uiOptions.locate("save");
                 saveButton.click();
                 checkModelSelections(uiOptions.model.selections, bwSkin);
+                jqUnit.assertEquals("Save event fired with selections", uiOptions.model.selections, savedSelections);
                 applierRequestChanges(uiOptions, ybSkin);
     
                 var cancelButton = uiOptions.locate("cancel");
@@ -101,7 +106,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 start();
             };
             
-            jqUnit.expect(22);
+            jqUnit.expect(23);
                        
             var that = fluid.uiOptions.fullNoPreview("#myUIOptions", {
                 prefix: "../../../../components/uiOptions/html/",
@@ -109,6 +114,13 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     options: {
                         listeners: {
                             onReady: testComponent
+                        }
+                    }
+                },
+                uiOptions: {
+                    options: {
+                        listeners: {
+                            onSave: testSave
                         }
                     }
                 }


### PR DESCRIPTION
FLUID-4428: Revised version of botched options munging scheme for FLUID-4409 with test case demonstrating listener registration for NoPreview configuration (many more required). New directive in "inline" grade for "middle level defaults" named "derivedDefaults" with the options munging directive returned to being simply a map of strings to strings representing EL source and destination. New shared "inline" component creator function shares some more code between preview and noPreview - fatPanel is still generally a junkyard.
@michelled, @jobara - test cases are passing with exception of "verdana" font setting test number 2.2 on UIEnhancer - but this is also failing for me on current trunk (may just be an artifact of my FF3.6 which I imagine is not supported for the release). A quick run-through the demos seems to be working
