### PR TITLE
FLUID-5271: Corrected closure strategy in framework to enable successful use in uPortal

### DIFF
--- a/src/components/pager/js/Pager.js
+++ b/src/components/pager/js/Pager.js
@@ -498,7 +498,7 @@ var fluid_1_5 = fluid_1_5 || {};
             }
         }],
         modelListeners: {
-            "": "{that}.events.onModelChange.fire({change}.value, {change}.oldValue)"
+            "": "{that}.events.onModelChange.fire({change}.value, {change}.oldValue, {that})"
         },
         listeners: {
             onCreate: {

--- a/src/framework/core/js/ModelTransformation.js
+++ b/src/framework/core/js/ModelTransformation.js
@@ -20,7 +20,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 var fluid_1_5 = fluid_1_5 || {};
 var fluid = fluid || fluid_1_5;
 
-(function ($) {
+(function ($, fluid) {
     "use strict";
 
     fluid.registerNamespace("fluid.model.transform");

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -20,7 +20,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 var fluid_1_5 = fluid_1_5 || {};
 var fluid = fluid || fluid_1_5;
 
-(function ($) {
+(function ($, fluid) {
     "use strict";
 
     fluid.registerNamespace("fluid.model.transform");

--- a/src/tests/component-tests/pager/html/PagedTable-test.html
+++ b/src/tests/component-tests/pager/html/PagedTable-test.html
@@ -180,7 +180,11 @@
                 </ul>
             </div>
         </div>
-
     </div>
+    <script>
+        var runTests = fluid.tests.runPagedTableTests; 
+        fluid = fluid_1_5 = null; // test FLUID-5271 for some substantial part of the framework
+        runTests();
+    </script>
   </body>
 </html>

--- a/src/tests/component-tests/pager/js/PagedTableTests.js
+++ b/src/tests/component-tests/pager/js/PagedTableTests.js
@@ -17,7 +17,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 // JSLint options 
 /*jslint white: true, funcinvoke: true, undef: true, newcap: true, nomen: true, regexp: true, bitwise: true, browser: true, forin: true, indent: 4 */
 
-(function ($) {
+(function ($, fluid) {
   
     jqUnit.module("Paged Table Tests");
     
@@ -139,11 +139,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return pager;
     };
 
-    $(document).ready(function () {
-
-    // This IoC-enabled test must come first, as a result of an undiagnosed Firefox issue which causes the running
-    // of the plain QUnit tests to somehow clobber the markup belonging to it
-       
     fluid.tests.tooltipModuleSource = function (pager) {
         var pageLinksTop = $("a", pager.pagerBar.locate("pageLinks"));
         var pageLinksBottom = $("a", pager["pagerBar-1"].locate("pageLinks"));
@@ -223,6 +218,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             }
         }
     });
+    
+    fluid.tests.runPagedTableTests = function () {
+
+    // This IoC-enabled test must come first, as a result of an undiagnosed Firefox issue which causes the running
+    // of the plain QUnit tests to somehow clobber the markup belonging to it
+       
 
     // QUnit's markup restoration cycle can't play nicely with ours. It grabs the document's markup at a slightly later point
     // than our initialisation - during which time we have rendered already and clobbered it. It doesn't expose an event
@@ -233,7 +234,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     var rendered_ioc = $("<div id=\"rendered-ioc\"></div>").html(rendered);
     rendered_ioc.appendTo(document.body);
     fluid.test.runTests(["fluid.tests.pagerTooltipEnv"]);
-
+    
+    jqUnit.module("Paged Table Tests");
 
     // Just tests that the pager will initialize with only a container, and dataModel passed in.
     // The rest of the options are the defaults.
@@ -546,6 +548,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
 
     
-    });
+    };
     
-})(jQuery);
+})(jQuery, fluid_1_5);

--- a/src/tests/component-tests/tooltip/js/TooltipTests.js
+++ b/src/tests/component-tests/tooltip/js/TooltipTests.js
@@ -16,7 +16,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 // JSLint options 
 /*jslint white: true, funcinvoke: true, undef: true, newcap: true, nomen: true, regexp: true, bitwise: true, browser: true, forin: true, maxerr: 100, indent: 4 */
 
-(function ($) {
+(function ($, fluid) {
     fluid.registerNamespace("fluid.tests.tooltip");
         
     fluid.tests.tooltip.trackTooltip = function (disp, that, target, tooltip) {
@@ -311,4 +311,4 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         });
     };
     
-})(jQuery);
+})(jQuery, fluid_1_5);

--- a/src/tests/test-core/jqUnit/js/jqUnit-browser.js
+++ b/src/tests/test-core/jqUnit/js/jqUnit-browser.js
@@ -22,7 +22,7 @@ var jqUnit = jqUnit || {};
 
 // A function to load the testswarm agent if running in the testswarm environment
 // This code was derived from testsuite.js ( http://code.google.com/p/jquery-ui/source/browse/trunk/tests/unit/testsuite.js )
-(function () {
+(function ($, fluid) {
     var param = "swarmURL=";
     var url = window.location.search;
     url = decodeURIComponent(url.slice(url.indexOf(param) + param.length));
@@ -175,4 +175,4 @@ var jqUnit = jqUnit || {};
     };
       
     
-})();
+})(jQuery, fluid_1_5);


### PR DESCRIPTION
Test cases now check for many cases of inadvertent leakage of global "fluid" back into closures. Correction of onModelChange event signature which was an unnecessary breakage from Infusion 1.4 which also caused trouble to uPortal integration.

@michelled - could you look at this today since it is required urgently by the uPortal team? Thanks!
