### PR TITLE
FLUID-4537: Further fixes to allow path values to be resolved when raw reference to "pathAs" is issued from light material. Modified test case as supplied by JURA.

### DIFF
--- a/src/webapp/framework/core/js/FluidIoC.js
+++ b/src/webapp/framework/core/js/FluidIoC.js
@@ -1074,7 +1074,7 @@ outer:  for (var i = 0; i < exist.length; ++i) {
         if (!base) {
             return base;
         }
-        return fluid.get(base, parsed.path);
+        return parsed.noDereference? parsed.path: fluid.get(base, parsed.path);
     };
     
     // unsupported, non-API function

--- a/src/webapp/framework/renderer/js/RendererUtilities.js
+++ b/src/webapp/framework/renderer/js/RendererUtilities.js
@@ -302,7 +302,7 @@ fluid_1_5 = fluid_1_5 || {};
             var EL = fluid.model.composePath(path, i); 
             var envAdd = {};
             if (options.pathAs) {
-                envAdd[options.pathAs] = EL;
+                envAdd[options.pathAs] = "${" + EL + "}";
             }
             if (options.valueAs) {
                 envAdd[options.valueAs] = fluid.get(config.model, EL, config.resolverGetConfig);
@@ -368,8 +368,15 @@ fluid_1_5 = fluid_1_5 || {};
     fluid.transformContextPath = function (parsed, env) {
         if (parsed.context) {
             var fetched = env[parsed.context];
+            var EL;
             if (typeof(fetched) === "string") {
-                return { path: fluid.model.composePath(fetched, parsed.path) }; 
+                EL = fluid.extractEL(fetched, {ELstyle: "${}"});
+            }
+            if (EL) {
+                return {
+                    noDereference: parsed.path === "", 
+                    path: fluid.model.composePath(EL, parsed.path) 
+                    }; 
             }
         }
         return parsed;

--- a/src/webapp/tests/framework-tests/renderer/html/RendererUtilities-test.html
+++ b/src/webapp/tests/framework-tests/renderer/html/RendererUtilities-test.html
@@ -134,7 +134,13 @@
                 <h1><a class="link" href="" title=""><span class="title">Title</span></a></h1>
                 <p class="description">Description</p>
             </div>
-        </div> 
+        </div>
+
+        <div class="pathAsProp">
+            <div class="pathexp-row">
+                <div class="pathexp-row-decorated"></div>
+            </div>
+        </div>
         
     </div>
     

--- a/src/webapp/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
+++ b/src/webapp/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
@@ -950,7 +950,7 @@ fluid.registerNamespace("fluid.tests");
                     type: "fluid.renderer.repeat",
                     controlledBy: "vector",
                     pathAs: "elementPath",
-                    valueAs: "element", 
+                    valueAs: "element",
                     repeatID: "link",
                     tree: {
                         linktext: "${{elementPath}}",
@@ -1457,6 +1457,49 @@ fluid.registerNamespace("fluid.tests");
             var attr = links.attr("title");
             jqUnit.assertEquals("Description title rendered", that.model.feeds[0].description, attr);
         });
-        
+
+        fluid.defaults("fluid.tests.pathExpander", {
+            gradeNames: ["autoInit", "fluid.viewComponent"]
+        });
+        fluid.defaults("fluid.tests.pathExpanderParent", {
+            gradeNames: ["autoInit", "fluid.rendererComponent"],
+            model: {
+                rows: ["0", "1", "2"]
+            },
+            selectors: {
+                row: ".pathexp-row",
+                decorated: ".pathexp-row-decorated"
+            },
+            repeatingSelectors: ["row"],
+            protoTree: {
+                expander: {
+                    repeatID: "row",
+                    type: "fluid.renderer.repeat",
+                    pathAs: "path",
+                    valueAs: "value",
+                    controlledBy: "rows",
+                    tree: {
+                        decorated: {
+                            decorators: {
+                                type: "fluid",
+                                func: "fluid.tests.pathExpander",
+                                options: {
+                                    path: "{path}",
+                                    val: "{value}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            renderOnInit: true
+        });
+        protoTests.test("FLUID-4537 further: pathAs propagation", function () {
+            var that = fluid.tests.pathExpanderParent(".pathAsProp");
+            var decorators = fluid.renderer.getDecoratorComponents(that);
+            fluid.each(decorators, function (comp, name) {
+                jqUnit.assertEquals("Path should not be expanded into value", "rows." + comp.options.val, comp.options.path);
+            });
+        });
     }; 
 })(jQuery); 


### PR DESCRIPTION
This creates an inconsistency in resolution, depending on whether the "pathAs" variable is dereferenced with a further path segment or not - in the former case, it will be resolved as a value, and in the latter case, will remain as a path.
