### PR TITLE
FLUID-5239: Added unit test

### DIFF
--- a/src/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/src/tests/framework-tests/core/js/FluidIoCTests.js
@@ -185,13 +185,13 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
-    
+
     /** FLUID-3674: New model semantic tests **/
-    
+
     fluid.tests.fluid3674recorder = function (that, path, value, oldValue) {
         that.fireRecord.push({path: path, value: value, oldValue: oldValue});
     };
-    
+
     fluid.defaults("fluid.tests.fluid3674head", {
         gradeNames: ["fluid.standardComponent", "autoInit"],
         members: {
@@ -205,7 +205,7 @@ fluid.registerNamespace("fluid.tests");
             thing2: 3
         },
         events: {
-            createEvent: null  
+            createEvent: null
         },
         invokers: {
             record: "fluid.tests.fluid3674recorder({that}, {arguments}.0, {arguments}.1, {arguments}.2)",
@@ -248,17 +248,17 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
-    
+
     jqUnit.test("FLUID-3674 declarative listener test", function () {
         var that = fluid.tests.fluid3674head();
         that.applier.requestChange("thing1.nest1", 3);
-        jqUnit.assertDeepEq("Single change correctly reported", 
+        jqUnit.assertDeepEq("Single change correctly reported",
             [{path: ["thing1", "nest1"], value: 3, oldValue: 2}], that.fireRecord);
         for (var i = 0; i < 2; ++ i) {
             that.fireRecord.length = 0;
             that.events.createEvent.fire();
             that.changeNest2(true);
-            jqUnit.assertDeepEq("Change reported to subcomponent - time " + (i + 1), 
+            jqUnit.assertDeepEq("Change reported to subcomponent - time " + (i + 1),
                 [{path: ["thing1", "nest2"], value: true, oldValue: false}], that.fireRecord);
             that.child.changeNest2(false);
         }
@@ -266,9 +266,9 @@ fluid.registerNamespace("fluid.tests");
         that.changeThing2(5);
         jqUnit.assertDeepEq("Source guarded change not reported", [], that.fireRecord);
     });
-    
+
     /** Preservation of material with "exotic types" (with constructor) for FLUID-5089 **/
-    
+
     fluid.tests.customType = new Date();
 
     fluid.defaults("fluid.tests.typedMemberComponent", {
@@ -282,18 +282,18 @@ fluid.registerNamespace("fluid.tests");
             cat2: "@expand:fluid.identity({that}.cat)"
         }
     });
-    
+
     jqUnit.test("FLUID-5089: Preservation of exotic types", function () {
         jqUnit.assertTrue("Sanity check: detect custom object by instanceof", fluid.tests.customType instanceof Date);
-        
+
         var comp = fluid.tests.typedMemberComponent();
-        jqUnit.assertTrue("An exotic object stored as a component default should not be corrupted.", 
+        jqUnit.assertTrue("An exotic object stored as a component default should not be corrupted.",
             comp.cat instanceof Date);
-        jqUnit.assertTrue("An exotic object stored as an IoC-resolved component default should not be corrupted.", 
+        jqUnit.assertTrue("An exotic object stored as an IoC-resolved component default should not be corrupted.",
             comp.options.synthDef.cat instanceof Date);
-        jqUnit.assertTrue("An exotic object resolved via an expander should not be corrupted.", 
+        jqUnit.assertTrue("An exotic object resolved via an expander should not be corrupted.",
             comp.options.synthDef.cat2 instanceof Date);
-        jqUnit.assertTrue("An exotic object resolved via a top-level expander should not be corrupted.", 
+        jqUnit.assertTrue("An exotic object resolved via a top-level expander should not be corrupted.",
             comp.cat3 instanceof Date);
     });
 
@@ -382,6 +382,29 @@ fluid.registerNamespace("fluid.tests");
         var result = that.events.event.fire(false);
         jqUnit.assertUndefined("Event returned to nonpreventable through merge", result);
     });
+
+    /** FLUID-5239 **/
+
+    // dynamically creating name to show that anything starting with "source" will not be resolved by IoC
+    var name = "source" + fluid.allocateGuid();
+
+    fluid.defaults("fluid." + name, {
+        gradeNames: ["fluid.eventedComponent", "autoInit"]
+    });
+
+    jqUnit.test("FLUID-5239: Component name starting with 'source'", function () {
+        jqUnit.expect(1);
+        fluid[name]({
+            listeners: {
+                onCreate: {
+                    listener: "jqUnit.assertNotUndefined",
+                    args: ["The reference to {" + name + "} should resolve to the component", "{" + name + "}"]
+                }
+            }
+        });
+    });
+
+    /** end FLUID-5239 **/
 
     /** FLUID-4634 demands exclusion test **/
 
@@ -1066,11 +1089,11 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5128 - Soft Namespaces removal test **/
-    
+
     fluid.tests.fluid5128listener = function (that, index) {
         that.fireRecord.push(index);
     };
-    
+
     fluid.defaults("fluid.tests.fluid5128child", {
         gradeNames: ["fluid.eventedComponent", "autoInit"],
         listeners: {
@@ -1080,7 +1103,7 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
-    
+
     fluid.defaults("fluid.tests.fluid5128head", {
         gradeNames: ["fluid.eventedComponent", "autoInit"],
         members: {
@@ -1101,7 +1124,7 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
-    
+
     jqUnit.test("FLUID-5128 Soft listener deregistration test", function () {
         var that = fluid.tests.fluid5128head();
         that.events.createEvent.fire();
@@ -1703,7 +1726,7 @@ fluid.registerNamespace("fluid.tests");
                     if (!started) {
                         started = true;
                         jqUnit.start();
-                    }                  
+                    }
                 },
                 onReady: {
                     listener: function (that) {
@@ -2766,7 +2789,7 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5013: IoCSS doesn't pass down non-options blocks **/
-    
+
     fluid.defaults("fluid.tests.top", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         components: {
@@ -2801,7 +2824,7 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5014 Case 1 - IoCSS: one source value gets passed down to several subcomponents **/
-    
+
     fluid.defaults("fluid.tests.fluid5014root", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         components: {
@@ -2859,7 +2882,7 @@ fluid.registerNamespace("fluid.tests");
     fluid.tests.testDistro("fluid.tests.fluid5014distro2");
 
     /** FLUID-5014 Case 2 - IoCSS: one source value gets passed down to its own and its grade component **/
-    
+
     fluid.defaults("fluid.tests.fluid5014gradeComponent", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         components: {
@@ -2934,7 +2957,7 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5018 - IoCSS: Pass to-be-resolved option to a target **/
-    
+
     fluid.defaults("fluid.tests.own", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         components: {
@@ -2955,9 +2978,9 @@ fluid.registerNamespace("fluid.tests");
 
         jqUnit.assertEquals("The to-be-resolved option is passed down to the target", 10, root.ownSub.options.resolvedOption);
     });
-    
+
     /** FLUID-5126 - Corruption of listener material held in demands blocks **/
-    
+
     fluid.defaults("fluid.tests.fluid5126parent", {
         gradeNames: ["fluid.eventedComponent", "autoInit"],
         events: {
@@ -2985,7 +3008,7 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
-    
+
     fluid.tests.fluid5126register = function () {
         fluid.demands("fluid.eventedComponent", "fluid.tests.fluid5126parent", {
             options: {
@@ -2997,11 +3020,11 @@ fluid.registerNamespace("fluid.tests");
             }
         });
     };
-    
+
     fluid.tests.fluid5126listener = function (that, parent) {
         parent.idRecord.push(that.id);
     };
-    
+
     jqUnit.test("FLUID-5126: Corruption of listener records in demands blocks", function () {
         var parent = fluid.tests.fluid5126parent();
         function cycle() {
@@ -3201,7 +3224,7 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5033 - Grade reloading **/
-    
+
     function defineFluid5033Grade(value) {
         // Note that this technique must not be used within ordinary user code - in general the dynamic redefinition of a grade is an error.
         // This technique is only appropriate for development or "live coding" scenarios
@@ -3225,15 +3248,15 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-4922 - Fast invokers and their caching characteristics **/
-    
+
     fluid.tests.add = function (a, b) {
         return a + b;
     };
-    
+
     fluid.tests.addArray = function (a, array) {
         return a + array[0] + array[1];
     };
-    
+
     fluid.defaults("fluid.tests.fluid4922", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         members: {
@@ -3258,7 +3281,7 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
-    
+
     jqUnit.test("FLUID-4922 - fast and slow invokers", function () {
         var that = fluid.tests.fluid4922();
         jqUnit.assertEquals("Slow init", 2, that.slowInvoker(1));
@@ -3272,15 +3295,15 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5127 - Test cases for compact invokers, listeners and expandesr **/
-    
+
     fluid.tests.fluid5127listener = function (value1, value2, that) {
         that.fireValue = value1 + value2;
     };
-    
+
     fluid.tests.fluid5127modifyOne = function (value1, that) {
         that.one = value1;
     };
-    
+
     fluid.defaults("fluid.tests.fluid5127root", {
         gradeNames: ["fluid.eventedComponent", "autoInit"],
         members: {
@@ -3314,36 +3337,36 @@ fluid.registerNamespace("fluid.tests");
             ]
         }
     });
-    
+
     jqUnit.test("FLUID-5127 - compact syntax", function () {
         var that = fluid.tests.fluid5127root();
         jqUnit.assertEquals("String arguments", "thing", that.thing);
         jqUnit.assertEquals("Single arguments", "thing", that.thing2);
         jqUnit.assertEquals("Two arguments", 3, that.added);
-        
+
         jqUnit.assertEquals("Number", 3.5, that.number);
         jqUnit.assertEquals("true", true, that["true"]);
         jqUnit.assertEquals("false", false, that["false"]);
-        
+
         var added = that.addOne(2);
         jqUnit.assertEquals("Compact invoker", 3, added);
         jqUnit.assertEquals("Expander to invoker", 3, that.addedInvoke);
-        
+
         that.events.addEvent.fire(1);
         jqUnit.assertEquals("Compact direct listener", 2, that.fireValue);
-        
+
         that.events.addEvent2.fire(1);
         jqUnit.assertEquals("Compact invoker listener", 2, that.fireValue);
-        
+
         that.events.addEvent3.fire(); // listener modifies the value of "one" to 2
         jqUnit.assertEquals("Multiple compact listeners", 4, that.fireValue);
-        
+
         jqUnit.assertEquals("Static invoker", 2, that.addOne(1));
         jqUnit.assertEquals("Dynamic invoker", 3, that.addOneDynamic(1));
     });
 
     /** FLUID-5036, Case 1 - An IoCSS source that is fetched from the static environment is not resolved correctly **/
-    
+
     fluid.defaults("fluid.tests.fluid5036_1Root", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         components: {
@@ -3375,7 +3398,7 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5036, Case 2 - An IoCSS source that is fetched from the static environment is not resolved correctly **/
-    
+
     fluid.defaults("fluid.tests.fluid5036_2Root", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         // Note: this is not a recommended implementation technique, causing double nesting of options - this test is purely intendend to verify fix to a
@@ -3487,7 +3510,7 @@ fluid.registerNamespace("fluid.tests");
     });
 
     /** FLUID-5094: Dynamic grade merging takes an undefined source passed in from IoCSS into account rather than ignoring it **/
-    
+
     fluid.defaults("fluid.tests.fluid5094", {
         gradeNames: ["fluid.littleComponent", "fluid.tests.nonExistedGrade", "autoInit"],
         components: {
@@ -3549,9 +3572,9 @@ fluid.registerNamespace("fluid.tests");
         var that = fluid.tests.fluid5117();
         jqUnit.assertDeepEq("The output of an expander argument is same as the return of the expander function", that.options.inputObject, that.options.outputObject);
     });
-    
+
     /** FLUID-5108: Source and supplied dynamic grades that both have common option(s) are not merged correctly **/
-    
+
     fluid.defaults("fluid.tests.fluid5108", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         source: {
@@ -3560,7 +3583,7 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
-    
+
     fluid.defaults("fluid.tests.fluid5108Grade", {
         gradeNames: ["fluid.littleComponent", "autoInit"],
         source: {
@@ -3632,29 +3655,29 @@ fluid.registerNamespace("fluid.tests");
             }
         }
     });
- 
+
     fluid.tests.dynamicInvoker.getDynamicInvoker = function () {
         return "fluid.tests.dynamicInvokerGrade";
     };
- 
+
     fluid.defaults("fluid.tests.dynamicInvokerGrade", {
         gradeNames: ["autoInit", "fluid.littleComponent"],
         invokers: {
             method: "fluid.tests.dynamicInvokerGrade.method"
         }
     });
- 
+
     fluid.tests.dynamicInvokerGrade.method = function () {
         jqUnit.assertTrue("Dynamic invoker is called", true);
     };
- 
+
     jqUnit.test("Test dynamic grade invoker contribution.", function () {
         jqUnit.expect(2);
         var component = fluid.tests.dynamicInvoker();
         jqUnit.assertValue("Invoker is resolved correctly", component.method);
         component.method();
     });
-    
+
     /** FLUID-5212 dynamic grade linkage aka "new demands blocks" **/
 
     fluid.defaults("fluid.tests.gradeLinkageComponent", {


### PR DESCRIPTION
Added a unit test showing that if a component is created with a name starting with "source" it cannot be referenced by name, using IoC.

http://issues.fluidproject.org/browse/FLUID-5239
