### PR TITLE
FLUID-5281: Remove extra "./js/FluidIoC.js"

### DIFF
--- a/src/framework/core/frameworkDependencies.json
+++ b/src/framework/core/frameworkDependencies.json
@@ -14,7 +14,6 @@
             "./js/ModelTransformationTransforms.js",
             "./js/jquery.keyboard-a11y.js",
             "./js/FluidView.js",
-            "./js/FluidIoC.js",
             "./js/FluidRequests.js"
         ],
         "dependencies": [


### PR DESCRIPTION
from frameworkDependencies.json

http://issues.fluidproject.org/browse/FLUID-5281
