### PR TITLE
FLUID-5463: Updating build scripts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
             },
             necessities: {
                 files: [{
-                    src: ["README.md", "ReleaseNotes.txt", "Infusion-LICENSE.txt"],
+                    src: ["README.*", "ReleaseNotes.*", "Infusion-LICENSE.*"],
                     dest: "build/"
                 }, {
                     // The jQuery license file needs to be copied explicitly since


### PR DESCRIPTION
The logic to copy over the README, Release-Notes and Infusion-LICENSE has been made a bit more robust to find the files with any file extension. This should prevent omitted files when the file format is changed, but the name remains the same.

http://issues.fluidproject.org/browse/FLUID-5463
