### PR TITLE
FLUID-4252: turning off debug and logging

### DIFF
--- a/src/webapp/components/uploader/js/Uploader.js
+++ b/src/webapp/components/uploader/js/Uploader.js
@@ -24,9 +24,6 @@ var fluid_1_4 = fluid_1_4 || {};
  ************/
 
 (function ($, fluid) {
-    
-    fluid.setLogging(true);
-    
     var fileOrFiles = function (that, numFiles) {
         return (numFiles === 1) ? that.options.strings.progress.singleFile : 
             that.options.strings.progress.pluralFiles;

--- a/src/webapp/demos/reorderer/layoutReorderer/js/layoutReordererDemo.js
+++ b/src/webapp/demos/reorderer/layoutReorderer/js/layoutReordererDemo.js
@@ -18,7 +18,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
 var demo = demo || {};
 (function ($, fluid) {
-    fluid.setLogging(true);
     demo.initlayoutReorderer = function () {
         fluid.reorderLayout("#demo-layoutReorderer", {
             selectors: {

--- a/src/webapp/framework/core/js/Fluid.js
+++ b/src/webapp/framework/core/js/Fluid.js
@@ -41,7 +41,7 @@ var fluid = fluid || fluid_1_4;
     };
     var globalObject = window || {};
     
-    var softFailure = [false];
+    var softFailure = [true];
     
     // This function will be patched from FluidIoC.js in order to describe complex activities
     fluid.describeActivity = function () {

--- a/src/webapp/tests/manual-tests/js/simple-progress.js
+++ b/src/webapp/tests/manual-tests/js/simple-progress.js
@@ -71,7 +71,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
  
     $(function () {
-        fluid.setLogging(true);
         absoluteProgress = fluid.progress("#absoluteProgress");
         floatyProgress = fluid.progress("#floatyProgress", {selectors: {
             displayElement: ".fluid-progress-bar" // required


### PR DESCRIPTION
Removed unneeded instances of fluid.setLogging. I left them on in the
tests and some error handling functions in fluid.js and fluidParser.js.
I couldn't find debug mode on anywhere. For fluid.fail the new method
is to set softFailure to [true]

http://issues.fluidproject.org/browse/FLUID-4252
