### PR TITLE
FLUID-4780: Fixing tooltip test and tooltip code.

### DIFF
--- a/src/webapp/components/tooltip/js/Tooltip.js
+++ b/src/webapp/components/tooltip/js/Tooltip.js
@@ -65,6 +65,7 @@ var fluid_1_5 = fluid_1_5 || {};
          */
         that.updateContent = function (content) {
             that.container.tooltip("option", "content", createContentFunc(content));
+            that.container.data("tooltip").tooltip.html(content);
         };
         
         /**

--- a/src/webapp/tests/component-tests/tooltip/js/TooltipTests.js
+++ b/src/webapp/tests/component-tests/tooltip/js/TooltipTests.js
@@ -65,7 +65,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             jqUnit.assertTrue("The tooltip element is exposed correctly", 0 === tt.elm.index(ttELM));
             
             tt.updateContent(newContent);
-            jqUnit.assertTrue("The tooltip content should have updated", newContent, ttELM.text());
+            jqUnit.assertEquals("The tooltip content should have updated", newContent, ttELM.text());
             
             tt.container.tooltip("destroy");
         });


### PR DESCRIPTION
Tooltip should be updated dynamically once updateContent() is called and there is no need for a user to refocus on the element (call close() and then open() for the tooltip) to see a change in the tooltip's content.
Also fixed the test since it always passed.
