### PR TITLE
FLUID-5399: Moving the basic uploader

### DIFF
--- a/src/demos/uploader/css/uploader.css
+++ b/src/demos/uploader/css/uploader.css
@@ -2,7 +2,7 @@
     margin: 5em;
 }
 
-/* Shifts the basic uploader so that it isn't covered by the "*" from the overviewPanel */
+/* Shifts the basic uploader so that it isn't covered by the overviewPanel */
 .fl-progEnhance-basic {
-    margin: 4em;
+    margin: 4em 24em;
 }


### PR DESCRIPTION
Moved the basic uploader over so that it wouldn't be covered by the overview panels container. This had been capturing the mouse events when javascript was off. Preventing mouse interaction.

http://issues.fluidproject.org/browse/FLUID-5399
