### PR TITLE
FLUID-5409: Fixed reference to IE8 style sheet

### DIFF
--- a/src/instructionalDemos/framework/preferences/conditionalAdjusters1/conditional.html
+++ b/src/instructionalDemos/framework/preferences/conditionalAdjusters1/conditional.html
@@ -13,11 +13,6 @@
 
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
 
-        <!--[if IE 8]>
-            <link rel="stylesheet" type="text/css" href="../../../../framework/preferences/css/ie8.css" />
-            <link rel="stylesheet" type="text/css" href="css/ie8.css" />
-        <![endif]-->
-
         <title>Preferences Editor Demo: Conditional Adjusters</title>
         <script type="text/javascript" src="../../../../lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../lib/jquery/ui/js/jquery.ui.core.js"></script>

--- a/src/instructionalDemos/framework/preferences/conditionalAdjusters2/conditional.html
+++ b/src/instructionalDemos/framework/preferences/conditionalAdjusters2/conditional.html
@@ -13,11 +13,6 @@
 
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
 
-        <!--[if IE 8]>
-            <link rel="stylesheet" type="text/css" href="../../../../framework/preferences/css/ie8.css" />
-            <link rel="stylesheet" type="text/css" href="css/ie8.css" />
-        <![endif]-->
-
         <title>Preferences Editor Demo: Conditional Adjusters</title>
         <script type="text/javascript" src="../../../../lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../lib/jquery/ui/js/jquery.ui.core.js"></script>

--- a/src/instructionalDemos/framework/preferences/shared/html/SeparatedPanelPrefsEditorFrame.html
+++ b/src/instructionalDemos/framework/preferences/shared/html/SeparatedPanelPrefsEditorFrame.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" type="text/css" href="../css/demo.css" />
 
         <!--[if IE 8]>
-            <link rel="stylesheet" type="text/css" href="../css/ie8.css" />
+            <link rel="stylesheet" type="text/css" href="../../../../../framework/preferences/css/ie8.css" />
         <![endif]-->
 
         <title>Preferences Editor</title>


### PR DESCRIPTION
http://issues.fluidproject.org/browse/FLUID-5409

Also removed some unneeded includes of IE8 styles on the main pages or the instructional demos.
