### PR TITLE
FLUID-5334: clearing iframe animation queue

### DIFF
--- a/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
+++ b/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
@@ -90,7 +90,7 @@ var fluid_1_5 = fluid_1_5 || {};
                         },
                         operateHide: {
                             funcName: "fluid.prefs.separatedPanel.hidePanel",
-                            args: ["{that}.dom.panel", "{separatedPanel}.iframeRenderer.iframe", "{that}.events.afterPanelHide.fire"],
+                            args: ["{that}.dom.panel", "{iframeRenderer}.iframe", "{that}.events.afterPanelHide.fire"],
                             // override default implementation
                             "this": null,
                             "method": null


### PR DESCRIPTION
Clearing the iframe's jQuery animation queue when the panel is hidden. Previously it could get into a state where the sizing animation would complete after hiding, causing it to appear "open".

http://issues.fluidproject.org/browse/FLUID-5334
