### PR TITLE
FLUID-4685: Fixed the detection of px2em factor on body element

### DIFF
--- a/src/webapp/components/uiOptions/js/UIEnhancer.js
+++ b/src/webapp/components/uiOptions/js/UIEnhancer.js
@@ -352,8 +352,9 @@ var fluid_1_5 = fluid_1_5 || {};
     };
     
     fluid.uiEnhancer.getPx2EmFactor = function (container, fontSizeMap) {
-        // The base font size is the computed font size of the container's parent element unless the container itself has been a "body" tag
-        if (container.get(0).tagName !== "BODY") {
+        // The base font size is the computed font size of the container's parent element unless the container itself 
+        // has been the DOM root element "HTML" which is NOT detectable with this algorithm
+        if (container.get(0).tagName !== "HTML") {
             container = container.parent();
         }
         return fluid.uiEnhancer.getTextSizeInPx(container, fontSizeMap);

--- a/src/webapp/tests/component-tests/uiOptions/js/UIEnhancerTests.js
+++ b/src/webapp/tests/component-tests/uiOptions/js/UIEnhancerTests.js
@@ -59,12 +59,19 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             jqUnit.assertEquals("Things are still styled with 'last-class' ", 2, $(".last-class").length);
         });
 
-        tests.test("getPx2EmFactor", function () {
+        tests.test("getPx2EmFactor & getTextSizeInEm", function () {
+            expect(2);
+            
             var container = $(".flt-baseFontSize-child");
             var uiEnhancer = fluid.uiEnhancer(container, uiEnhancerOptions);
             var px2emFactor = fluid.uiEnhancer.getPx2EmFactor(container, uiEnhancer.options.fontSizeMap);
 
             jqUnit.assertEquals("Check that the factor is pulled from the container correctly", 8, px2emFactor);
+
+            var container = $("html");
+            var fontSizeInEm = fluid.uiEnhancer.getTextSizeInEm(container, uiEnhancer.options.fontSizeMap);
+
+            jqUnit.assertEquals("Unable to detect the text size in em for the DOM root element <html>. Always return 1em.", 1, fontSizeInEm);
         });
 
         tests.test("TextSizer", function () {


### PR DESCRIPTION
To fix the issue that 1em is always applied to body element at the page load regardless its original font size.
