### PR TITLE
FLUID-4736: Direct fix to default value merge policies to restore framework + tests to functionality

### DIFF
--- a/src/webapp/components/reorderer/js/Reorderer.js
+++ b/src/webapp/components/reorderer/js/Reorderer.js
@@ -614,7 +614,9 @@ var fluid_1_5 = fluid_1_5 || {};
         },
         selectors: {
             dropWarning: ".flc-reorderer-dropWarning",
-            movables: ".flc-reorderer-movable",
+            movables:    ".flc-reorderer-movable",
+            selectables: ".flc-reorderer-movable",
+            dropTargets: ".flc-reorderer-movable",
             grabHandle: "",
             stylisticOffset: ""
         },

--- a/src/webapp/demos/reorderer/gridReorderer/html/gridReorderer.html
+++ b/src/webapp/demos/reorderer/gridReorderer/html/gridReorderer.html
@@ -34,9 +34,9 @@
             <h1>Letter Puzzle</h1>
 
             <p><strong>Mouse instructions:</strong> Drag and drop items with the mouse.</p>
-            <p><strong>Keyboard instructions:</strong>Direction keys (arrow keys or i-j-k-m) move focus. CTRL + direction keys move the item.</p>
+            <p><strong>Keyboard instructions:</strong> Direction keys (arrow keys or i-j-k-m) move focus. CTRL + direction keys move the item.</p>
 
-            <div class="flc-reorderer-movable">                               
+            <div class="flc-reorderer-movable">
             <ul class="demoSelector-gridReorderer-alphabetGrid demo-gridReorderer-alphabetGrid fl-focus">
                 <div class="flc-reorderer-movable">F</div>
                 <div class="flc-reorderer-movable">G</div>           
@@ -49,7 +49,7 @@
                 <div class="flc-reorderer-movable">C</div>
             </ul>
         
-        </div>
+            </div>
         <script type="text/javascript">
             demo.initGridReorderer();
         </script>

--- a/src/webapp/demos/reorderer/imageReorderer/html/imageReorderer.html
+++ b/src/webapp/demos/reorderer/imageReorderer/html/imageReorderer.html
@@ -35,7 +35,7 @@
      <h1>Image Gallery</h1>
      
      <p><strong>Mouse instructions:</strong> Drag and drop items with the mouse.  View an image by clicking it.</p>
-     <p><strong>Keyboard instructions:</strong>Direction keys (arrow keys or i-j-k-m) move focus. CTRL + direction keys move the item. View an image by using the 'Return' or 'Enter' key.</p>
+     <p><strong>Keyboard instructions:</strong> Direction keys (arrow keys or i-j-k-m) move focus. CTRL + direction keys move the item. View an image by using the 'Return' or 'Enter' key.</p>
             
     <form action="#" id="reorder-images-form" class="flc-imageReorderer fl-imageReorderer fl-reorderer-horizontalLayout fl-focus">
     

--- a/src/webapp/framework/core/js/Fluid.js
+++ b/src/webapp/framework/core/js/Fluid.js
@@ -1147,7 +1147,10 @@ var fluid = fluid || fluid_1_5;
             }
         }      
     };
-                
+
+    // TODO: so far, profiling does not suggest that this implementation is a performance risk, but we really should start
+    // "precompiling" these.
+    // unsupported, NON-API function                
     fluid.mergePolicyIs = function (policy, test) {
         return typeof (policy) === "string" && $.inArray(test, policy.split(/\s*,\s*/)) !== -1;
     };
@@ -1200,6 +1203,41 @@ var fluid = fluid || fluid_1_5;
         }
         return target;
     }
+
+    // TODO: deprecate this method of detecting default value merge policies before 1.5 in favour of 
+    // explicit typed records a la ModelTransformations
+    // unsupported, NON-API function
+    fluid.isDefaultValueMergePolicy = function (policy) {
+        return typeof(policy) === "string"
+            && (policy.indexOf(",") === -1 && !/replace|preserve|nomerge|noexpand|reverse/.test(policy));
+    };
+    
+    // unsupported, NON-API function
+    fluid.applyDefaultValueMergePolicy = function (defaults, merged) {
+        var policy = merged.mergePolicy;
+        if (policy && typeof (policy) !== "string") {
+            for (var key in policy) {
+                var elrh = policy[key];
+                if (fluid.isDefaultValueMergePolicy(elrh)) {
+                    var defaultTarget = fluid.get(defaults, key);
+                    var mergedTarget = fluid.get(merged, key);
+                 // TODO: this implementation is faulty since it will trigger if a user modifies a source value to its default value
+                 // - and also will still copy over a target if user modifies it to its default value
+                 // probably needs FLUID-4392 for a proper fix since the algorithm will need a fundamental change to progress from
+                 // R2L rather than L2R (is that even possible!)
+                    if (defaultTarget === mergedTarget) {
+                        var defaultSource = fluid.get(defaults, elrh);
+                        var mergedSource = fluid.get(merged, elrh);
+                        // NB: This line represents a change in policy - will not apply default value policy to defaults themselves
+                        if (defaultSource !== mergedSource) {
+                            fluid.set(merged, key, mergedSource);
+                        }
+                    }
+                }
+            }
+        }
+        return merged;
+    };
     
     /** Merge a collection of options structures onto a target, following an optional policy.
      * This function is typically called automatically, as a result of an invocation of
@@ -1223,18 +1261,6 @@ var fluid = fluid || fluid_1_5;
             var source = arguments[i];
             if (source !== null && source !== undefined) {
                 mergeImpl(policy, path, target, source, policy ? policy[""] : null, {seenIds: {}});
-            }
-        }
-        if (policy && typeof (policy) !== "string") {
-            for (var key in policy) {
-                var elrh = policy[key];
-                if (typeof (elrh) === "string" && elrh !== "replace" && elrh !== "preserve") {
-                    var oldValue = fluid.get(target, key);
-                    if (oldValue === null || oldValue === undefined) {
-                        var value = fluid.get(target, elrh);
-                        fluid.set(target, key, value);
-                    }
-                }
             }
         }
         return target;     
@@ -1289,7 +1315,9 @@ var fluid = fluid || fluid_1_5;
             extraArgs = fluid.transformOptions(extraArgs, transRec);
         }
         mergeArgs = mergeArgs.concat(extraArgs);
-        that.options = fluid.merge.apply(null, mergeArgs);
+        var merged = fluid.merge.apply(null, mergeArgs);
+        merged = fluid.applyDefaultValueMergePolicy(defaults, merged);
+        that.options = merged;
     };
     
     // The Fluid Component System proper   

--- a/src/webapp/tests/framework-tests/core/html/FluidJS-test.html
+++ b/src/webapp/tests/framework-tests/core/html/FluidJS-test.html
@@ -15,6 +15,7 @@
         <!--  These are the jqUnit test js files -->
         <script type="text/javascript" src="../../../lib/qunit/js/qunit.js"></script>
         <script type="text/javascript" src="../../../test-core/jqUnit/js/jqUnit.js"></script>
+        <script type="text/javascript" src="../../../test-core/utils/js/TestUtils.js"></script>
 
         <!--  These are tests that have been written using this page as data -->
         <script type="text/javascript" src="../js/FluidJSTests.js"></script>

--- a/src/webapp/tests/framework-tests/core/html/FluidJSStandalone-test.html
+++ b/src/webapp/tests/framework-tests/core/html/FluidJSStandalone-test.html
@@ -21,6 +21,7 @@
         <!--  These are the jqUnit test js files -->
         <script type="text/javascript" src="../../../lib/qunit/js/qunit.js"></script>
         <script type="text/javascript" src="../../../test-core/jqUnit/js/jqUnit.js"></script>
+        <script type="text/javascript" src="../../../test-core/utils/js/TestUtils.js"></script>
 
         <!--  These are tests that have been written using this page as data -->
         <script type="text/javascript" src="../js/FluidJSTests.js"></script>


### PR DESCRIPTION
Some implementation issues remain for FLUID-4733. Tidy up of rather faulty test cases committed at revision 2f00bd (SVN revision 10385) apparently to resolve "FLUID-3682" which is actually an irrelevant issue. Probably actually meant for FLUID-3824.
