### PR TITLE
FLUID-5474: No longer removing tocTemplate option (master branch)

### DIFF
--- a/src/components/uiOptions/js/UIOptions.js
+++ b/src/components/uiOptions/js/UIOptions.js
@@ -22,13 +22,11 @@ var fluid_2_0 = fluid_2_0 || {};
         gradeNames: ["fluid.prefs.constructed.prefsEditor", "autoInit"],
         distributeOptions: {
             source: "{that}.options.tocTemplate",
-            removeSource: true,
             target: "{that uiEnhancer}.options.tocTemplate"
         },
         enhancer: {
             distributeOptions: {
                 source: "{that}.options.tocTemplate",
-                removeSource: true,
                 target: "{that > fluid.prefs.enactor.tableOfContents}.options.tocTemplate"
             }
         }

--- a/tests/component-tests/uiOptions/js/UIOptionsTests.js
+++ b/tests/component-tests/uiOptions/js/UIOptionsTests.js
@@ -21,7 +21,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.module("UIOptions Tests");
 
         jqUnit.asyncTest("Pass in customized toc template", function () {
-            jqUnit.expect(1);
+            jqUnit.expect(2);
 
             var customizedTocTemplate = "../../../../src/components/tableOfContents/html/TableOfContents.html";
 
@@ -29,7 +29,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 tocTemplate: customizedTocTemplate,
                 listeners: {
                     onReady: function (that) {
-                        jqUnit.assertEquals("The toc template is applied properly", customizedTocTemplate, that.enhancer.uiEnhancer.fluid_prefs_enactor_tableOfContents.options.tocTemplate);
+                        jqUnit.assertEquals("The toc template is applied properly to the pageEnhancer", customizedTocTemplate, that.enhancer.uiEnhancer.fluid_prefs_enactor_tableOfContents.options.tocTemplate);
+                        jqUnit.assertEquals("FLUID-5474: The toc template is applied properly to iframeEnhancer", customizedTocTemplate, that.prefsEditorLoader.iframeRenderer.iframeEnhancer.fluid_prefs_enactor_tableOfContents.options.tocTemplate);
                         jqUnit.start();
                     }
                 },


### PR DESCRIPTION
Distribute options had been moving the tocTemplate option, as opposed to copying it. The result of which was that the iframeEnhancer was looking for the option in a place it had been removed from. Also added tests to verify that the tocTemplate is being passed to the iframeEnhancer.

http://issues.fluidproject.org/browse/FLUID-5474
