### PR TITLE
FLUID-5344: Refactored skipped test action

### DIFF
--- a/src/tests/component-tests/uploader/html/HTML5UploaderSupport-test.html
+++ b/src/tests/component-tests/uploader/html/HTML5UploaderSupport-test.html
@@ -40,7 +40,6 @@
     <div id="qunit-testrunner-toolbar"></div>
     <h2 id="qunit-userAgent"></h2>
     <ol id="qunit-tests"></ol>
-    <p class="noTestMessage"></p>
 
      <!-- Test HTML -->
     <div id="qunit-fixture">

--- a/src/tests/component-tests/uploader/js/HTML5UploaderSupportTests.js
+++ b/src/tests/component-tests/uploader/js/HTML5UploaderSupportTests.js
@@ -20,7 +20,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
         // Only run tests in browsers that support HTML5 upload
         if (!window.FormData) {
-            $(".noTestMessage").text("Tests were not run, as the current browser does not support HTML5");
+            jqUnit.test("No Tests Run", function () {
+                // have to run a dummy test to prevent a false failure report when running allTest.html
+                jqUnit.assert("This browser does not support HTML5 upload");
+            });
         } else {
             fluid.registerNamespace("fluid.tests.uploader.html5");
 


### PR DESCRIPTION
When running allTest.html, it will report an error if no tests are run. I've converted the message for skipping the tests for browsers that don't support HTML5 upload, to be part of a dummy assertion.

http://issues.fluidproject.org/browse/FLUID-5344
