### PR TITLE
FLUID-4711: Fix for clearComponent issued against material containing injected components

### DIFF
--- a/src/webapp/framework/core/js/Fluid.js
+++ b/src/webapp/framework/core/js/Fluid.js
@@ -1424,6 +1424,7 @@ var fluid = fluid || fluid_1_5;
             togo = entry.apply(null, args);
         }
 
+        // TODO: deprecate "returnedOptions" and incorporate into regular ginger world system
         var returnedOptions = togo ? togo.returnedOptions : null;
         if (returnedOptions) {
             fluid.merge(that.options.mergePolicy, that.options, returnedOptions);

--- a/src/webapp/framework/renderer/js/RendererUtilities.js
+++ b/src/webapp/framework/renderer/js/RendererUtilities.js
@@ -37,26 +37,29 @@ fluid_1_5 = fluid_1_5 || {};
         }
         return togo;
     };
-    
-    fluid.renderer.visitDecorators = function(that, visitor) {
+
+    // TODO: API status of these 3 functions is uncertain. So far, they have never
+    // appeared in documentation. API change required for Infusion 1.5 to include instantiator.
+    // This is inconvenient, but in the future, all component discovery will require this.   
+    fluid.renderer.visitDecorators = function(that, visitor, instantiator) {
         fluid.visitComponentChildren(that, function(component, name) {
             if (name.indexOf(fluid.renderer.decoratorComponentPrefix) === 0) {
                 visitor(component, name);
             }
-        }, {flat: true});  
+        }, {flat: true, instantiator: instantiator});  
     };
 
     fluid.renderer.clearDecorators = function(instantiator, that) {
         fluid.renderer.visitDecorators(that, function(component, name) {
             instantiator.clearComponent(that, name);
-        });
+        }, instantiator);
     };
     
-    fluid.renderer.getDecoratorComponents = function(that) {
+    fluid.renderer.getDecoratorComponents = function(that, instantiator) {
         var togo = {};
         fluid.renderer.visitDecorators(that, function(component, name) {
             togo[name] = component;
-        });
+        }, instantiator);
         return togo;
     };
 

--- a/src/webapp/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/src/webapp/tests/framework-tests/core/js/FluidIoCTests.js
@@ -632,6 +632,8 @@ fluid.registerNamespace("fluid.tests");
         that.eventChild.events.parentEvent.fire();
         
     });
+
+    /** FLUID-4055 - reinstantiation test **/
     
     fluid.tests.reinsNonComponent = function () {
         return {
@@ -742,6 +744,39 @@ fluid.registerNamespace("fluid.tests");
         checkValue("Changed value", reins, "headValue2", expectedPaths);
     });
     
+    /** FLUID-4711 - corruption in clear with injected material of longer scope **/
+    
+    fluid.defaults("fluid.tests.clearParent", {
+        gradeNames: ["fluid.eventedComponent", "autoInit"],
+        events: {
+            requestStart: null
+        },
+        components: {
+            longChild: {
+                type: "fluid.tests.refChild"
+            },
+            shortParent: {
+                type: "fluid.tests.refChild",
+                createOnEvent: "requestStart",
+                options: {
+                    components: {
+                         clearParent: "{clearParent}"
+                    }
+                }
+            }
+        }  
+    });
+    
+    fluidIoCTests.test("FLUID-4711 reinstantiation test", function () {
+        var reins = fluid.tests.clearParent();
+        reins.events.requestStart.fire();
+        jqUnit.assertValue("Child components instantiated and injected", reins.shortParent.clearParent.longChild);
+        reins.events.requestStart.fire();
+        jqUnit.assertValue("Long lifetime component has survived", reins.longChild);
+    });
+    
+    /** FLUID-4179 unexpected material in clear test **/
+    
     fluid.defaults("fluid.tests.misclearTop", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         components: {
@@ -776,6 +811,8 @@ fluid.registerNamespace("fluid.tests");
         jqUnit.assertValue("Component successfully constructed", that);
     });
     
+    /** FLUID-4129 - merge policy for component options test **/
+    
     fluid.defaults("fluid.tests.mergeChild", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         mergePolicy: {
@@ -803,6 +840,7 @@ fluid.registerNamespace("fluid.tests");
             mergeComp.mergeChild.options.dangerousParams);
     });
 
+    /** Component lifecycle functions and merging test **/
     
     fluid.tests.makeInitFunction = function (name) {
         return function (that) {
@@ -900,6 +938,8 @@ fluid.registerNamespace("fluid.tests");
         jqUnit.assertDeepEq("Expected initialisation sequence", testComp.initFunctionRecord, expected); 
     });
     
+    /** FLUID-4290 - createOnEvent sequence corruption test **/
+    
     fluid.defaults("fluid.tests.createOnEvent", {
         gradeNames: ["fluid.eventedComponent", "autoInit"],
         events: {
@@ -939,6 +979,8 @@ fluid.registerNamespace("fluid.tests");
         var testComp = fluid.tests.createOnEvent();
         jqUnit.assert("Component successfully constructed");
     });
+
+    /** Guided component sequence (priority field without createOnEvent **/
 
     fluid.tests.guidedChildInit = function (that) {
        // awful, illegal, side-effect-laden init function :P
@@ -1000,6 +1042,8 @@ fluid.registerNamespace("fluid.tests");
         var testComp = fluid.tests.guidedParent();
         jqUnit.assertDeepEq("Children constructed in sort order", [1, 2, 3, 4], testComp.constructRecord);
     });
+    
+    /** Tree circularity test (early detection of stack overflow **/
         
     fluid.defaults("fluid.tests.circularity", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
@@ -1074,7 +1118,6 @@ fluid.registerNamespace("fluid.tests");
     fluid.tests.circular.initEngine = function (that) {
       // This line, which is a somewhat illegal use of an invoker before construction is complete,
       // will trigger failure
-      //  fluid.fail("Thing");
         that.bindEvents();
     };
     
@@ -1125,6 +1168,7 @@ fluid.registerNamespace("fluid.tests");
         }
     });
 
+    /** Correct resolution of invoker arguments through the tree **/
 
     fluid.tests.invokerGrandParent = function (options) {
         var that = fluid.initLittleComponent("fluid.tests.invokerGrandParent", options);
@@ -1178,6 +1222,8 @@ fluid.registerNamespace("fluid.tests");
             newValue, that.invokerwrapper.invoker2.checkTestValue());
     });
     
+    /** FLUID-4285 - prevent attempts to refer to options outside options block **/
+    
     fluid.defaults("fluid.tests.news.parent", {
         gradeNames: ["fluid.modelComponent", "autoInit"],
         model: { test: "test" },
@@ -1228,6 +1274,8 @@ fluid.registerNamespace("fluid.tests");
             fluid.pushSoftFailure(-1);  
         }
     });
+    
+    /** FLUID-4626 - references between separated component "islands" (without common instantiator) **/
     
     fluid.defaults("fluid.tests.island1", {
         gradeNames: ["fluid.eventedComponent", "autoInit"],

--- a/src/webapp/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
+++ b/src/webapp/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
@@ -896,6 +896,9 @@ fluid.registerNamespace("fluid.tests");
         
         fluid.defaults("fluid.tests.repeatHead", {
             gradeNames: ["fluid.rendererComponent", "autoInit"],
+            components: {
+                instantiator: "{instantiator}",
+            },
             protoTree: {
                 expander: {
                     type: "fluid.renderer.repeat",
@@ -925,7 +928,7 @@ fluid.registerNamespace("fluid.tests");
             };
             var head = fluid.tests.repeatHead(".repeater-leaf-test", {model: model});
             head.refreshView();
-            var decorators = fluid.renderer.getDecoratorComponents(head);
+            var decorators = fluid.renderer.getDecoratorComponents(head, head.instantiator);
             var declist = [];
             fluid.each(decorators, function (decorator, key) {
                 declist.push({key: key, decorator: decorator});
@@ -1546,6 +1549,9 @@ fluid.registerNamespace("fluid.tests");
         });
         fluid.defaults("fluid.tests.pathExpanderParent", {
             gradeNames: ["autoInit", "fluid.rendererComponent"],
+            components: {
+                instantiator: "{instantiator}",
+            },
             model: {
                 rows: ["0", "1", "2"]
             },
@@ -1579,7 +1585,7 @@ fluid.registerNamespace("fluid.tests");
         });
         protoTests.test("FLUID-4537 further: pathAs propagation", function () {
             var that = fluid.tests.pathExpanderParent(".pathAsProp");
-            var decorators = fluid.renderer.getDecoratorComponents(that);
+            var decorators = fluid.renderer.getDecoratorComponents(that, that.instantiator);
             fluid.each(decorators, function (comp, name) {
                 jqUnit.assertEquals("Path should not be expanded into value", "rows." + comp.options.val, comp.options.path);
             });


### PR DESCRIPTION
Rationalisation of various internal APIs such as visitComponentChildren to explicitly perform path tracking, and cleanup of the instantiator recordkeeping system to be more clear about which records are expected (idToPath contains ONLY the "created path" whereas pathToComponent contains paths for both injected and created components). Paving the way towards a more reliable instantiator-only system that no longer performs manual component discovery. Two APIs in RendererUtilities.js adjusted to reflect this.
