### PR TITLE
FLUID-5625: Update demo APIl links to new production docs url

### DIFF
--- a/demos/inlineEdit/json/config.json
+++ b/demos/inlineEdit/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/inlineEdit",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Simple+Text+Inline+Edit+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/InlineEditAPI.html",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Simple Text Inline Edit feedback"
     }
 }

--- a/demos/pager/json/config.json
+++ b/demos/pager/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/pager",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Pager+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/PagerAPI.html",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Pager feedback"
     }
 }

--- a/demos/prefsFramework/json/config.json
+++ b/demos/prefsFramework/json/config.json
@@ -10,7 +10,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/prefsFramework",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Preferences+Framework",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/PreferencesFramework.html",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Preferences Framework feedback"
     }
 }

--- a/demos/progress/json/config.json
+++ b/demos/progress/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/progress",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Progress+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/ProgressAPI.html",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Progress feedback"
     }
 }

--- a/demos/renderer/json/config.json
+++ b/demos/renderer/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/renderer",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Renderer",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/Renderer.html",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Renderer feedback"
     }
 }

--- a/demos/reorderer/gridReorderer/json/config.json
+++ b/demos/reorderer/gridReorderer/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/gridReorderer",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Grid+Reorderer+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/GridReordererAPI.html",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Grid Reorderer feedback"
     }
 }

--- a/demos/reorderer/imageReorderer/json/config.json
+++ b/demos/reorderer/imageReorderer/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/imageReorderer",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Image+Reorderer+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/ImageReordererAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Image+Reorderer+Design+Overview",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Image Reorderer feedback"
     }

--- a/demos/reorderer/layoutReorderer/json/config.json
+++ b/demos/reorderer/layoutReorderer/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/layoutReorderer",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Layout+Reorderer+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/LayoutReordererAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Layout+Reorderer+Design+Overview",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Layout Reorderer feedback"
     }

--- a/demos/reorderer/listReorderer/json/config.json
+++ b/demos/reorderer/listReorderer/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/listReorderer",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/List+Reorderer+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/ListReordererAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/List+Reorderer+Design+Overview",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=List Reorderer feedback"
     }

--- a/demos/tableOfContents/json/config.json
+++ b/demos/tableOfContents/json/config.json
@@ -9,7 +9,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/tableOfContents",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Table+of+Contents+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/TableOfContentsAPI.html",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Table of Contents feedback"
     }
 }

--- a/demos/uiOptions/json/config.json
+++ b/demos/uiOptions/json/config.json
@@ -8,7 +8,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/uiOptions",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/User+Interface+Options+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/UserInterfaceOptionsAPI.html",
         "designLink": "http://wiki.fluidproject.org/pages/viewpage.action?pageId=29959408",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=UI Options feedback"
     }

--- a/demos/uploader/json/config.json
+++ b/demos/uploader/json/config.json
@@ -8,7 +8,7 @@
     },
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/uploader",
-        "apiLink": "http://wiki.fluidproject.org/display/docs/Uploader+API",
+        "apiLink": "http://docs.fluidproject.org/infusion/development/UploaderAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Uploader+Design+Overview",
         "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Uploader feedback"
     }


### PR DESCRIPTION
Note that
a) we have nothing at all in the docs yet for the Keyboard a11y plugin
b) we have nothing in the docs yet about browser support
so those two links are still referencing the archived docs wiki