### PR TITLE
GPII-114_FLUID-4852: Added configs for get'ing and set'ing escaped elpaths as used for model transformation

### DIFF
--- a/src/webapp/framework/core/js/DataBinding.js
+++ b/src/webapp/framework/core/js/DataBinding.js
@@ -105,33 +105,6 @@ var fluid_1_5 = fluid_1_5 || {};
         }
     };
     
-        
-    fluid.model.defaultGetConfig = {
-        strategies: [fluid.model.funcResolverStrategy, fluid.model.defaultFetchStrategy]
-    };
-
-    fluid.model.defaultSetConfig = {
-        strategies: [fluid.model.funcResolverStrategy, fluid.model.defaultFetchStrategy, fluid.model.defaultCreatorStrategy]
-    };
-
-    // TODO: When FLUID-4852 is fixed, remove these definitions:
-    // fluid.model.escapedGetConfig and fluid.model.escapedSetConfig 
-    fluid.model.escapedGetConfig = {
-        parser: {
-            parse: fluid.pathUtil.parseEL,
-            compose: fluid.pathUtil.composePath
-        },
-        strategies: [fluid.model.defaultFetchStrategy]
-    };
-
-    fluid.model.escapedSetConfig = {
-        parser: {
-            parse: fluid.pathUtil.parseEL,
-            compose: fluid.pathUtil.composePath
-        },
-        strategies: [fluid.model.defaultFetchStrategy, fluid.model.defaultCreatorStrategy]
-    };
-    
     // unsupported, NON-API function
     fluid.model.traverseWithStrategy = function (root, segs, initPos, config, uncess) {
         var strategies = config.strategies;
@@ -431,7 +404,31 @@ var fluid_1_5 = fluid_1_5 || {};
             }
         }
     };
-          
+        
+    fluid.model.defaultGetConfig = {
+        strategies: [fluid.model.funcResolverStrategy, fluid.model.defaultFetchStrategy]
+    };
+
+    fluid.model.defaultSetConfig = {
+        strategies: [fluid.model.funcResolverStrategy, fluid.model.defaultFetchStrategy, fluid.model.defaultCreatorStrategy]
+    };
+
+    fluid.model.escapedGetConfig = {
+        parser: {
+            parse: fluid.pathUtil.parseEL,
+            compose: fluid.pathUtil.composePath
+        },
+        strategies: [fluid.model.defaultFetchStrategy]
+    };
+
+    fluid.model.escapedSetConfig = {
+        parser: {
+            parse: fluid.pathUtil.parseEL,
+            compose: fluid.pathUtil.composePath
+        },
+        strategies: [fluid.model.defaultFetchStrategy, fluid.model.defaultCreatorStrategy]
+    };
+
     /** Add a listener to a ChangeApplier event that only acts in the case the event
      * has not come from the specified source (typically ourself)
      * @param modelEvent An model event held by a changeApplier (typically applier.modelChanged)

--- a/src/webapp/framework/core/js/ModelTransformations.js
+++ b/src/webapp/framework/core/js/ModelTransformations.js
@@ -655,20 +655,14 @@ var fluid = fluid || fluid_1_5;
      */
     fluid.model.transformWithRules = function (source, rules, options) {
         options = options || {};
-        var parser = {
-            parse: fluid.pathUtil.parseEL,
-            compose: fluid.pathUtil.composePath
-        };
-        var getConfig = {
-            parser: parser,
-            strategies: [fluid.model.defaultFetchStrategy]
-        };
+        
+        var getConfig = fluid.model.escapedGetConfig;
+        
         var schemaStrategy = fluid.model.transform.decodeStrategy(source, options, getConfig);
-        var setConfig = {
-            parser: parser,
-            strategies: [fluid.model.defaultFetchStrategy, schemaStrategy ? fluid.model.transform.schemaToCreatorStrategy(schemaStrategy)
-                : fluid.model.defaultCreatorStrategy]
-        };
+        var setConfig = fluid.copy(fluid.model.escapedSetConfig);
+        setConfig.strategies = [fluid.model.defaultFetchStrategy, schemaStrategy ? fluid.model.transform.schemaToCreatorStrategy(schemaStrategy)
+                : fluid.model.defaultCreatorStrategy];
+
         var expander = {
             source: source,
             target: schemaStrategy ? fluid.model.transform.defaultSchemaValue(schemaStrategy(null, "", 0, [""])) : {},
@@ -693,8 +687,7 @@ var fluid = fluid || fluid_1_5;
             fluid.model.transform.expandWildcards(expander, source);
         }
         fluid.model.fireSortedChanges(expander.queuedChanges, expander.finalApplier);
-        return expander.target;
-        
+        return expander.target;    
     };
     
     $.extend(fluid.model.transformWithRules, fluid.model.transform);


### PR DESCRIPTION
This is a pre-requisite for removing duplicate definitions from the GPII code. I created GPII-114 for this. Not sure to what extend this also takes care of FLUID-4852, or whether this JIRA was though to be integrated as default behavior as opposed to seperate configs.

JIRAs in question:
http://issues.fluidproject.org/browse/FLUID-4852
http://issues.gpii.net/browse/GPII-114
