### PR TITLE
FLUID-5247: Fix for incorrect treatment of escaped paths in Model Transformations with respect to schema

### DIFF
--- a/src/framework/core/js/ModelTransformation.js
+++ b/src/framework/core/js/ModelTransformation.js
@@ -463,10 +463,10 @@ var fluid = fluid || fluid_1_5;
     };
     
     // unsupported, NON-API function
-    fluid.model.transform.flatSchemaStrategy = function (flatSchema) {
+    fluid.model.transform.flatSchemaStrategy = function (flatSchema, getConfig) {
         var keys = fluid.model.sortByKeyLength(flatSchema);
         return function (root, segment, index, segs) {
-            var path = fluid.path.apply(null, segs.slice(0, index));
+            var path = getConfig.parser.compose.apply(null, segs.slice(0, index));
           // TODO: clearly this implementation could be much more efficient
             for (var i = 0; i < keys.length; ++i) {
                 var key = keys[i];
@@ -584,7 +584,7 @@ var fluid = fluid || fluid_1_5;
         // Modify schemaStrategy if we collected flat schema options for the setConfig of finalApplier
         if (transform.collectedFlatSchemaOpts !== undefined) {
             $.extend(transform.collectedFlatSchemaOpts, options.flatSchema);
-            schemaStrategy = fluid.model.transform.flatSchemaStrategy(transform.collectedFlatSchemaOpts);
+            schemaStrategy = fluid.model.transform.flatSchemaStrategy(transform.collectedFlatSchemaOpts, getConfig);
         }
         setConfig.strategies = [fluid.model.defaultFetchStrategy, schemaStrategy ? fluid.model.transform.schemaToCreatorStrategy(schemaStrategy)
                 : fluid.model.defaultCreatorStrategy];

--- a/src/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/src/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -725,19 +725,17 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         method: "assertDeepEq",
         expected: source.sheep
     }, {
-        message: "arrayValue() with a nested transformation",
+        message: "FLUID-5248: arrayValue() with a nested transformation",
         expandWrap: false,
         transform: {
             "b": {
                 "transform": {
                     "type": "fluid.transforms.arrayValue",
                     "value": {
-                        "value": { 
-                            "transform": {
-                                "type": "fluid.transforms.linearScale",
-                                "value": 5,
-                                "factor": 0.1
-                            }
+                        "transform": {
+                            "type": "fluid.transforms.linearScale",
+                            "value": 5,
+                            "factor": 0.1
                         }
                     }
                 }
@@ -745,11 +743,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         method: "assertDeepEq",
         expected: {
-            "b": [
-                {
-                    "value": 0.5
-                }
-            ]
+            "b": [0.5]
         }
     }];
 


### PR DESCRIPTION
Incorporates modified test case for FLUID-5248 which is invalid as posted on the JIRA - see the discussion there. 
http://issues.fluidproject.org/browse/FLUID-5248

The fix for FLUID-5247 was best met by some wholesale cut and paste of upcoming material from the FLUID-3674 branch since the "accessor config" system was improved there to support this kind of use case. This has no real issues for the FLUID-3674 branch since all conflicts that this introduces in DataBinding.js will be discarded in any case.

@jobara, @kaspermarkus
