### PR TITLE
FLUID-4871: Includes ProgressiveEnhancement in npm module.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,7 +11,6 @@ src/webapp/lib/json
 src/webapp/lib/swfobject
 src/webapp/lib/swfupload
 src/webapp/framework/fss
-src/webapp/framework/enhancement
 build-scripts
 products
 project.xml


### PR DESCRIPTION
Previously we were excluding the ProgressiveEnhancement files from our npm module. This pull request removes it from .npmignore, ensuring that it is included in Node.js. @amb26 or @yzen, can you review?
