### PR TITLE
FLUID-5697: provide a means of excluding headers

### DIFF
--- a/demos/prefsFramework/index.html
+++ b/demos/prefsFramework/index.html
@@ -90,7 +90,7 @@
             });
         </script>
 
-        <div class="flc-overviewPanel fl-overviewPanel-container"></div>
+        <div class="flc-overviewPanel flc-toc-exclude fl-overviewPanel-container"></div>
         <!-- BEGIN markup for Preference Editor -->
         <div class="flc-prefsEditor-separatedPanel fl-prefsEditor-separatedPanel">
             <!-- This is the div that will contain the Preference Editor component -->

--- a/demos/prefsFramework/index.html
+++ b/demos/prefsFramework/index.html
@@ -90,7 +90,7 @@
             });
         </script>
 
-        <div class="flc-overviewPanel flc-toc-exclude fl-overviewPanel-container"></div>
+        <div class="flc-overviewPanel fl-overviewPanel-container"></div>
         <!-- BEGIN markup for Preference Editor -->
         <div class="flc-prefsEditor-separatedPanel fl-prefsEditor-separatedPanel">
             <!-- This is the div that will contain the Preference Editor component -->

--- a/demos/prefsFramework/js/prefsEditorDemo.js
+++ b/demos/prefsFramework/js/prefsEditorDemo.js
@@ -86,7 +86,10 @@ var demo = demo || {};
             messagePrefix: "../../src/framework/preferences/messages/",  // The common path to settings panel templates. The template defined in "panels" element will take precedence over this definition.
             tableOfContents: {
                 enactor: {
-                    tocTemplate: "../../src/components/tableOfContents/html/TableOfContents.html"
+                    tocTemplate: "../../src/components/tableOfContents/html/TableOfContents.html",
+                    ignoreForToC: {
+                        "overviewPanel": ".flc-overviewPanel"
+                    }
                 }
             },
 

--- a/demos/tableOfContents/index.html
+++ b/demos/tableOfContents/index.html
@@ -39,68 +39,85 @@
             <nav class="row">
                 <div class="flc-toc-tocContainer demo-toc large-4 small-centered columns"></div>
             </nav>
-
-            <h1>Amphibians</h1>
+            <h1>Species</h1>
+            <h2>Amphibians</h2>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam interdum, elit lobortis dictum placerat, sapien nulla volutpat nisl, a elementum purus est sit amet pede. Vestibulum tempus, libero ut eleifend commodo, nibh quam fermentum neque, vitae suscipit nulla erat id nisl. Aliquam sollicitudin sapien sed nisl gravida malesuada. Praesent magna velit, cursus id, aliquet at, varius a, mauris. Mauris lacinia, est eget dapibus porta, augue ipsum adipiscing sapien, vitae lobortis risus diam vitae est. Fusce id felis. Donec turpis lorem, commodo non, iaculis nec, tristique vel, ligula. Donec molestie nulla non sapien. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Integer neque dolor, aliquam quis, fringilla tempor, scelerisque nec, nibh. Nullam volutpat fermentum purus. Curabitur vitae urna. Vivamus nibh. Curabitur non tortor. Suspendisse mi elit, placerat at, rutrum eu, congue vel, elit. Donec erat ligula, placerat id, commodo at, dignissim eu, tellus. Nam luctus metus. Curabitur molestie tincidunt sem.
             </p>
-            <h2>Toads</h2>
+            <h3>Toads</h3>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec blandit rhoncus diam. Donec nunc magna, volutpat ac, fermentum in, venenatis id, nibh. Nulla vitae erat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In sed quam. Curabitur luctus tempor nunc. Donec mollis. Integer accumsan viverra massa. Morbi accumsan placerat tellus. Aenean ornare ultrices lorem. Nam in quam. Integer placerat commodo diam. Quisque a tellus.
             </p>
-            <h3>Natterjack Toads</h3>
+            <h4>Natterjack Toads</h4>
             <p>
                 Nullam sed ligula. Curabitur ac urna sit amet nisl sagittis placerat. Proin tincidunt massa nec enim. Mauris aliquam lacus ac metus. Integer tempus molestie augue. Morbi sodales erat non nisl. Aliquam fringilla. Fusce dui odio, dapibus eu, venenatis ac, viverra vel, mauris. Vestibulum tortor lorem, ultricies vitae, adipiscing et, posuere et, orci. Pellentesque tincidunt. Vivamus venenatis mollis metus. Nunc ullamcorper, ipsum a dictum dictum, enim purus sagittis risus, ut aliquam tellus risus at mauris.
             </p>
-            <h2>Salamander</h2>
+            <h3>Salamander</h3>
             <p>
                 Quisque ornare odio et orci congue viverra. Sed id nisi. Vivamus vehicula, purus at pellentesque bibendum, leo nunc pharetra sem, eu dignissim eros turpis vitae erat. Curabitur at ipsum. In at risus at nulla imperdiet facilisis. Vestibulum elit. Morbi sit amet ipsum a quam ultricies faucibus. Vestibulum justo quam, interdum at, posuere eu, volutpat ut, dui. Integer mauris. Praesent id tellus eu mi viverra ultrices.
             </p>
-            <h2>Newt</h2>
+            <h3>Newt</h3>
             <p>
                 Suspendisse adipiscing, enim sit amet auctor rutrum, lacus mi sollicitudin purus, vitae semper erat elit id nisi. In hac habitasse platea dictumst. Integer velit. Nam eu ligula. Nulla id mi vitae tortor luctus semper. Suspendisse sit amet dolor eu metus blandit molestie. Vivamus at magna vitae mauris ultricies molestie. Nulla convallis, nisi a semper vehicula, elit mi facilisis mi, tristique cursus magna quam quis augue. Nunc pulvinar, erat ac consectetur vehicula, nisi odio scelerisque leo, non faucibus diam arcu eu quam.
             </p>
 
-            <h1>Birds</h1>
+            <h2>Birds</h2>
             <p>
                 Maecenas viverra fermentum sapien. Cras venenatis tempus pede. Etiam eu ligula. Ut ut libero. Donec malesuada lorem vel tellus. Donec vel leo. Aliquam ipsum. Fusce nec nibh dignissim turpis tristique semper. Curabitur lorem nibh, fringilla eget, dignissim sed, rutrum fermentum, leo. In scelerisque, augue eget imperdiet vehicula, orci diam tincidunt sapien, et tristique dui diam vitae eros. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
             </p>
-            <h2>Anseriformes</h2>
+            <h3>Anseriformes</h3>
             <p>
                 Nulla suscipit. Praesent pulvinar turpis at ante. Quisque accumsan, sem vestibulum aliquet mattis, quam ipsum tempor arcu, sed congue metus elit ut felis. Vivamus scelerisque turpis eu nulla. Fusce eu nulla sed quam varius viverra. In hac habitasse platea dictumst. Phasellus commodo, nunc nec luctus lacinia, mi lorem placerat odio, aliquet laoreet nibh risus sit amet pede. Nulla euismod lorem placerat ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aenean pretium, sem ut volutpat cursus, massa justo porta ipsum, vitae ultrices lacus nibh ut ante. Pellentesque placerat, purus varius facilisis iaculis, pede ligula lacinia urna, quis posuere nibh velit eu eros. Fusce enim. In congue velit in nisi. Phasellus nec augue vel nibh pharetra sagittis.
             </p>
-            <h3>Ducks</h3>
+            <h4>Ducks</h4>
             <p>
                 Fusce eu leo eget enim sollicitudin scelerisque. Aenean eleifend, turpis id accumsan dapibus, felis sem accumsan turpis, a ullamcorper libero arcu sit amet tortor. Vestibulum sit amet velit eget risus pulvinar varius. Pellentesque vehicula mauris quis turpis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam quis risus. Cras ipsum risus, vehicula et, elementum ut, accumsan vel, tortor. Sed iaculis libero nec urna tristique mollis. Nullam tortor nulla, faucibus quis, eleifend ut, tincidunt quis, dui. Aenean hendrerit viverra neque. In vestibulum ultrices mi. Phasellus at mi. Nunc sed nisl. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Quisque magna. Sed dignissim feugiat eros. Duis condimentum laoreet nisi. Nullam accumsan tortor eu quam.
             </p>
-            <h2>Galliformes</h2>
+            <h3>Galliformes</h3>
             <p>
                 Nulla felis turpis, elementum eu, gravida eget, scelerisque eu, erat. Morbi massa dolor, porta nec, tristique in, rhoncus in, elit. Morbi ut enim a dolor ullamcorper posuere. Nullam vehicula turpis nec nibh. Integer est. Morbi id erat ac diam auctor venenatis. Nam ipsum tellus, rhoncus vel, sollicitudin in, sodales ac, lorem. Ut aliquam ipsum vitae erat sodales venenatis. Nulla facilisi. Donec lacinia adipiscing massa. Duis fermentum, odio at fringilla placerat, ligula velit luctus nibh, sed commodo felis tortor sit amet lorem. Maecenas nec erat sed quam fringilla pharetra. Nam sit amet dolor ac quam pellentesque pretium. Morbi est arcu, volutpat laoreet, feugiat nec, gravida non, metus.
             </p>
-            <h3>Grouse</h3>
+            <h4>Grouse</h4>
             <p>
                 Nulla gravida laoreet neque. Donec vel erat eget neque sollicitudin ultrices. Cras porttitor, sem in sollicitudin blandit, est est vehicula nisi, sed aliquam neque risus sit amet erat. In leo ligula, interdum id, aliquam vitae, venenatis a, tellus. Cras in justo at nibh aliquam blandit. Donec dignissim convallis purus. Fusce eu ligula a nisl luctus placerat. Curabitur dignissim dui in massa. Aliquam vulputate vestibulum lorem. Sed est pede, ultricies non, volutpat id, vestibulum ut, urna. Fusce non diam. Aliquam erat volutpat. Aliquam venenatis pretium tellus. Maecenas ultrices dolor rhoncus magna. Nulla facilisi. Vestibulum mauris turpis, vulputate vel, malesuada ut, mollis sed, neque. Duis at sem a est laoreet sodales.
             </p>
-            <h1>Mammals</h1>
+            <h2>Mammals</h2>
             <p>
                 Proin varius faucibus neque. Aliquam convallis, nibh eu consectetur semper, augue nisl lobortis leo, eu sodales turpis sem ut leo. Morbi euismod eleifend orci. Praesent eget orci quis turpis sollicitudin volutpat. Curabitur felis enim, viverra eget, congue ac, semper sed, mi. Praesent porttitor sodales sem. Aenean volutpat odio a erat. Integer lacus erat, aliquet a, auctor non, laoreet dapibus, purus. Donec sed sem. Phasellus convallis hendrerit quam. Sed vel nibh id nunc bibendum ultrices. In nec nisi. Suspendisse justo nisl, dapibus a, pulvinar ac, blandit sit amet, odio. Vivamus eros dui, rhoncus in, cursus non, rhoncus sed, diam. Praesent pretium feugiat velit. Donec turpis est, pulvinar in, consectetur sit amet, consequat sed, nibh. Praesent tempor malesuada purus. Ut non libero. Praesent pulvinar. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
             </p>
-            <h2>Cats</h2>
+            <h3>Cats</h3>
             <p>
                 Nunc vehicula eleifend enim. Morbi pede. Suspendisse placerat. Nunc bibendum dolor et purus. Proin vehicula. Duis facilisis mi quis mauris. Mauris nunc dolor, congue quis, consectetur sed, imperdiet eget, tortor. In blandit lectus nec risus. In semper posuere turpis. Aenean ac dolor non purus lobortis fringilla.
             </p>
-            <h2>Dogs</h2>
+            <h3>Dogs</h3>
             <p>
                 Nam et odio. Quisque accumsan ornare orci. Suspendisse et augue vitae nulla egestas luctus. Quisque at leo vel sem dignissim volutpat. Curabitur varius. Aenean non odio vel nunc viverra vehicula. Curabitur suscipit vestibulum neque. Duis gravida, urna sed viverra dapibus, ligula nisi sagittis lacus, vel pulvinar tortor ante id turpis. Suspendisse ut pede. Vivamus vestibulum leo ac sapien.
             </p>
-            <h2>Humans</h2>
+            <h3>Humans</h3>
             <p>
                 Fusce rutrum purus sit amet mi. Nullam non purus. Aenean rhoncus, augue id varius mattis, augue urna rhoncus arcu, at dapibus risus neque at massa. Suspendisse potenti. Sed risus sem, rhoncus a, pretium et, dignissim vitae, urna. Etiam urna leo, pellentesque sollicitudin, convallis ac, aliquam euismod, massa. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla facilisi. Vestibulum odio augue, tincidunt eu, vehicula eget, venenatis id, massa. Vivamus pharetra imperdiet elit. Mauris lacus tortor, mattis ac, ullamcorper non, consequat at, nisl. Maecenas tellus purus, convallis sit amet, euismod eu, fermentum faucibus, magna.
             </p>
-            <h4>CATT</h4>
+            <h5>CATT</h5>
             <p>
                 Morbi fermentum rutrum dui. Nunc lorem. Fusce cursus. Ut dignissim, ante vitae dapibus rutrum, dolor lacus sollicitudin tortor, sed molestie tellus est eget lectus. Vestibulum ac ipsum. Morbi augue augue, hendrerit vestibulum, ultrices eu, laoreet a, nisi. Pellentesque non nisl sed erat pretium lacinia. Pellentesque libero felis, eleifend sit amet, porta at, sagittis ac, nisi. Maecenas magna. Vivamus sapien. Integer mattis, orci quis iaculis vestibulum, est purus porta libero, sit amet luctus diam risus at neque. Mauris suscipit, leo vitae aliquam pellentesque, orci diam scelerisque eros, a porta quam magna a justo. In tristique aliquet eros. Nam ullamcorper mi vel massa. Fusce quis pede.
             </p>
+
+            <h2 class="flc-toc-exclude">Trees</h2>
+            <em> The headers for this section should all be excluded from the ToC </em>
+            <section class="flc-toc-exclude">
+                <h3>Chestnut</h3>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </p>
+                <h3>Oak</h3>
+                <p>
+                    Nam interdum, elit lobortis dictum placerat, sapien nulla volutpat nisl, a elementum purus est sit amet pede.
+                </p>
+                <h3>Sugar Maple</h3>
+                <p>
+                    Vestibulum tempus, libero ut eleifend commodo, nibh quam fermentum neque, vitae suscipit nulla erat id nisl. Aliquam sollicitudin sapien sed nisl gravida malesuada. Praesent magna velit, cursus id, aliquet at, varius a, mauris. Mauris lacinia, est eget dapibus porta, augue ipsum adipiscing sapien, vitae lobortis risus diam vitae est. Fusce id felis. Donec turpis lorem, commodo non, iaculis nec, tristique vel, ligula. Donec molestie nulla non sapien. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Integer neque dolor, aliquam quis, fringilla tempor, scelerisque nec, nibh. Nullam volutpat fermentum purus. Curabitur vitae urna. Vivamus nibh. Curabitur non tortor. Suspendisse mi elit, placerat at, rutrum eu, congue vel, elit. Donec erat ligula, placerat id, commodo at, dignissim eu, tellus. Nam luctus metus. Curabitur molestie tincidunt sem.
+                </p>
+            </section>
         </main>
 
         <script type="text/javascript">

--- a/demos/tableOfContents/index.html
+++ b/demos/tableOfContents/index.html
@@ -102,9 +102,9 @@
                 Morbi fermentum rutrum dui. Nunc lorem. Fusce cursus. Ut dignissim, ante vitae dapibus rutrum, dolor lacus sollicitudin tortor, sed molestie tellus est eget lectus. Vestibulum ac ipsum. Morbi augue augue, hendrerit vestibulum, ultrices eu, laoreet a, nisi. Pellentesque non nisl sed erat pretium lacinia. Pellentesque libero felis, eleifend sit amet, porta at, sagittis ac, nisi. Maecenas magna. Vivamus sapien. Integer mattis, orci quis iaculis vestibulum, est purus porta libero, sit amet luctus diam risus at neque. Mauris suscipit, leo vitae aliquam pellentesque, orci diam scelerisque eros, a porta quam magna a justo. In tristique aliquet eros. Nam ullamcorper mi vel massa. Fusce quis pede.
             </p>
 
-            <h2 class="flc-toc-exclude">Trees</h2>
+            <h2 class="demo-toc-trees">Trees</h2>
             <em> The headers for this section should all be excluded from the ToC </em>
-            <section class="flc-toc-exclude">
+            <section class="demo-toc-trees">
                 <h3>Chestnut</h3>
                 <p>
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/demos/tableOfContents/js/tableOfContentsDemo.js
+++ b/demos/tableOfContents/js/tableOfContentsDemo.js
@@ -30,6 +30,10 @@ var demo = demo || {};
             }
         });
 
-        fluid.tableOfContents("body");
+        fluid.tableOfContents("body", {
+            ignoreForToC: {
+                trees: ".demo-toc-trees"
+            }
+        });
     };
 })(jQuery, fluid);

--- a/demos/uiOptions/index.html
+++ b/demos/uiOptions/index.html
@@ -61,12 +61,15 @@
                 fluid.uiOptions.prefsEditor(".flc-prefsEditor-separatedPanel", {
                     "templatePrefix": "../../src/framework/preferences/html/",
                     "messagePrefix": "../../src/framework/preferences/messages/",
-                    "tocTemplate": "../../src/components/tableOfContents/html/TableOfContents.html"
+                    "tocTemplate": "../../src/components/tableOfContents/html/TableOfContents.html",
+                    "ignoreForToC": {
+                        "overviewPanel": ".flc-overviewPanel"
+                    }
                 });
             });
         </script>
 
-        <div class="flc-overviewPanel flc-toc-exclude fl-overviewPanel-container"></div>
+        <div class="flc-overviewPanel fl-overviewPanel-container"></div>
         <!-- BEGIN markup for Preference Editor -->
         <div class="flc-prefsEditor-separatedPanel fl-prefsEditor-separatedPanel">
             <!-- This is the div that will contain the Preference Editor component -->

--- a/demos/uiOptions/index.html
+++ b/demos/uiOptions/index.html
@@ -66,7 +66,7 @@
             });
         </script>
 
-        <div class="flc-overviewPanel fl-overviewPanel-container"></div>
+        <div class="flc-overviewPanel flc-toc-exclude fl-overviewPanel-container"></div>
         <!-- BEGIN markup for Preference Editor -->
         <div class="flc-prefsEditor-separatedPanel fl-prefsEditor-separatedPanel">
             <!-- This is the div that will contain the Preference Editor component -->

--- a/src/components/tableOfContents/js/TableOfContents.js
+++ b/src/components/tableOfContents/js/TableOfContents.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2011 OCAD University
+Copyright 2011-2015 OCAD University
 Copyright 2011 Lucendo Development Ltd.
 
 Licensed under the Educational Community License (ECL), Version 2.0 or the New
@@ -112,7 +112,7 @@ var fluid_2_0 = fluid_2_0 || {};
             tocHeader: "Table of Contents"
         },
         selectors: {
-            headings: ":header:visible:not(.flc-toc-tocContainer :header)",
+            headings: ":header:visible:not(.flc-toc-tocContainer :header, .flc-toc-exclude :header, .flc-toc-exclude)",
             tocContainer: ".flc-toc-tocContainer",
             tocAnchors: ".flc-toc-anchors"
         },

--- a/src/components/tableOfContents/js/TableOfContents.js
+++ b/src/components/tableOfContents/js/TableOfContents.js
@@ -44,8 +44,18 @@ var fluid_2_0 = fluid_2_0 || {};
         return anchorInfo;
     };
 
-    fluid.tableOfContents.refreshView = function (that) {
+    fluid.tableOfContents.locateHeadings = function (that) {
         var headings = that.locate("headings");
+
+        fluid.each(that.options.ignoreForToC, function (sel) {
+            headings = headings.not(sel).not(sel + " :header");
+        });
+
+        return headings;
+    };
+
+    fluid.tableOfContents.refreshView = function (that) {
+        var headings = that.locateHeadings();
 
         // remove existing toc anchors from the the DOM, before adding any new ones.
         that.locate("tocAnchors").remove();
@@ -94,6 +104,10 @@ var fluid_2_0 = fluid_2_0 || {};
             },
             insertAnchor: "fluid.tableOfContents.insertAnchor",
             generateGUID: "fluid.allocateSimpleId",
+            locateHeadings: {
+                funcName: "fluid.tableOfContents.locateHeadings",
+                args: ["{that}"]
+            },
             refreshView: {
                 funcName: "fluid.tableOfContents.refreshView",
                 args: ["{that}"]
@@ -112,9 +126,12 @@ var fluid_2_0 = fluid_2_0 || {};
             tocHeader: "Table of Contents"
         },
         selectors: {
-            headings: ":header:visible:not(.flc-toc-tocContainer :header, .flc-toc-exclude :header, .flc-toc-exclude)",
+            headings: ":header:visible",
             tocContainer: ".flc-toc-tocContainer",
             tocAnchors: ".flc-toc-anchors"
+        },
+        ignoreForToC: {
+            tocContainer: "{that}.options.selectors.tocContainer"
         },
         anchorClass: "flc-toc-anchors",
         events: {

--- a/src/components/uiOptions/js/UIOptions.js
+++ b/src/components/uiOptions/js/UIOptions.js
@@ -20,10 +20,13 @@ var fluid_2_0 = fluid_2_0 || {};
 
     fluid.defaults("fluid.uiOptions.prefsEditor", {
         gradeNames: ["fluid.prefs.constructed.prefsEditor", "autoInit"],
-        distributeOptions: {
+        distributeOptions: [{
             source: "{that}.options.tocTemplate",
             target: "{that uiEnhancer}.options.tocTemplate"
-        },
+        }, {
+            source: "{that}.options.ignoreForToC",
+            target: "{that uiEnhancer}.options.ignoreForToC"
+        }],
         enhancer: {
             distributeOptions: [{
                 source: "{that}.options.tocTemplate",

--- a/src/components/uiOptions/js/UIOptions.js
+++ b/src/components/uiOptions/js/UIOptions.js
@@ -25,10 +25,13 @@ var fluid_2_0 = fluid_2_0 || {};
             target: "{that uiEnhancer}.options.tocTemplate"
         },
         enhancer: {
-            distributeOptions: {
+            distributeOptions: [{
                 source: "{that}.options.tocTemplate",
                 target: "{that > fluid.prefs.enactor.tableOfContents}.options.tocTemplate"
-            }
+            }, {
+                source: "{that}.options.ignoreForToC",
+                target: "{that > fluid.prefs.enactor.tableOfContents}.options.ignoreForToC"
+            }]
         }
     });
 

--- a/src/framework/preferences/js/Enactors.js
+++ b/src/framework/preferences/js/Enactors.js
@@ -410,6 +410,10 @@ var fluid_2_0 = fluid_2_0 || {};
                 listener: "{that}.applyToc",
                 args: ["{change}.value"]
             }
+        },
+        distributeOptions: {
+            source: "{that}.options.ignoreForToC",
+            target: "{that tableOfContents}.options.ignoreForToC"
         }
     });
 

--- a/tests/component-tests/tableOfContents/html/TableOfContents-test.html
+++ b/tests/component-tests/tableOfContents/html/TableOfContents-test.html
@@ -111,9 +111,9 @@
 
         <div id="fluid-5697">
             <div class="flc-toc-tocContainer toc"></div>
-            <h2>Inculded</h2>
-            <h2 class="flc-toc-exclude">Excluded</h2>
-            <section class="flc-toc-exclude">
+            <h2>Included</h2>
+            <h2 class="fluid-5697-exclude">Excluded</h2>
+            <section class="fluid-5697-exclude">
                 <h3>Excluded</h3>
             </section>
         </div>

--- a/tests/component-tests/tableOfContents/html/TableOfContents-test.html
+++ b/tests/component-tests/tableOfContents/html/TableOfContents-test.html
@@ -90,13 +90,6 @@
             <div id="tocInsertAnchor"></div>
         </div>
 
-        <div id="tocFilterHeadings">
-            <h1 style="display:none;">H1</h1>
-            <h2>H2</h2>
-            <h3>H3</h3>
-            <h4>H4</h4>
-        </div>
-
         <div id="flc-toc-noHeaders">
             <div class="flc-toc-tocContainer toc"></div>
             <p>Paragraph 1</p>
@@ -114,6 +107,15 @@
         <div id="flc-toc-l10n">
             <div class="flc-toc-tocContainer toc"></div>
             <h2>L10N</h2>
+        </div>
+
+        <div id="fluid-5697">
+            <div class="flc-toc-tocContainer toc"></div>
+            <h2>Inculded</h2>
+            <h2 class="flc-toc-exclude">Excluded</h2>
+            <section class="flc-toc-exclude">
+                <h3>Excluded</h3>
+            </section>
         </div>
     </body>
 </html>

--- a/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
+++ b/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
@@ -629,7 +629,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             var testHeadings = {
                 headingInfo: [{
                     level: "2",
-                    text: "Inculded",
+                    text: "Included",
                     url: "#test"
                 }]
             };

--- a/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
+++ b/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2011 OCAD University
+Copyright 2011-2015 OCAD University
 
 Licensed under the Educational Community License (ECL), Version 2.0 or the New
 BSD license. You may not use this file except in compliance with one these
@@ -616,6 +616,36 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                             jqUnit.start();
                         },
                         args: ["{that}.levels"]
+                    }
+                }
+            });
+        });
+
+        /**
+        * #FLUID-5697: Test the exclusion of headers
+        */
+        jqUnit.asyncTest("FLUID-5697: Header exclusion", function () {
+            // craft headingInfo so renderTOCTest() can use it
+            var testHeadings = {
+                headingInfo: [{
+                    level: "2",
+                    text: "Inculded",
+                    url: "#test"
+                }]
+            };
+
+            renderTOCComponent("#fluid-5697", {
+                listeners: {
+                    onReady: {
+                        listener: function (that, levels) {
+                            renderTOCTest(levels, testHeadings);
+                            renderTOCAnchorTest();
+                            var numHeadings = testHeadings.headingInfo.length;
+
+                            jqUnit.assertEquals("The correct number of anchors should be present", numHeadings, that.locate("tocAnchors").length);
+                            jqUnit.start();
+                        },
+                        args: ["{that}", "{that}.levels"]
                     }
                 }
             });

--- a/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
+++ b/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
@@ -635,6 +635,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             };
 
             renderTOCComponent("#fluid-5697", {
+                ignoreForToC: {
+                    "fluid-5697": ".fluid-5697-exclude"
+                },
                 listeners: {
                     onReady: {
                         listener: function (that, levels) {


### PR DESCRIPTION
Added a class that can be used to exclude a header or section of headers from being included in the Table of Contents.

https://issues.fluidproject.org/browse/FLUID-5697