### PR TITLE
FLUID-4532: Reverting ARIA labeller component to pre-IoC strategy

### DIFF
--- a/src/webapp/framework/core/js/FluidView.js
+++ b/src/webapp/framework/core/js/FluidView.js
@@ -27,14 +27,16 @@ var fluid_1_5 = fluid_1_5 || {};
         labelAttribute: "aria-label",
         liveRegionMarkup: "<div class=\"liveRegion fl-offScreen-hidden\" aria-live=\"polite\"></div>",
         liveRegionId: "fluid-ariaLabeller-liveRegion",
-        invokers: {
-            generateLiveElement: {funcName: "fluid.ariaLabeller.generateLiveElement", args: ["{ariaLabeller}"]}
+        events: {
+            generateLiveElement: "unicast"
+        },
+        listeners: {
+            generateLiveElement: "fluid.ariaLabeller.generateLiveElement"
         }
     });
  
     fluid.ariaLabeller = function (element, options) {
         var that = fluid.initView("fluid.ariaLabeller", element, options);
-        fluid.initDependents(that);
 
         that.update = function (newOptions) {
             newOptions = newOptions || that.options;
@@ -42,7 +44,7 @@ var fluid_1_5 = fluid_1_5 || {};
             if (newOptions.dynamicLabel) {
                 var live = fluid.jById(that.options.liveRegionId); 
                 if (live.length === 0) {
-                    live = that.generateLiveElement();
+                    live = that.events.generateLiveElement.fire(that);
                 }
                 live.text(newOptions.text);
             }

--- a/src/webapp/tests/component-tests/reorderer/html/AriaLabeller-test.html
+++ b/src/webapp/tests/component-tests/reorderer/html/AriaLabeller-test.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Aria Labeller Tests</title>
+        
+        <!--  This is the jqUnit test css file -->
+        <link rel="stylesheet" media="screen" href="../../../lib/qunit/css/qunit.css" />
+        
+        <!--  These are the required javascript modules  -->
+        <script type="text/javascript" src="../../../../lib/jquery/core/js/jquery.js"></script>
+        <script type="text/javascript" src="../../../../lib/jquery/ui/js/jquery.ui.core.js"></script>
+        <script type="text/javascript" src="../../../../lib/jquery/ui/js/jquery.ui.widget.js"></script>
+        <script type="text/javascript" src="../../../../lib/jquery/ui/js/jquery.ui.mouse.js"></script>
+        <script type="text/javascript" src="../../../../lib/jquery/ui/js/jquery.ui.draggable.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/jquery.keyboard-a11y.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/Fluid.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/FluidDebugging.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/FluidDocument.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/FluidView.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/DataBinding.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/FluidIoC.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/FluidDOMUtilities.js"></script>
+        <script type="text/javascript" src="../../../../components/reorderer/js/ReordererDOMUtilities.js" ></script>
+        <script type="text/javascript" src="../../../../components/reorderer/js/GeometricManager.js"></script>
+        <script type="text/javascript" src="../../../../components/reorderer/js/Reorderer.js"></script>
+
+        <!--  These are the jqUnit test js files -->
+        <script type="text/javascript" src="../../../lib/qunit/js/qunit.js"></script>
+        <script type="text/javascript" src="../../../test-core/jqUnit/js/jqUnit.js"></script>
+
+        <!-- Utilities for working with the Reorderer -->
+        <script type="text/javascript" src="../../../test-core/utils/js/TestUtils.js"></script>
+        <script type="text/javascript" src="../../../component-tests/reorderer/js/ReordererTestUtils.js"></script>
+        <script type="text/javascript" src="../../../component-tests/reorderer/js/UnorderedListTestConstants.js"></script>
+
+        <script type="text/javascript" src="../js/AriaLabellerTests.js"></script>
+
+    </head>
+    <body>
+    <h1 id="qunit-header">Aria Labeller Test Suite</h1>
+    <h2 id="qunit-banner"></h2>
+    <div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+
+    <!-- Test HTML -->
+    <div id="main" class="container">
+
+        <div id="list1" class="reorderer_container">
+            <ul>
+                <li id="list1item1" class="flc-reorderer-movable">Item 1</li>
+                <li id="list1item2" class="flc-reorderer-movable">Item 2</li>
+                <li id="list1item3" class="flc-reorderer-movable">Item 3</li>
+                <li id="list1item4" class="flc-reorderer-movable">Item 4</li>
+                <li id="list1item5" class="flc-reorderer-movable">Item 5</li>
+            </ul>
+        </div>
+
+        <div id="list2" class="reorderer_container">
+            <ul>
+                <li id="list2item1" class="flc-reorderer-movable">Item 1</li>
+                <li id="list2item2" class="flc-reorderer-movable">Item 2</li>
+                <li id="list2item3" class="flc-reorderer-movable">Item 3</li>
+                <li id="list2item4" class="flc-reorderer-movable">Item 4</li>
+                <li id="list2item5" class="flc-reorderer-movable">Item 5</li>
+            </ul>
+        </div>
+     </div>
+   
+    </body>
+</html>

--- a/src/webapp/tests/component-tests/reorderer/js/AriaLabellerTests.js
+++ b/src/webapp/tests/component-tests/reorderer/js/AriaLabellerTests.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2011 OCAD University
+
+Licensed under the Educational Community License (ECL), Version 2.0 or the New
+BSD license. You may not use this file except in compliance with one these
+Licenses.
+
+You may obtain a copy of the ECL 2.0 License and BSD License at
+https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
+*/
+
+// Declare dependencies
+/*global fluid, jqUnit, jQuery, itemIds*/
+
+// JSLint options 
+/*jslint white: true, funcinvoke: true, undef: true, newcap: true, nomen: true, regexp: true, bitwise: true, browser: true, forin: true, maxerr: 100, indent: 4 */
+
+(function ($) {
+    $(document).ready(function () {
+        fluid.setLogging(true);
+        
+        fluid.registerNamespace("fluid.tests");
+        
+        var AriaLabellerTests = new jqUnit.TestCase("Aria Labeller Tests");
+        var k = fluid.testUtils.reorderer.bindReorderer(itemIds);
+
+        function assertItemsInOrder(message, expectOrder) {
+            return fluid.testUtils.reorderer.assertItemsInOrder(message, expectOrder, 
+                $("li", $("#list1")), "list1item");
+        }        
+
+        fluid.defaults("fluid.tests.labellerTester", {
+            gradeNames: ["fluid.viewComponent", "autoInit"],
+            components: {
+                reorderer: {
+                    type: "fluid.reorderList"
+                }
+            }
+        });
+        
+        fluid.demands("fluid.reorderList", "fluid.tests.labellerTester", 
+            ["{labellerTester}.container", "{options}"]);
+        
+        AriaLabellerTests.test("IoC instantiation", function () {
+
+            var labellerTester = fluid.tests.labellerTester("#list1");
+            jqUnit.assertNotUndefined("reorderer created", labellerTester.reorderer);
+
+            $("#list1item3").focus();
+            k.compositeKey(labellerTester.reorderer, fluid.testUtils.ctrlKeyEvent("DOWN"), 2);
+            assertItemsInOrder("after ctrl-down, order should be ", [1, 2, 4, 3, 5]);
+
+            var region = fluid.jById(fluid.defaults("fluid.ariaLabeller").liveRegionId);
+            jqUnit.assertNotUndefined("Live region should exist", region);
+        });
+    });
+})(jQuery);


### PR DESCRIPTION
This implementation should never have been using IoC - this looks like a grievous conceptual error left over from some cleanup after CSpace/1.3 work of late last year. As well as running into the FLUID-4192 "broken trees" issue, this unacceptably exposes users of FluidView.js onto a dependence on the IoC system. It should be possible for anyone to use the aria labeller without including IoC - I have reverted the impl onto an old-fashioned "unicast" event for the time being which will still enable this strategy to be customised as per the apparent original intention. 
