### PR TITLE
FLUID-5474: No longer removing tocTemplate option (1.5.x branch)

### DIFF
--- a/src/components/uiOptions/js/UIOptions.js
+++ b/src/components/uiOptions/js/UIOptions.js
@@ -22,16 +22,14 @@ var fluid_1_5 = fluid_1_5 || {};
         gradeNames: ["fluid.prefs.constructed.prefsEditor", "autoInit"],
         distributeOptions: {
             source: "{that}.options.tocTemplate",
-            removeSource: true,
             target: "{that uiEnhancer}.options.tocTemplate"
         },
         enhancer: {
             distributeOptions: {
                 source: "{that}.options.tocTemplate",
-                removeSource: true,
                 target: "{that > fluid.prefs.enactor.tableOfContents}.options.tocTemplate"
             }
         }
     });
-    
+
 })(jQuery, fluid_1_5);

--- a/src/tests/component-tests/uiOptions/js/UIOptionsTests.js
+++ b/src/tests/component-tests/uiOptions/js/UIOptionsTests.js
@@ -21,7 +21,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.module("UIOptions Tests");
 
         jqUnit.asyncTest("Pass in customized toc template", function () {
-            jqUnit.expect(1);
+            jqUnit.expect(2);
 
             var customizedTocTemplate = "../../../../components/tableOfContents/html/TableOfContents.html";
 
@@ -29,7 +29,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 tocTemplate: customizedTocTemplate,
                 listeners: {
                     onReady: function (that) {
-                        jqUnit.assertEquals("The toc template is applied properly", customizedTocTemplate, that.enhancer.uiEnhancer.fluid_prefs_enactor_tableOfContents.options.tocTemplate);
+                        jqUnit.assertEquals("The toc template is applied properly to the pageEnhancer", customizedTocTemplate, that.enhancer.uiEnhancer.fluid_prefs_enactor_tableOfContents.options.tocTemplate);
+                        jqUnit.assertEquals("FLUID-5474: The toc template is applied properly to iframeEnhancer", customizedTocTemplate, that.prefsEditorLoader.iframeRenderer.iframeEnhancer.fluid_prefs_enactor_tableOfContents.options.tocTemplate);
                         jqUnit.start();
                     }
                 },


### PR DESCRIPTION
Preserving the tocTemplate options after a distribute options call. Added a unit test. This is for the 1.5.x branch.

http://issues.fluidproject.org/browse/FLUID-5474
