### PR TITLE
FLUID-4602: Fixed the browseButton selector

### DIFF
--- a/src/webapp/components/uploader/js/HTML5UploaderSupport.js
+++ b/src/webapp/components/uploader/js/HTML5UploaderSupport.js
@@ -336,7 +336,7 @@ var fluid_1_5 = fluid_1_5 || {};
                 options: {
                     queueSettings: "{multiFileUploader}.options.queueSettings",
                     selectors: {
-                        browseButton: "{multiFileUploader}.selectors.browseButton"
+                        browseButton: "{multiFileUploader}.options.selectors.browseButton"
                     },
                     listeners: {
                         onFilesQueued: "{local}.addFiles"


### PR DESCRIPTION
The default for the browseButton selector in "fluid.uploader.html5Strategy.local" was set incorrectly. The setting was missing "options" from the EL path. This prevented a user from being able to change the selector for the browseButton from fluid.uploader. I've made the necessary change and verified that the unit tests are still passing.

http://issues.fluidproject.org/browse/FLUID-4602
