### PR TITLE
FLUID-4794: updating progressive enhancement

### DIFF
--- a/src/webapp/components/uploader/js/FlashUploaderSupport.js
+++ b/src/webapp/components/uploader/js/FlashUploaderSupport.js
@@ -24,7 +24,7 @@ var fluid_1_5 = fluid_1_5 || {};
 
     fluid.uploader = fluid.uploader || {};
     
-    fluid.demands("fluid.uploaderImpl", "fluid.uploader.swfUpload", {
+    fluid.demands("fluid.uploader.singleFileUploader", "fluid.browser.supportsFlash", {
         funcName: "fluid.uploader.multiFileUploader"
     });
     
@@ -79,7 +79,7 @@ var fluid_1_5 = fluid_1_5 || {};
         }
     });
     
-    fluid.demands("fluid.uploader.progressiveStrategy", "fluid.uploader.swfUpload", {
+    fluid.demands("fluid.uploader.progressiveStrategy", "fluid.browser.supportsFlash", {
         funcName: "fluid.uploader.swfUploadStrategy"
     });
     

--- a/src/webapp/components/uploader/js/HTML5UploaderSupport.js
+++ b/src/webapp/components/uploader/js/HTML5UploaderSupport.js
@@ -20,11 +20,11 @@ var fluid_1_5 = fluid_1_5 || {};
 
 (function ($, fluid) {
 
-    fluid.demands("fluid.uploaderImpl", "fluid.uploader.html5", {
+    fluid.demands("fluid.uploader.singleFileUploader", "fluid.browser.supportsBinaryXHR", {
         funcName: "fluid.uploader.multiFileUploader"
     });
     
-    fluid.demands("fluid.uploader.progressiveStrategy", "fluid.uploader.html5", {
+    fluid.demands("fluid.uploader.progressiveStrategy", "fluid.browser.supportsBinaryXHR", {
         funcName: "fluid.uploader.html5Strategy"
     });
     

--- a/src/webapp/components/uploader/js/Uploader.js
+++ b/src/webapp/components/uploader/js/Uploader.js
@@ -376,31 +376,21 @@ var fluid_1_5 = fluid_1_5 || {};
             "static environment or else is visible in the current component tree");
     };
     
+    fluid.check({
+        "fluid.browser.supportsBinaryXHR": "fluid.browser.binaryXHR",
+        "fluid.browser.supportsFormData": "fluid.browser.formData",
+        "fluid.browser.supportsFlash": "fluid.browser.flash",
+        "fluid.browser.isBrowser": "fluid.browser.isBrowser"
+    });
+    
     fluid.defaults("fluid.uploader", {
         gradeNames: ["fluid.viewComponent"],
         components: {
-            uploaderContext: {
-                type: "fluid.progressiveCheckerForComponent",
-                options: {componentName: "fluid.uploader"}
-            },
             uploaderImpl: {
-                type: "fluid.uploaderImpl",
+                type: "fluid.uploader.singleFileUploader",
                 container: "{uploader}.container",
                 options: "{uploader}.uploaderOptions"
             }
-        },
-        progressiveCheckerOptions: {
-            checks: [
-                {
-                    feature: "{fluid.browser.supportsBinaryXHR}",
-                    contextName: "fluid.uploader.html5"
-                },
-                {
-                    feature: "{fluid.browser.supportsFlash}",
-                    contextName: "fluid.uploader.swfUpload"
-                }
-            ],
-            defaultContextName: "fluid.uploader.singleFile"
         }
     });
     
@@ -743,10 +733,6 @@ var fluid_1_5 = fluid_1_5 || {};
         selectors: {
             basicUpload: ".fl-progEnhance-basic"
         }
-    });
-
-    fluid.demands("fluid.uploaderImpl", "fluid.uploader.singleFile", {
-        funcName: "fluid.uploader.singleFileUploader"
     });
     
 })(jQuery, fluid_1_5);

--- a/src/webapp/demos/uploader/html/uploader.html
+++ b/src/webapp/demos/uploader/html/uploader.html
@@ -31,9 +31,9 @@
         <script type="text/javascript" src="../../../components/progress/js/Progress.js"></script>
         <script type="text/javascript" src="../../../components/uploader/js/FileQueueView.js"></script>
         <script type="text/javascript" src="../../../components/uploader/js/ErrorPanel.js"></script>
+        <script type="text/javascript" src="../../../components/uploader/js/HTML5UploaderSupport.js"></script>
         <script type="text/javascript" src="../../../components/uploader/js/FlashUploaderSupport.js"></script>
         <script type="text/javascript" src="../../../components/uploader/js/Flash9UploaderSupport.js"></script>
-        <script type="text/javascript" src="../../../components/uploader/js/HTML5UploaderSupport.js"></script>
         <script type="text/javascript" src="../../../components/uploader/js/DemoUploadManager.js"></script>
         <script type="text/javascript" src="../../../components/uploader/js/MimeTypeExtensions.js"></script>
 

--- a/src/webapp/framework/enhancement/js/ProgressiveEnhancement.js
+++ b/src/webapp/framework/enhancement/js/ProgressiveEnhancement.js
@@ -59,15 +59,20 @@ var fluid_1_5 = fluid_1_5 || {};
             isBrowser: fluid.typeTag("fluid.browser")
         };
         
-        $.extend(fluid.staticEnvironment, features);
+        fluid.browser.isBrowser = function () {
+            return typeof(window) !== "undefined" && window.document;
+        };
+        
+        // $.extend(fluid.staticEnvironment, features);
     }
+    
     /*
      * takes an object of key/value pairs where the key will be the key in the static enivronment and the value is a function or function name to run.
      * {staticEnvKey: "progressiveCheckFunc"}
      */
     fluid.check = function (stuffToCheck) {
         fluid.each(stuffToCheck, function (val, key) {
-            var results = val && typeof(val) === "string" ? fluid.invokeGlobalFunction(val) : val();
+            var results = !fluid.staticEnvironment[key] && (typeof(val) === "string" ? fluid.invokeGlobalFunction(val) : val());
             
             if (results) {
                 fluid.staticEnvironment[key] = fluid.typeTag(key);

--- a/src/webapp/tests/framework-tests/enhancement/js/ProgressiveEnhancementTests.js
+++ b/src/webapp/tests/framework-tests/enhancement/js/ProgressiveEnhancementTests.js
@@ -82,12 +82,14 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     fluid.registerNamespace("fluid.test");
     
     jqUnit.test("fluid.check", function () {
-        jqUnit.expect(4);
+        jqUnit.expect(9);
         fluid.test.setEnvironment = function () {
+            jqUnit.assertTrue("The setEnvironment check was run", true);
             return true;
         };
         
         fluid.test.notSetEnvironment = function () {
+            jqUnit.assertTrue("The notSetEnvironment test was run", true);
             return false;
         };
         
@@ -114,6 +116,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         fluid.each(checksNotSet, function (val, key) {
             jqUnit.assertUndefined("The key '" + key + "', should not exist in the static environment", fluid.staticEnvironment[key]);
         });
+        
+        // Rerun a check that has been run before. It should not execute the check func.
+        fluid.check({set1: "fluid.test.setEnvironment"});
+        // Verify that the key is still in the static environment
+        jqUnit.assertValue("The key 'set1', should exist in the static environment", fluid.staticEnvironment.set1);
     }); 
     
     jqUnit.test("fluid.forget", function () {


### PR DESCRIPTION
Adding in two new functions to the progressive enhancement: check and forget. The check function takes an object where the keys will map to the static environment if the value is a function that evaluates to true. This can be used, for example, to test browser features and only set the static environment if they exist. The forget function takes a list of keys to remove from the static environment.

This is the first pass at updating our progressive enhancement strategy to make it more easily extended.
http://issues.fluidproject.org/browse/FLUID-4794
