### PR TITLE
FLUID-5214: removed default sourceApplier

### DIFF
--- a/src/framework/preferences/js/ModelRelay.js
+++ b/src/framework/preferences/js/ModelRelay.js
@@ -47,7 +47,7 @@ var fluid_1_5 = fluid_1_5 || {};
                 args: ["{that}.options.sourceApplier.modelChanged", "{that}.options.listenerNamespaces"]
             }
         },
-        sourceApplier: null,  // must be supplied by implementors
+        // sourceApplier: {external}.applier must be supplied by implementors
         rules: {}  // must be supplied by implementors, in format: "externalModelKey": "internalModelKey"
     });
 


### PR DESCRIPTION
Replaced the default sourceApplier: null with a comment about how to supply one. This default had lead to the possibility of the sourceApplier being overridden by the default null value depending on grade name order.

http://issues.fluidproject.org/browse/FLUID-5214
