### PR TITLE
FLUID-4942: Fixes Infusion event system bug with Prototype.js.

### DIFF
--- a/src/webapp/framework/core/js/Fluid.js
+++ b/src/webapp/framework/core/js/Fluid.js
@@ -794,7 +794,7 @@ var fluid = fluid || fluid_1_4;
         var sortedListeners = [];
         
         function fireToListeners(listeners, args, wrapper) {
-            for (var i in listeners) {
+            for (var i = 0; i < listeners.length; ++i) {
                 var lisrec = listeners[i];
                 var listener = lisrec.listener;
                 if (typeof (listener) === "string") {


### PR DESCRIPTION
This is a one line fix to fireToListeners, removing the for..in in favour of a regular for loop in order to avoid a breakage in uPortal due to Prototype.js.

Note that this bug is fixed in Infusion master, so this is just a quick fix for 1.4 users.

@amb26, @michelled or @jobara, can you review this and push it to the infusion-1.4.x branch?
