### PR TITLE
FLUID-5349: Adding a note to the overviewPanel

### DIFF
--- a/src/demos/prefsFramework/json/config.json
+++ b/src/demos/prefsFramework/json/config.json
@@ -5,8 +5,8 @@
         "titleEnd": "framework demo"
     },
     "markup": {
-        "description": "The Preferences Framework offers a reusable set of schemas, programming APIs, and UI building blocks specific to the creation, persistence, and integration of preference editors into a variety of web-based applications, content management systems, and delivery environments.",
-        "instructions": "<ul><li>To access the preference editor on this page, click the 'Show Display Preferences' tab in the upper right corner of the window.</li><li>Try adjusting the controls in the panel that opens. You will see the changes applied to the page immediately.</li><li>The \"text-to-speech\" and \"simplify\" adjusters are not part of the Preferences Framework, but are provided as illustrations for adding additional panels/enactors as well as a preview of how advanced preferences could be set.</li></ul>"
+        "description": "<p>The Preferences Framework offers a reusable set of schemas, programming APIs, and UI building blocks specific to the creation, persistence, and integration of preference editors into a variety of web-based applications, content management systems, and delivery environments.</p><p><em>NOTE: The 'text-to-speech' and 'simplify' adjusters are not part of the Preferences Framework, but are provided as illustrations for adding additional panels/enactors, as well as a preview of how advanced preferences could be set.</em></p>",
+        "instructions": "<ul><li>To access the preference editor on this page, click the 'Show Display Preferences' tab in the upper right corner of the window.</li><li>Try adjusting the controls in the panel that opens. You will see the changes applied to the page immediately.</li></ul>"
     },
     "links": {
         "codeLink": "https://github.com/fluid-project/infusion/tree/master/src/framework/preferences",


### PR DESCRIPTION
Added a note in the instructions to indicate that "text-to-speech" and "simplify" are not actually part of the preferences framework.

http://issues.fluidproject.org/browse/FLUID-5349
