### PR TITLE
FLUID-4440: fixing path to jQuery UI theme

### DIFF
--- a/src/webapp/demos/fss/clearfix/html/clearfix.html
+++ b/src/webapp/demos/fss/clearfix/html/clearfix.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <link rel="stylesheet" type="text/css" href="../../../../framework/fss/css/fss-layout.css" />
-        <link rel="stylesheet" type="text/css" href="../../../../lib/jquery/ui/css/demo-theme/jquery.ui.theme.css" />
+        <link rel="stylesheet" type="text/css" href="../../../../lib/jquery/ui/css/default-theme/jquery.ui.theme.css" />
         <link rel="stylesheet" type="text/css" href="../css/clearfix.css" />
         
         <script type="text/javascript" src="../../../../lib/jquery/core/js/jquery.js"></script>

--- a/src/webapp/demos/fss/linearize/html/linearize.html
+++ b/src/webapp/demos/fss/linearize/html/linearize.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="../../../../framework/fss/css/fss-layout.css" />
         <link rel="stylesheet" type="text/css" href="../../../../framework/fss/css/fss-text.css" />
         <link rel="stylesheet" type="text/css" href="../../../../framework/fss/css/fss-theme-mist.css" />
-        <link rel="stylesheet" type="text/css" href="../../../../lib/jquery/ui/css/demo-theme/jquery.ui.theme.css" />
+        <link rel="stylesheet" type="text/css" href="../../../../lib/jquery/ui/css/default-theme/jquery.ui.theme.css" />
         <link rel="stylesheet" type="text/css" href="../css/linearize.css" />
         
         <script type="text/javascript" src="../../../../lib/jquery/core/js/jquery.js"></script>


### PR DESCRIPTION
One of the folders had been renamed from demo-theme to default-theme.
Fixing this in the path, has solved the issue.

http://issues.fluidproject.org:18080/browse/FLUID-4440
