### PR TITLE
FLUID-5338: wrapped instantiator in ready function

### DIFF
--- a/src/demos/shared/js/overviewWrapper.js
+++ b/src/demos/shared/js/overviewWrapper.js
@@ -21,17 +21,19 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         }
     };
 
-    fluid.fetchResources(resources, function(resourceSpecs) {
-        var bundle = JSON.parse(resourceSpecs.bundle.resourceText);
-        fluid.overviewPanel(".flc-overviewPanel", {
-            resources: {
-                template: {
-                    href: bundle.templateUrl || "../../components/overviewPanel/html/overviewPanelTemplate.html"
-                }
-            },
-            strings: bundle.strings,
-            markup: bundle.markup,
-            links: bundle.links
+    $(document).ready(function () {
+        fluid.fetchResources(resources, function(resourceSpecs) {
+            var bundle = JSON.parse(resourceSpecs.bundle.resourceText);
+            fluid.overviewPanel(".flc-overviewPanel", {
+                resources: {
+                    template: {
+                        href: bundle.templateUrl || "../../components/overviewPanel/html/overviewPanelTemplate.html"
+                    }
+                },
+                strings: bundle.strings,
+                markup: bundle.markup,
+                links: bundle.links
+            });
         });
     });
 })(jQuery, fluid);


### PR DESCRIPTION
Wrapped the call to fluid.fetchResources in a $(document).ready function to prevent the overviewPanel from instantiating before its container has been loaded into the DOM.

http://issues.fluidproject.org/browse/FLUID-5338
