### PR TITLE
FLUID-5523: Fixed demo overlay panel links to demo code

### DIFF
--- a/demos/inlineEdit/json/config.json
+++ b/demos/inlineEdit/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Click on or tab to either of the editable text fields.</li><li>Type something and hit Enter or Tab</li><li>Try the Undo/Redo button.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/inlineEdit/simple",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/inlineEdit",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Simple+Text+Inline+Edit+API",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Simple Text Inline Edit feedback"
     }

--- a/demos/keyboard-a11y/json/config.json
+++ b/demos/keyboard-a11y/json/config.json
@@ -10,7 +10,7 @@
         "instructions": "<ul><li>Tab to the images. Arrow keys move the focus, and 'Space,' 'Return' or 'Enter' open the current image in the viewer.</li><li>Try tabbing to the 'five star rating' widget and using the arrow keys and Enter to rate the image.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/keyboard-a11y",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/keyboard-a11y",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Keyboard+Accessibility+Plugin+API",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Keyboard Accessibility Plugin feedback"
     }

--- a/demos/overviewPanel/index.html
+++ b/demos/overviewPanel/index.html
@@ -59,7 +59,7 @@
                         },
                         links: {
                             titleLink: "http://fluidproject.org/products/infusion/",
-                            demoCodeLink: "https://github.com/fluid-project/infusion/tree/master/src/demos/overviewPanel",
+                            demoCodeLink: "https://github.com/fluid-project/infusion/tree/master/demos/overviewPanel",
                             infusionCodeLink: "https://github.com/fluid-project/infusion",
                             feedbackLink: "mailto:infusion-users@fluidproject.org?subject=Overview Panel feedback"
                         }

--- a/demos/pager/json/config.json
+++ b/demos/pager/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Try using the page links to jump to the first, last, and the 'middle' pages easily.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/pager",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/pager",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Pager+API",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Pager feedback"
     }

--- a/demos/prefsFramework/json/config.json
+++ b/demos/prefsFramework/json/config.json
@@ -9,7 +9,7 @@
         "instructions": "<ul><li>To access the preference editor on this page, click the 'Show Display Preferences' tab in the upper right corner of the window.</li><li>Try adjusting the controls in the panel that opens. You will see the changes applied to the page immediately.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/prefsFramework",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/prefsFramework",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Preferences+Framework",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Preferences Framework feedback"
     }

--- a/demos/progress/json/config.json
+++ b/demos/progress/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Click on the 'Submit' button to observe the progress component.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/progress",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/progress",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Progress+API",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Progress feedback"
     }

--- a/demos/renderer/json/config.json
+++ b/demos/renderer/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>The initial view shows the template on the left side of the page and the data model on the right.</li><li>Click the 'Render' button at the top of the page to render the data model into the template.</li><li>Try selecting different values in the form and observe how the data model automatically updates.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/renderer",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/renderer",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Renderer",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Renderer feedback"
     }

--- a/demos/reorderer/gridReorderer/json/config.json
+++ b/demos/reorderer/gridReorderer/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Try reordering the letters using the mouse.</li><li>Try reordering the letters using only the keyboard: Direction keys (arrow keys or i-j-k-m) move focus; CTRL + direction keys move the item.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/reorderer/gridReorderer",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/gridReorderer",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Grid+Reorderer+API",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Grid Reorderer feedback"
     }

--- a/demos/reorderer/imageReorderer/json/config.json
+++ b/demos/reorderer/imageReorderer/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Try reordering the images using the mouse.</li><li>Try reordering the images using only the keyboard: Direction keys (arrow keys or i-j-k-m) move focus; CTRL + direction keys move the item.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/reorderer/imageReorderer",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/imageReorderer",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Image+Reorderer+API",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Image+Reorderer+Design+Overview",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Image Reorderer feedback"

--- a/demos/reorderer/layoutReorderer/json/config.json
+++ b/demos/reorderer/layoutReorderer/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Try rearranging the portals using the mouse.</li><li>Try rearranging the portals using only the keyboard: Direction keys (arrow keys or i-j-k-m) move focus; CTRL + direction keys move the item.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/reorderer/layoutReorderer",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/layoutReorderer",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Layout+Reorderer+API",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Layout+Reorderer+Design+Overview",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Layout Reorderer feedback"

--- a/demos/reorderer/listReorderer/json/config.json
+++ b/demos/reorderer/listReorderer/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Try reordering the items using the mouse.</li><li>Try reordering the items using only the keyboard: Direction keys (left and right arrow keys, or i and m) move focus; CTRL + direction keys move the item.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/reorderer/listReorderer",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/listReorderer",
         "apiLink": "http://wiki.fluidproject.org/display/docs/List+Reorderer+API",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/List+Reorderer+Design+Overview",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=List Reorderer feedback"

--- a/demos/tableOfContents/json/config.json
+++ b/demos/tableOfContents/json/config.json
@@ -8,7 +8,7 @@
         "instructions": "<ul><li>Follow any of the links within the Table of Contents to the related section of the page.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/tableOfContents",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/tableOfContents",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Table+of+Contents+API",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Table of Contents feedback"
     }

--- a/demos/uiOptions/json/config.json
+++ b/demos/uiOptions/json/config.json
@@ -7,7 +7,7 @@
         "instructions": "<ul><li>To access UI Options, click the 'Show Display Preferences' tab in the upper right corner of the window.</li><li>Try adjusting the controls in the panel that opens. You will see the changes applied to the page immediately.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/uiOptions",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/uiOptions",
         "apiLink": "http://wiki.fluidproject.org/display/docs/User+Interface+Options+API",
         "designLink": "http://wiki.fluidproject.org/pages/viewpage.action?pageId=29959408",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=UI Options feedback"

--- a/demos/uploader/json/config.json
+++ b/demos/uploader/json/config.json
@@ -7,9 +7,9 @@
         "instructions": "<ul><li>Click the 'Browse Files' buttonto select files to be added to the queue.</li><li>Use the red 'X' delete button to remove files from the queue.</li><li>Click the 'Add More' button to add more files to the queue.</li><li>Click 'Upload' to start the upload.</li><li>Click 'Stop Upload' to pause the upload.</li></ul>"
     },
     "links": {
-        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/src/demos/uploader",
+        "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/uploader",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Uploader+API",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Uploader+Design+Overview",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=uploader feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Uploader feedback"
     }
 }


### PR DESCRIPTION
I've fixed all the links to the demo code. The API links still point to the wiki, but our html docs are not ready yet. I've filed a JIRA for this:  http://issues.fluidproject.org/browse/FLUID-5527
