### PR TITLE
FLUID-4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF
--- a/src/webapp/demos/uploader/html/uploader.html
+++ b/src/webapp/demos/uploader/html/uploader.html
@@ -41,15 +41,15 @@
         <script type="text/javascript" src="../js/uploaderDemo.js"></script>
     </head>
     <body>
+        <!-- Basic upload controls, used when JavaScript is unavailable -->
+        <form method="post" enctype="multipart/form-data" class="fl-progEnhance-basic">
+            <p>Use the Browse button to add a file, and the Save button to upload it.</p>
+            <input name="fileData" type="file" />
+            <input class="fl-uploader-basic-save" type="submit" value="Save"/>
+        </form>        
+        <!-- The Uploader's template will be injected via AJAX into this container. -->
 
         <div id="uploader-contents">
-	        <!-- Basic upload controls, used when JavaScript is unavailable -->
-	        <form method="post" enctype="multipart/form-data" class="fl-progEnhance-basic">
-	            <p>Use the Browse button to add a file, and the Save button to upload it.</p>
-	            <input name="fileData" type="file" />
-	            <input class="fl-uploader-basic-save" type="submit" value="Save"/>
-	        </form>        
-            <!-- The Uploader's template will be injected via AJAX into this container. -->
         </div>
         
         <script type="text/javascript">


### PR DESCRIPTION
Moved single file uploader markup out of the "uploader-contents" container so that the markup is never overwritten
