### PR TITLE
FLUID-4693: Unbind focusout listener early to avoid undesirable race condition on Chrome 18 which invokes focusout on DOM manipulation

### DIFF
--- a/src/webapp/components/reorderer/js/Reorderer.js
+++ b/src/webapp/components/reorderer/js/Reorderer.js
@@ -814,7 +814,6 @@ var fluid_1_5 = fluid_1_5 || {};
                     });
                 },
                 onMove: function (item, newPosition) {
-                    console.log("labeller onMove: map is ", movedMap);
                     fluid.clear(movedMap); // if we somehow were fooled into missing a defocus, at least clear the map on a 2nd move
                     // This unbind is needed for FLUID-4693 with Chrome 18, which generates a focusOut when
                     // simply doing the DOM manipulation to move the element to a new position.   


### PR DESCRIPTION
Sadly it was not possible to provoke this issue in a test case, possibly due to the limitations on simulations of focus. However, the issue is easily demonstrable in every integration with the LayoutReorderer in Chrome 18.
