### PR TITLE
FLUID-4732: Fixing inlineEdit namespace. Now users can use fluid.inlineE...

### DIFF
--- a/src/webapp/components/inlineEdit/js/InlineEdit.js
+++ b/src/webapp/components/inlineEdit/js/InlineEdit.js
@@ -331,11 +331,11 @@ var fluid_1_5 = fluid_1_5 || {};
      * @param {Object} options a collection of options settings
      */
     fluid.inlineEdit = function (componentContainer, userOptions) {   
-        var that = fluid.initView("inlineEdit", componentContainer, userOptions);
+        var that = fluid.initView("fluid.inlineEdit", componentContainer, userOptions);
         
         // if old 'defaultViewText' option was used intead of strings version, update strings version
         if ((that.options.defaultViewText !== undefined) &&
-            (that.options.strings.defaultViewText === fluid.defaults("inlineEdit").strings.defaultViewText)) {
+            (that.options.strings.defaultViewText === fluid.defaults("fluid.inlineEdit").strings.defaultViewText)) {
             that.options.strings.defaultViewText = that.options.defaultViewText;
         }
 
@@ -816,7 +816,7 @@ var fluid_1_5 = fluid_1_5 || {};
      */
     fluid.inlineEdits = function (componentContainer, options) {
         options = options || {};
-        var selectors = $.extend({}, fluid.defaults("inlineEdits").selectors, options.selectors);
+        var selectors = $.extend({}, fluid.defaults("fluid.inlineEdits").selectors, options.selectors);
         
         // Bind to the DOM.
         var container = fluid.container(componentContainer);
@@ -825,7 +825,7 @@ var fluid_1_5 = fluid_1_5 || {};
         return setupInlineEdits(editables, options);
     };
     
-    fluid.defaults("inlineEdit", {
+    fluid.defaults("fluid.inlineEdit", {
         gradeNames: ["fluid.viewComponent"],
         selectors: {
             text: ".flc-inlineEdit-text",
@@ -912,7 +912,7 @@ var fluid_1_5 = fluid_1_5 || {};
         selectOnEdit: false        
     });
     
-    fluid.defaults("inlineEdits", {
+    fluid.defaults("fluid.inlineEdits", {
         gradeNames: ["fluid.viewComponent"],
         selectors: {
             editables: ".flc-inlineEditable"

--- a/src/webapp/tests/component-tests/inlineEdit/html/InlineEdit-test.html
+++ b/src/webapp/tests/component-tests/inlineEdit/html/InlineEdit-test.html
@@ -17,6 +17,7 @@
         <script type="text/javascript" src="../../../../framework/core/js/FluidDocument.js"></script>
         <script type="text/javascript" src="../../../../framework/core/js/jquery.keyboard-a11y.js"></script>
         <script type="text/javascript" src="../../../../framework/core/js/Fluid.js"></script>
+        <script type="text/javascript" src="../../../../framework/core/js/FluidIoC.js"></script>
         <script type="text/javascript" src="../../../../framework/core/js/FluidView.js"></script>
         <script type="text/javascript" src="../../../../components/tooltip/js/Tooltip.js"></script>
         <script type="text/javascript" src="../../../../components/inlineEdit/js/InlineEdit.js"></script>
@@ -155,6 +156,11 @@
       <!-- Test overriding the tooltip text -->	
       <p id="inline-override-tooltip">
         <span class="flc-inlineEdit-text" id="text1">This text has a tooltip with custom text.</span>
+      </p>
+      
+      <!-- IOC test -->
+      <p id="ioc-inline-edit">
+        <span class="flc-ioc-inlineEditable"><span class="flc-inlineEdit-text">This IoC test</span></span>
       </p>
       </div>
     </body>

--- a/src/webapp/tests/component-tests/inlineEdit/js/InlineEditTests.js
+++ b/src/webapp/tests/component-tests/inlineEdit/js/InlineEditTests.js
@@ -70,10 +70,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             jqUnit.assertEquals("Text is set to", display[0].id, inlineEditor.viewEl[0].id);
             jqUnit.assertEquals("Edit container is set to", editContainer[0].id, inlineEditor.editContainer[0].id);
             jqUnit.assertEquals("Edit field is set to", editField[0].id, inlineEditor.editField[0].id);
-            jqUnit.assertEquals("Focus style is default", fluid.defaults("inlineEdit").styles.focus, inlineEditor.options.styles.focus);
-            jqUnit.assertEquals("Invitation style is default", fluid.defaults("inlineEdit").styles.invitation, inlineEditor.options.styles.invitation);
-            jqUnit.assertEquals("Paddings add is default", fluid.defaults("inlineEdit").paddings.edit, inlineEditor.options.paddings.edit);
-            jqUnit.assertEquals("Paddings minimum is default", fluid.defaults("inlineEdit").paddings.minimumEdit, inlineEditor.options.paddings.minimumEdit);
+            jqUnit.assertEquals("Focus style is default", fluid.defaults("fluid.inlineEdit").styles.focus, inlineEditor.options.styles.focus);
+            jqUnit.assertEquals("Invitation style is default", fluid.defaults("fluid.inlineEdit").styles.invitation, inlineEditor.options.styles.invitation);
+            jqUnit.assertEquals("Paddings add is default", fluid.defaults("fluid.inlineEdit").paddings.edit, inlineEditor.options.paddings.edit);
+            jqUnit.assertEquals("Paddings minimum is default", fluid.defaults("fluid.inlineEdit").paddings.minimumEdit, inlineEditor.options.paddings.minimumEdit);
             jqUnit.assertTrue("FLUID-2100: The tool tip is on by default", inlineEditor.options.useTooltip);
             jqUnit.isVisible("Display field is visible", "#display");
             jqUnit.notVisible("Edit field is hidden", "#edit-container");
@@ -189,7 +189,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             var display = $("#empty-display");
             jqUnit.assertEquals("Before initialization of empty display, display is empty", "", display.text());
             var inlineEditor = fluid.inlineEdit("#empty-inline-edit");
-            jqUnit.assertEquals("After initialization of empty display, display has invitation text: ", fluid.defaults("inlineEdit").strings.defaultViewText, display.text());
+            jqUnit.assertEquals("After initialization of empty display, display has invitation text: ", fluid.defaults("fluid.inlineEdit").strings.defaultViewText, display.text());
             jqUnit.assertTrue("Invitation text has invitation text style", display.hasClass(inlineEditor.options.styles.defaultViewStyle));
             jqUnit.assertTrue("Invitation text still contains it's initial class attribute as well", display.hasClass("flc-inlineEdit-text")); // added for FLUID-1803 
             jqUnit.assertEquals("The textEditButton text should be set", "Edit text " + inlineEditor.options.strings.defaultViewText, inlineEditor.locate("textEditButton").text());
@@ -206,7 +206,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             inlineEditor.edit();
             edit.prop("value", "");
             inlineEditor.finish();
-            jqUnit.assertEquals("After clearing the field, display should have invitation text again: ", fluid.defaults("inlineEdit").strings.defaultViewText, display.text());
+            jqUnit.assertEquals("After clearing the field, display should have invitation text again: ", fluid.defaults("fluid.inlineEdit").strings.defaultViewText, display.text());
             jqUnit.assertTrue("Invitation text has invitation text style", display.hasClass(inlineEditor.options.styles.defaultViewStyle));
             jqUnit.assertTrue("Invitation text still contains it's initial class attribute as well", display.hasClass("flc-inlineEdit-text")); // added for FLUID-1803
         });
@@ -227,12 +227,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
             var display = $("#empty-display");
             var inlineEditor = fluid.inlineEdit("#empty-inline-edit");
-            jqUnit.assertEquals("After initialization of empty display, display has default invitation text: ", fluid.defaults("inlineEdit").strings.defaultViewText, display.text());
+            jqUnit.assertEquals("After initialization of empty display, display has default invitation text: ", fluid.defaults("fluid.inlineEdit").strings.defaultViewText, display.text());
             var button = inlineEditor.textEditButton;
             button.focus();
-            jqUnit.assertEquals("After focus, display has default focussed invitation text: ", fluid.defaults("inlineEdit").strings.defaultFocussedViewText, display.text());
+            jqUnit.assertEquals("After focus, display has default focussed invitation text: ", fluid.defaults("fluid.inlineEdit").strings.defaultFocussedViewText, display.text());
             button.blur();
-            jqUnit.assertEquals("After blur, display has default invitation text: ", fluid.defaults("inlineEdit").strings.defaultViewText, display.text());
+            jqUnit.assertEquals("After blur, display has default invitation text: ", fluid.defaults("fluid.inlineEdit").strings.defaultViewText, display.text());
         });
 
         inlineEditTests.test("Invitation text (none)", function () {
@@ -245,7 +245,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     
             var inlineEditor = fluid.inlineEdit("#empty-inline-edit", {defaultViewText: ""});
             jqUnit.assertEquals("After initialization, display is still empty", "", display.text());
-            jqUnit.assertEquals("The display field padding is ", fluid.defaults("inlineEdit").paddings.minimumView, parseFloat(display.css("padding-right")));
+            jqUnit.assertEquals("The display field padding is ", fluid.defaults("fluid.inlineEdit").paddings.minimumView, parseFloat(display.css("padding-right")));
     
             var testText = "This is test text that is a bit long.";
             var edit = inlineEditor.editField;
@@ -261,7 +261,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             edit.prop("value", "");
             inlineEditor.finish();
             jqUnit.assertEquals("After clearing the field, display should be empty again: ", "", display.text());
-            jqUnit.assertEquals("The display field padding is ", fluid.defaults("inlineEdit").paddings.minimumView, parseFloat(display.css("padding-right")));
+            jqUnit.assertEquals("The display field padding is ", fluid.defaults("fluid.inlineEdit").paddings.minimumView, parseFloat(display.css("padding-right")));
         });
         
         inlineEditTests.test("isEditing", function () {
@@ -919,6 +919,25 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 });
                 var display = $("#empty-display");
                 jqUnit.assertEquals("Initialized with both strings, the new one should win out", newWay, display.text());
+            });
+            
+            inlineEditTests.test("IOC InlineEdit test", function () {
+                var inlineEdit = $("#ioc-inline-edit").find(".flc-ioc-inlineEditable");
+                
+                fluid.defaults("fluid.componentWithInlineEdit", {
+                    gradeNames: ["fluid.eventedComponent", "autoInit"],
+                    components: {
+                        iocInlineEdit: {
+                            type: "fluid.inlineEdit",
+                            container: inlineEdit,
+                            options: {
+                                tooltipText: "My optional tooltip. InlineEdit has options"
+                            }
+                        }
+                    }
+                });
+                var someComponent = fluid.componentWithInlineEdit();
+                jqUnit.assertTrue("inlineEdit was resolved in IOC", someComponent.iocInlineEdit);
             });
         })();
     });


### PR DESCRIPTION
...dit which will be properly resolved as IoC component.
