### PR TITLE
FLUID-5277: Created a unit test to demonstrate FLUID-5277 issue

### DIFF
--- a/src/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
+++ b/src/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
@@ -1831,4 +1831,15 @@ fluid.registerNamespace("fluid.tests");
                 "${{test}.string}", that.locate("simpleBound6").text());
         });
     };
+
+    // FLUID-5277: Improve the error message when an nonexistent container is provided for fluid.viewRelayComponent and fluid.rendererRelayComponent
+    fluid.defaults("fluid.tests.fluid5277", {
+        gradeNames: ["fluid.rendererRelayComponent", "autoInit"]
+    });
+
+    jqUnit.test("FLUID-5277: Improve the error message when an nonexistent container is provided for fluid.viewRelayComponent and fluid.rendererRelayComponent", function () {
+        var that = fluid.tests.fluid5277("#nonexistent-container");
+        jqUnit.assertUndefined("Failed at instantiating the component with an nonexistent container", that);
+    });
+
 })(jQuery);


### PR DESCRIPTION
The issue is to improve the error message when a nonexistent container is provided for fluid.viewRelayComponent or fluid.rendererRelayComponent.

Refer to: http://issues.fluidproject.org/browse/FLUID-5277

This pull request should be merged in with a fix to itself.
