### PR TITLE
FLUID-4609: Added new fluid.getLoader() function which allows path-aware fluid loading to be based from user's directory rather than Fluid's

### DIFF
--- a/src/webapp/framework/core/js/Fluid.js
+++ b/src/webapp/framework/core/js/Fluid.js
@@ -37,9 +37,14 @@ var fluid = fluid || fluid_1_5;
     
     fluid.version = "Infusion 1.5";
     
+    // Export this for use in environments like node.js, where it is useful for
+    // configuring stack trace behaviour
+    fluid.Error = Error;
+    
     fluid.environment = {
         fluid: fluid
     };
+    
     var globalObject = window || {};
     
     var softFailure = [false];

--- a/src/webapp/module/fluid.js
+++ b/src/webapp/module/fluid.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2012 OCAD University
+Copyright 2012 OCAD University, Antranig Basman
 
 Licensed under the Educational Community License (ECL), Version 2.0 or the New
 BSD license. You may not use this file except in compliance with one these
@@ -48,11 +48,23 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     
     var fluid = context.fluid;
 
-    fluid.require = function (moduleName, namespace) {
+    fluid.require = function (moduleName, foreignRequire, namespace) {
+        foreignRequire = foreignRequire || require;
         namespace = namespace || moduleName;
-        var module = require(moduleName);
+        var module = foreignRequire(moduleName);
         fluid.set(context, namespace, module);
         return module;
+    };
+    
+    fluid.getLoader = function (dirName, foreignRequire) {
+        return {
+            require: function (moduleName, namespace) {
+                if (moduleName.indexOf("/") > -1) {
+                    moduleName = dirName + "/" + moduleName;
+                }
+                return fluid.require(moduleName, foreignRequire, namespace);
+            }
+        }
     };
 
     module.exports = fluid;


### PR DESCRIPTION
Also a similar facility for fluid.require which allows the module lookup path to be based from the user's position (usually higher up the directory tree than fluid). We now also export fluid's "Error" object so that it can be used for configuring stack traces in node.js
