### PR TITLE
FLUID-5298: Opportunistic fix for widespread component failures in Safari

### DIFF
--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1726,6 +1726,9 @@ var fluid = fluid || fluid_1_5;
             if (i > fluid.strategyRecursionBailout) {
                 fluid.fail("Overflow/circularity in options merging, current path is ", segs, " at depth " , i, " - please protect components from merging using the \"nomerge\" merge policy");
             }
+            if (fluid.isPrimitive(target)) { // For "use strict"
+                return undefined; // Review this after FLUID-4925 since the only trigger is in slow component lookahead
+            }
             if (fluid.isTracing) {
                 fluid.tracing.pathCount.push(fluid.path(segs.slice(0, i)));
             }


### PR DESCRIPTION
caused by "use strict" mode enabled in Fluid.js
@jobara - could you test this out and see how much better this makes the situation. If there are further test failures in Safari, please post the stack traces - thanks
