### PR TITLE
FLUID-4428: Fix and test case for failure to apply "direct options".

### DIFF
--- a/src/webapp/components/uiOptions/js/UIOptions.js
+++ b/src/webapp/components/uiOptions/js/UIOptions.js
@@ -253,23 +253,23 @@ var fluid_1_4 = fluid_1_4 || {};
     };
     
     fluid.uiOptions.mapOptionsRecord = function(options, sortedConfigKeys, config) {
-        options = options || {};
-        var optionsLow = {};
-        var optionsApplier = fluid.makeChangeApplier(options);
-        var lowApplier = fluid.makeChangeApplier(optionsLow);
+        var opRecs = [{}, {}, options || {}];
+        var appliers = fluid.transform(opRecs, function(opRec) {
+            return fluid.makeChangeApplier(opRec);
+        });
         fluid.each(sortedConfigKeys, function (origDest) {
             var source = config[origDest];
             var dest = fluid.uiOptions.expandShortPath(origDest);
-            var applier = origDest.charAt(0) === "!"? lowApplier : optionsApplier;
+            var applier = appliers[origDest.charAt(0) === "!"? 0 : 1];
             
             // Process the user pass-in options
             var value = fluid.get(options, source);
             if (value) {
                 applier.requestChange(dest, value, "ADD");
-                optionsApplier.requestChange(source, value, "DELETE");
+                appliers[2].requestChange(source, value, "DELETE");
             }
         });
-        return [optionsLow, options];
+        return opRecs;
     }
     // TODO: This dreadful function will be absorbed into the framework for 1.5
     /**

--- a/src/webapp/tests/component-tests/uiOptions/js/FullNoPreviewUIOptionsTests.js
+++ b/src/webapp/tests/component-tests/uiOptions/js/FullNoPreviewUIOptionsTests.js
@@ -78,6 +78,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             function testSave(selections) {
                 savedSelections = selections;
             }
+            var savedSelections2;
+            function testSave2(selections) {
+                savedSelections2 = selections;
+            }
             
             function testComponent(uiOptionsLoader, uiOptions) {
                 var defaultSiteSettings = uiOptions.settingsStore.options.defaultSiteSettings;
@@ -89,6 +93,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 saveButton.click();
                 checkModelSelections(uiOptions.model.selections, bwSkin);
                 jqUnit.assertEquals("Save event fired with selections", uiOptions.model.selections, savedSelections);
+                jqUnit.assertEquals("Direct save event fired with selections", uiOptions.model.selections, savedSelections2);
                 applierRequestChanges(uiOptions, ybSkin);
     
                 var cancelButton = uiOptions.locate("cancel");
@@ -106,7 +111,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 start();
             };
             
-            jqUnit.expect(23);
+            jqUnit.expect(24);
                        
             var that = fluid.uiOptions.fullNoPreview("#myUIOptions", {
                 prefix: "../../../../components/uiOptions/html/",
@@ -120,7 +125,22 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 uiOptions: {
                     options: {
                         listeners: {
-                            onSave: testSave
+                            "onSave.munged": testSave
+                        }
+                    }
+                },
+                components: {
+                    uiOptionsLoader: {
+                        options: {
+                            components: {
+                                uiOptions: {
+                                    options: {
+                                        listeners: {
+                                            "onSave.direct": testSave2
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
FLUID-4428: Fix and test case for failure to apply "direct options". As a result of a failure in merging, it is necessary to give different namespaces to the events so one listener in the test case does not overwrite the other - but the test demonstrates that both are at least now being taken into account in the merging process.
@michelled, @jobara
