### PR TITLE
FLUID-5449: fixing version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "infusion",
   "description": "Infusion is an application framework for developing flexible stuff with JavaScript.",
-  "version": "2.0-SNAPSHOT",
+  "version": "2.0.0-SNAPSHOT",
   "author": "Fluid Project",
   "bugs": "http://issues.fluidproject.org/browse/FLUID",
   "homepage": "http://www.fluidproject.org/",


### PR DESCRIPTION
The version number in the package.json file must conform to semver (http://semver.org) and be parseable by https://www.npmjs.org/doc/misc/semver.html

http://issues.fluidproject.org/browse/FLUID-5449
