### PR TITLE
FLUID-5210: Added a merge policy

### DIFF
--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -139,10 +139,24 @@ var fluid_1_5 = fluid_1_5 || {};
      * Base grade for composite panel *
      **********************************/
 
+    fluid.registerNamespace("fluid.prefs.compositePanel");
+
+    fluid.prefs.compositePanel.arrayMergePolicy = function (target, source) {
+        target = fluid.makeArray(target);
+        source = fluid.makeArray(source);
+        fluid.each(source, function (selector) {
+            if ($.inArray(selector, target) < 0) {
+                target.push(selector);
+            }
+        });
+        return target;
+    };
+
     fluid.defaults("fluid.prefs.compositePanel", {
         gradeNames: ["fluid.prefs.panel", "autoInit", "{that}.getDistributeOptionsGrade"],
         mergePolicy: {
-            subPanelOverrides: "noexpand"
+            subPanelOverrides: "noexpand",
+            selectorsToIgnore: fluid.prefs.compositePanel.arrayMergePolicy
         },
         selectors: {}, // requires selectors into the template which will act as the containers for the subpanels
         selectorsToIgnore: [], // should match the selectors that are used to identify the containers for the subpanels

--- a/src/tests/framework-tests/preferences/html/Panels-test.html
+++ b/src/tests/framework-tests/preferences/html/Panels-test.html
@@ -114,6 +114,7 @@
     <div class="fluid-5201"></div>
     <div class="fluid-5202"></div>
     <div class="fluid-5203"></div>
+    <div class="fluid-5210"></div>
 
     </body>
 </html>

--- a/src/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/src/tests/framework-tests/preferences/js/PanelsTests.js
@@ -740,6 +740,36 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     /* end FLUID-5203 */
 
+    /* start FLUID-5210 */
+
+    fluid.defaults("fluid.tests.fluid_5210.compositePanel", {
+        gradeNames: ["fluid.prefs.compositePanel", "autoInit"],
+        selectors: {
+            originalSelector: ""
+        },
+        selectorsToIgnore: ["originalSelector"],
+        resources: {
+            template: {
+                resourceText: "<div></div>"
+            }
+        }
+    });
+
+    jqUnit.test("FLUID-5210: merge selectorsToIgnore", function () {
+        var that = fluid.tests.fluid_5210.compositePanel(".fluid-5210", {
+            selectors: {
+                newSelector: ""
+            },
+            selectorsToIgnore: ["newSelector"]
+        });
+
+        var expected = ["originalSelector", "newSelector"];
+
+        jqUnit.assertDeepEq("The selectorsToIgnore should be merged", expected, that.options.selectorsToIgnore);
+    });
+
+    /* end FLUID-5210 */
+
     /*******************************************************************************
      * textFontPanel
      *******************************************************************************/


### PR DESCRIPTION
Adds a merge policy to the composite panel for merging selectorsToIgnore. This is necessary for the case where the composite panel has defined selectorsToIgnore. When the auxBuilder is run it needs to add selectorsToIgnore for the subpanel containers.
