### PR TITLE
FLUID-5082: Implementation and test cases for new "soft namespaces" system for event listeners

### DIFF
--- a/src/webapp/components/inlineEdit/js/InlineEdit.js
+++ b/src/webapp/components/inlineEdit/js/InlineEdit.js
@@ -853,18 +853,14 @@ var fluid_1_5 = fluid_1_5 || {};
         listeners: {
             onCreate: [{
                 func: "{that}.refreshView",
-                namespace: "refreshView"
             }, {
                 funcName: "fluid.inlineEdit.initializeEditView",
-                namespace: "initializeEditView",
                 args: ["{that}", true]
             }, {
                 funcName: "fluid.inlineEdit.setup",
-                namespace: "setup",
                 args: "{that}"
             }, {
                 funcName: "fluid.inlineEdit.processUndoDecorator",
-                namespace: "processUndoDecorator",
                 args: "{that}"
             }],
             onBeginEdit: {

--- a/src/webapp/components/reorderer/js/Reorderer.js
+++ b/src/webapp/components/reorderer/js/Reorderer.js
@@ -207,7 +207,7 @@ var fluid_1_5 = fluid_1_5 || {};
             onRefresh: null
         },
         listeners: {
-            onCreate: [ { // TODO: better model for creation sequence, with auto-namespaces
+            onCreate: [ {
                 funcName: "fluid.reorderer.bindHandlersToContainer",
                 args: ["{that}.container", "{that}.handleKeyDown", "{that}.handleKeyUp"]
             }, {
@@ -218,7 +218,6 @@ var fluid_1_5 = fluid_1_5 || {};
                 args: "{that}.container"
             }, {
                 funcName: "fluid.reorderer.processAfterMoveCallbackUrl",
-                namespace: "processAfterMoveCallbackUrl",
                 args: "{that}"  
             },
             "{that}.refresh"],
@@ -229,8 +228,7 @@ var fluid_1_5 = fluid_1_5 || {};
             },
             onHover: {
                 funcName: "fluid.reorderer.hoverStyleHandler",
-                args: ["{that}.dom", "{that}.options.styles", "{arguments}.0", "{arguments}.1"], // item, state
-                namespace: "style"
+                args: ["{that}.dom", "{that}.options.styles", "{arguments}.0", "{arguments}.1"] // item, state
             } 
         },
         invokers: {

--- a/src/webapp/components/undo/js/Undo.js
+++ b/src/webapp/components/undo/js/Undo.js
@@ -133,7 +133,6 @@ var fluid_1_5 = fluid_1_5 || {};
         listeners: {
             onCreate: [{
                 funcName: "fluid.undo.refreshView",
-                namespace: "refreshView",
                 args: "{that}"
             }, {
                 "this": "{that}.dom.undoControl",

--- a/src/webapp/framework/core/js/FluidIoC.js
+++ b/src/webapp/framework/core/js/FluidIoC.js
@@ -92,7 +92,7 @@ var fluid_1_5 = fluid_1_5 || {};
                 }
             }
             return toMount(target, name, i - prefix.length, segs.slice(offset));
-        }
+        };
     };
     
     // unsupported, NON-API function    
@@ -459,15 +459,15 @@ var fluid_1_5 = fluid_1_5 || {};
                 });
             }
             else if (record.createOnEvent) {
-               var event = fluid.event.expandOneEvent(that, record.createOnEvent);
-               fluid.set(shadow, ["dynamicComponentCount", recordKey], 0);
-               var listener = function () {
+                var event = fluid.event.expandOneEvent(that, record.createOnEvent);
+                fluid.set(shadow, ["dynamicComponentCount", recordKey], 0);
+                var listener = function () {
                     var key = fluid.registerDynamicRecord(that, recordKey, shadow.dynamicComponentCount[recordKey]++, record, "createOnEvent");
                     localSub[key] = {"arguments": fluid.makeArray(arguments)};
                     fluid.initDependent(that, key);
-               };
-               event.addListener(listener);
-               fluid.recordListener(event, listener, shadow);
+                };
+                event.addListener(listener);
+                fluid.recordListener(event, listener, shadow);
             }
         });
     };
@@ -496,7 +496,7 @@ var fluid_1_5 = fluid_1_5 || {};
     
     fluid.shadowForComponent = function (component) {
         var instantiator = fluid.getInstantiator(component);
-        return shadow = instantiator && component ? instantiator.idToShadow[component.id] : null;      
+        return instantiator && component ? instantiator.idToShadow[component.id] : null;      
     };
     
     fluid.getForComponent = function (component, path) {
@@ -1345,7 +1345,7 @@ outer:  for (var i = 0; i < exist.length; ++i) {
             fluid.fail("Record ", that, " must contain both entries \"method\" and \"this\" if it contains either");
         }
         if (!record.method) {
-           return null;
+            return null;
         }
         return {
             apply: function (noThis, args) {
@@ -1424,11 +1424,11 @@ outer:  for (var i = 0; i < exist.length; ++i) {
     fluid.event.makeTrackedListenerAdder = function (source) {
         var shadow = fluid.shadowForComponent(source);
         return function (event) {
-            return {addListener: function(listener) {
+            return {addListener: function (listener) {
                     fluid.recordListener(event, listener, shadow);
                     event.addListener.apply(null, arguments);
                 }
-            }
+            };
         };
     };
 
@@ -1473,9 +1473,19 @@ outer:  for (var i = 0; i < exist.length; ++i) {
             return togo;
         };
     };
+
+    // unsupported, non-API function    
+    fluid.event.resolveSoftNamespace = function (key) {
+        if (typeof(key) !== "string") {
+            return null;
+        } else {
+            var lastpos = Math.max(key.lastIndexOf("."), key.lastIndexOf("}"));
+            return key.substring(lastpos + 1);
+        }
+    };
     
     // unsupported, non-API function
-    fluid.event.resolveListenerRecord = function (lisrec, that, eventName) {
+    fluid.event.resolveListenerRecord = function (lisrec, that, eventName, namespace) {
         var badRec = function (record, extra) {
             fluid.fail("Error in listener record - could not resolve reference ", record, " to a listener or firer. "
                     + "Did you miss out \"events.\" when referring to an event firer?" + extra);
@@ -1493,7 +1503,12 @@ outer:  for (var i = 0; i < exist.length; ++i) {
                 expanded.listener = expanded.listener || expanded.func || expanded.funcName;
             }
             if (!expanded.listener) {
-                badRec(record, " Listener record must contain a member named \"listener\" or \"method\"");
+                badRec(record, " Listener record must contain a member named \"listener\", \"func\", \"funcName\" or \"method\"");
+            }
+            var softNamespace = fluid.event.resolveSoftNamespace(record.method ? record["this"] + "-" + record.method : expanded.listener);
+            if (!expanded.namespace && !namespace && softNamespace) {
+                expanded.softNamespace = true;
+                expanded.namespace = softNamespace;
             }
             var listener = expanded.listener = fluid.expandOptions(expanded.listener, that);
             if (!listener) {


### PR DESCRIPTION
- primarily designed to automatically assign sensible default namespaces for members of long rambling "onCreate" listener blocks. These will not mutually interfere but require an explicit namespace guess in order to be overridden.
