### PR TITLE
FLUID-4724: Force ToC to remain fully hidden on UIO full-page demo pages...

### DIFF
--- a/src/webapp/demos/uiOptions/html/uiOptionsFullWithPreview.html
+++ b/src/webapp/demos/uiOptions/html/uiOptionsFullWithPreview.html
@@ -73,8 +73,10 @@
         </div>
 
         <div class="content">
-            <div class="flc-toc-tocContainer fl-hidden">
-            </div>
+            <span class="fl-hidden">
+                <div class="flc-toc-tocContainer">
+                </div>
+            </span>
     
             <h1>User Interface Options</h1>
             <div id="myUIOptions"></div>

--- a/src/webapp/demos/uiOptions/html/uiOptionsFullWithoutPreview.html
+++ b/src/webapp/demos/uiOptions/html/uiOptionsFullWithoutPreview.html
@@ -67,8 +67,10 @@
         </div>
 
         <div class="content">
-            <div class="flc-toc-tocContainer fl-hidden">
-            </div>
+            <span class="fl-hidden">
+                <div class="flc-toc-tocContainer">
+                </div>
+            </span>
     
             <h1>User Interface Options</h1>        
             <div id="myUIOptions"></div>     


### PR DESCRIPTION
This is a small fix to the UIO demo.
