### PR TITLE
FLUID-5103: Fix for dynamic reorderer failure to take account of new elements until one is moved

### DIFF
--- a/src/components/reorderer/js/Reorderer.js
+++ b/src/components/reorderer/js/Reorderer.js
@@ -672,7 +672,6 @@ var fluid_1_5 = fluid_1_5 || {};
     };
     
     fluid.reorderer.refresh = function (dom, events, selectableContext, activeItem) {
-        events.onRefresh.fire();
         dom.refresh("movables");
         dom.refresh("selectables");
         dom.refresh("grabHandle", dom.fastLocate("movables"));
@@ -682,6 +681,7 @@ var fluid_1_5 = fluid_1_5 || {};
             selectableContext.selectables = dom.fastLocate("selectables");
             selectableContext.selectablesUpdated(activeItem);
         }
+        events.onRefresh.fire(); // This should be last otherwise handlers will see stale DOM binder contents 
     };
     
     /**

--- a/src/tests/component-tests/reorderer/html/GeometricManager-test.html
+++ b/src/tests/component-tests/reorderer/html/GeometricManager-test.html
@@ -10,6 +10,7 @@
     <link rel="Stylesheet" media="screen" href="../../../lib/qunit/css/qunit.css" />
     
     <script type="text/javascript" src="../../../../lib/jquery/core/js/jquery.js"></script>
+    <script type="text/javascript" src="../../../../framework/core/js/FluidDocument.js"></script>
     <script type="text/javascript" src="../../../../framework/core/js/Fluid.js"></script>
     <script type="text/javascript" src="../../../../framework/core/js/FluidDOMUtilities.js"></script>
     <script type="text/javascript" src="../../../../framework/core/js/FluidView.js"></script>


### PR DESCRIPTION
@michelled - this is the fix for the dynamic reorderer issue you found when testing the final FLUID-3674 branch last night. It seems that this issue had been reported before
