### PR TITLE
FLUID-5251: Conditional transformer now only evaluates the relevant block (true/false)

### DIFF
--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -130,7 +130,7 @@ var fluid = fluid || fluid_1_5;
     /* TODO: This inversion doesn't work if the value and factors are given as paths in the source model */
     fluid.transforms.linearScale.invert = function  (transformSpec, transform) {
         var togo = fluid.copy(transformSpec);
-        
+
         if (togo.factor) {
             togo.factor = (togo.factor === 0) ? 0 : 1 / togo.factor;
         }
@@ -173,24 +173,21 @@ var fluid = fluid || fluid_1_5;
         return (fun === undefined || inputs.left === undefined || inputs.right === undefined) ? undefined : fun(inputs.left, inputs.right);
     };
 
-
-    fluid.defaults("fluid.transforms.condition", { 
-        gradeNames: [ "fluid.multiInputTransformFunction", "fluid.standardOutputTransformFunction" ],
-        inputVariables: {
-            "true": null,
-            "false": null,
-            "condition": null
-        }
+    fluid.defaults("fluid.transforms.condition", {
+        gradeNames: ["fluid.transformFunction", "fluid.standardOutputTransformFunction"]
     });
-    
-    fluid.transforms.condition = function (inputs) {
-        if (inputs.condition === null) {
-            return undefined;
+
+    fluid.transforms.condition = function (transformSpec, transform) {
+        //transform should contain condition or conditionPath:
+        var condition = fluid.model.transform.getValue(transformSpec.conditionPath, transformSpec.condition, transform);
+
+        //evaluate true/false value depending on condition
+        if (condition === true) {
+            return fluid.model.transform.getValue(transformSpec.truePath, transformSpec['true'], transform);
+        } else if (condition === false) {
+            return fluid.model.transform.getValue(transformSpec.falsePath, transformSpec['false'], transform);
         }
-
-        return inputs[inputs.condition];
     };
-
 
     fluid.defaults("fluid.transforms.valueMapper", { 
         gradeNames: ["fluid.transformFunction", "fluid.lens"],

--- a/src/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/src/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -576,6 +576,23 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             expected: {
                 conclusion: "Congratulations, you are a genius"
             }
+        }, {
+            message: "GPII-5251: Only one of the conditions should be executed",
+            expandWrap: true,
+            transform: {
+                type: "fluid.transforms.condition",
+                conditionPath: "catsAreDecent",
+                "true": {
+                    "Antranig": "cat"
+                },
+                "false": {
+                    "Kasper": "polar"
+                }
+            },
+            method: "assertDeepEq",
+            expected: {
+                "Antranig": "meow"
+            }
         }
     ];
 
@@ -1535,32 +1552,27 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     var multiInputTransformations = {
         transform: {
-            type: "fluid.transforms.condition",
-            condition: {
+            type: "fluid.transforms.linearScale",
+            valuePath: "foo.bar",
+            factorPath: "boo.har",
+            offset: {
                 transform: {
                     type: "fluid.transforms.binaryOp",
-                    leftPath: "hello.world",
-                    operator: "&&",
-                    right: false
+                    leftPath: "choo.choo",
+                    rightPath: "boo.hoo",
+                    operator: "+"
                 }
-            },
-            "false": {
-                transform: {
-                    type: "fluid.transforms.value",
-                    inputPath: "falsey.goes.here",
-                    outputPath: "conclusion"
-                }
-            },
-            truePath: "kasper.rocks"
+            }
         }
     };
 
     jqUnit.test("collect inputPath from multiInput transformations", function () {
         var paths = fluid.model.transform.collectInputPaths(multiInputTransformations);
         var expected = [
-            "falsey.goes.here",
-            "hello.world",
-            "kasper.rocks"
+            "boo.har",
+            "boo.hoo",
+            "choo.choo",
+            "foo.bar"
         ];
         jqUnit.assertDeepEq("Collected input paths", expected, paths.sort());
     });


### PR DESCRIPTION
Changed condition transformer to a non-standard inputtransformer, only evaluting the relevant 'input' based on what the condition evaluates to
