### PR TITLE
FLUID-4959: Added a height to the toggle label so it doesn't scale with ...

### DIFF
--- a/src/webapp/components/uiOptions/css/FatPanelUIOptionsFrame.css
+++ b/src/webapp/components/uiOptions/css/FatPanelUIOptionsFrame.css
@@ -7,6 +7,7 @@
 
 .fl-uiOptions-fatPanel .fl-uiOptions {
     font-family: 'OpenSans',"Myriad Pro", Helvetica, Arial, sans-serif;
+    line-height: 1.2em !important; /* FLUID-4959: fix the line height so it doesn't scale with the UIO line spacing scaling. */
 }
 
 /* UI Options Fat Panel styles */
@@ -187,6 +188,10 @@
 	height:2em;
 	margin-right:10px;
 	float:left;
+}
+
+.fl-uiOptions-fatPanel .fl-uiOptions-fatPanel-toc label {
+	line-height: 1.7em !important;
 }
 
 .fl-uiOptions-fatPanel .fl-uiOptions-fatPanel-option-description {


### PR DESCRIPTION
...the line spacing option. This will fix the 'off' text in position. Also added a fixed height to the fl-uiOptions container so that line spacing in UIO does not scale with UIO. This may not be a solution we want, but for the demo it helps keep UIO from looking broken.
