### PR TITLE
FLUID-4442: Fixes lamest Uploader bug ever (by me).

### DIFF
--- a/src/webapp/components/uploader/js/HTML5UploaderSupport.js
+++ b/src/webapp/components/uploader/js/HTML5UploaderSupport.js
@@ -91,20 +91,6 @@ var fluid_1_4 = fluid_1_4 || {};
         events.onFileComplete.fire(file);
     };
     
-    fluid.uploader.html5Strategy.progressTracker = function () {
-        var that = {
-            previousBytesLoaded: 0
-        };
-        
-        that.getChunkSize = function (bytesLoaded) {
-            var chunkSize = bytesLoaded - that.previousBytesLoaded;
-            that.previousBytesLoaded = bytesLoaded;
-            return chunkSize;
-        };
-        
-        return that;
-    };
-    
     fluid.uploader.html5Strategy.monitorFileUploadXHR = function (file, events, xhr) {
         xhr.onreadystatechange = function () {
             if (xhr.readyState === 4) {
@@ -120,9 +106,8 @@ var fluid_1_4 = fluid_1_4 || {};
             }
         };
 
-        var progressTracker = fluid.uploader.html5Strategy.progressTracker();
         xhr.upload.onprogress = function (pe) {
-            events.onFileProgress.fire(file, progressTracker.getChunkSize(pe.loaded), pe.total);
+            events.onFileProgress.fire(file, pe.loaded, pe.total);
         };
     };
     

--- a/src/webapp/tests/component-tests/uploader/js/HTML5UploaderSupportTests.js
+++ b/src/webapp/tests/component-tests/uploader/js/HTML5UploaderSupportTests.js
@@ -297,21 +297,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             checkEventOrderForFiles(eventOrder, files, transcript);
             checkOnFileCompleteEvent(transcript);            
         });         
-        
-        /***************************
-         * progressTracker() Tests *
-         ***************************/
-        
-        html5UploaderTests.test("Ensure loaded bytes are properly tracked", function () {
-            var progress = fluid.uploader.html5Strategy.progressTracker();    
 
-            var uploadProgress = progress.getChunkSize(100);
-            jqUnit.assertEquals("The chunk size should be", 100, uploadProgress);
-            jqUnit.assertEquals("100 bytes were previously uploaded", 100, progress.previousBytesLoaded);
-            
-            uploadProgress = progress.getChunkSize(250);
-            jqUnit.assertEquals("The chunk size should now be", 150, uploadProgress);
-        });
         
         /************************************
          * generateMultiPartContent() Tests *


### PR DESCRIPTION
File upload progress is now reported correctly in the HTML5 strategy. Fixed by removing the unnecessary chunking code that breaks the semantics of Uploader's onFileProgress event.

@amb26 or @jobara, can you review this and push to the project repo? I've tested as far as ensuring that no regressions occur and that the unit tests run, but I'm having some difficulty testing it on my local machine due to the incredible lack of latency for uploads. If you think the code looks good, I think it's safe to push this into the project repository and test it from the hourly build site.
