### PR TITLE
FLUID-3863: Implementation and test cases for noWrap option for keyboard-a11y selectable.

### DIFF
--- a/src/webapp/framework/core/js/jquery.keyboard-a11y.js
+++ b/src/webapp/framework/core/js/jquery.keyboard-a11y.js
@@ -296,10 +296,10 @@ var fluid = fluid || fluid_1_5;
     var reifyIndex = function(sc_that) {
         var elements = sc_that.selectables;
         if (sc_that.activeItemIndex >= elements.length) {
-            sc_that.activeItemIndex = 0;
+            sc_that.activeItemIndex = (sc_that.options.noWrap ? elements.length  - 1: 0);
         }
         if (sc_that.activeItemIndex < 0 && sc_that.activeItemIndex !== NO_SELECTION) {
-            sc_that.activeItemIndex = elements.length - 1;
+            sc_that.activeItemIndex = (sc_that.options.noWrap ? 0 : elements.length - 1);
         }
         if (sc_that.activeItemIndex >= 0) {
             fluid.focus(elements[sc_that.activeItemIndex]);
@@ -522,7 +522,8 @@ var fluid = fluid || fluid_1_5;
         selectableElements: null,
         onSelect: null,
         onUnselect: null,
-        onLeaveContainer: null
+        onLeaveContainer: null,
+        noWrap: false
     };
 
     /********************************************************************

--- a/src/webapp/tests/framework-tests/core/js/keyboard-a11y-tests.js
+++ b/src/webapp/tests/framework-tests/core/js/keyboard-a11y-tests.js
@@ -604,4 +604,26 @@ if (!fluid.unwrap) {
         jqUnit.assertTrue("When onLeaveContainer is not specified, onUnselect should be called instead when tabbing out of the selectables container.", 
                           wasCalled);
     });
+
+    keyboardA11y.test("No-wrap options", function () {
+        // This test can only be run on FF, due to reliance on DOM 2 for synthesizing events.
+        if (!$.browser.mozilla) {
+            return;
+        }
+        var menu = makeMenuSelectable({
+            noWrap: true
+        });
+
+        menu.items.fluid("selectable.select", getFirstMenuItem());
+        simulateKeyDown(getFirstMenuItem(), $.ui.keyCode.UP);
+        keyboardA11y.assertSelected(getFirstMenuItem());
+        keyboardA11y.assertNotSelected(getLastMenuItem());
+
+        menu.items.fluid("selectable.select", getLastMenuItem());
+        simulateKeyDown(getLastMenuItem(), $.ui.keyCode.DOWN);
+        keyboardA11y.assertSelected(getLastMenuItem());
+        keyboardA11y.assertNotSelected(getFirstMenuItem());
+
+    });
+
 })(jQuery);


### PR DESCRIPTION
@michelled: This issue has come up again for the VideoPlayer  pop-up menus. An implementation is relatively simple.
