### PR TITLE
FLUID-5397, FLUID-5394: Fixed for failures observed with pager+tooltip demos

### DIFF
--- a/src/framework/core/js/DataBinding.js
+++ b/src/framework/core/js/DataBinding.js
@@ -456,7 +456,7 @@ var fluid_1_5 = fluid_1_5 || {};
         var sourceListener = function (newValue, oldValue, path, changeRequest, trans, applier) {
             var transId = trans.id;
             var transRec = fluid.getModelTransactionRec(instantiator, transId);
-            if (applier && trans) {
+            if (applier && trans && !transRec[applier.applierId]) { // don't trash existing record which may contain "options" (FLUID-5397)
                 transRec[applier.applierId] = {transaction: trans}; // enlist the outer user's original transaction
             }
             var existing = transRec[applierId];
@@ -674,6 +674,7 @@ var fluid_1_5 = fluid_1_5 || {};
             var change = allChanges[i];
             change.listener.apply(null, change.args);
         }
+        fluid.clearLinkCounts(transRec, true); // "options" structures for relayCount are aliased
     };
     
     fluid.model.commitRelays = function (instantiator, transactionId) {
@@ -685,7 +686,6 @@ var fluid_1_5 = fluid_1_5 || {};
                 transEl.transaction.reset();
             }
         });
-        fluid.clearLinkCounts(transRec, true); // "options" structures for relayCount are aliased
     };
 
     fluid.model.updateRelays = function (instantiator, transactionId) {

--- a/src/tests/framework-tests/core/js/DataBindingTests.js
+++ b/src/tests/framework-tests/core/js/DataBindingTests.js
@@ -1332,6 +1332,32 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertDeepEq("Total invalidation", expected4, that.model);
     });
 
+    /** FLUID-5397: Mouse droppings within relay documents in complex cases **/
+
+    fluid.defaults("fluid.tests.fluid5397root", {
+        gradeNames: ["fluid.tests.fluid5045root", "autoInit"],
+        model: {
+            pageSize: 20,
+            totalRange: 164
+        }
+    });
+
+    jqUnit.test("FLUID-5397: Mouse droppings within relay documents accrete over time", function () {
+        var that = fluid.tests.fluid5397root();
+        that.applier.change("pageSize", 10);
+        that.applier.change("pageSize", 20);
+        that.applier.change("pageSize", 10);
+        that.applier.change("pageIndex", 16);
+        fluid.tests.assertTransactionsConcluded(that);
+        var expected = {
+            pageIndex: 16,
+            pageCount: 17,
+            pageSize: 10,
+            totalRange: 164
+        };
+        jqUnit.assertDeepEq("Model allows last page", expected, that.model);
+    });
+
      // FLUID-3674: Old-fashioned model sharing between components is still possible (remove this test when old grades are removed)
     var fluid3674Model = {
         key: "value"


### PR DESCRIPTION
Corrupt records in relay system caused failures in operating the model constraints after long sequences of changes ( > 2 ). Race conditions within jQuery UI tooltip widget would cause attempts to display widgets over nonexistent elements due to triggering of updateContent before old tooltips had been removed from the document after animation, or if the tooltip's owner was removed from the document before the event was serviced.
