### PR TITLE
Fluid 5680: Hide icons from AT and added aria-label for hide/show button

### DIFF
--- a/demos/prefsFramework/index.html
+++ b/demos/prefsFramework/index.html
@@ -100,7 +100,7 @@
             <div class="fl-panelBar">
                 <span class="fl-prefsEditor-buttons">
                     <button id="reset" class="flc-prefsEditor-reset fl-prefsEditor-reset"><span class="fl-icon-undo"></span> Reset</button>
-                    <button id="show-hide" class="flc-slidingPanel-toggleButton fl-prefsEditor-showHide"> Show/Hide</button>
+                    <button id="show-hide" class="flc-slidingPanel-toggleButton fl-prefsEditor-showHide">Show/Hide</button>
                 </span>
             </div>
         </div>

--- a/src/components/slidingPanel/js/SlidingPanel.js
+++ b/src/components/slidingPanel/js/SlidingPanel.js
@@ -25,10 +25,6 @@ var fluid_2_0 = fluid_2_0 || {};
             toggleButton: ".flc-slidingPanel-toggleButton",
             toggleButtonLabel: ".flc-slidingPanel-toggleButton"
         },
-        strings: {
-            showText: "show",
-            hideText: "hide"
-        },
         events: {
             onPanelHide: null,
             onPanelShow: null,

--- a/src/components/slidingPanel/js/SlidingPanel.js
+++ b/src/components/slidingPanel/js/SlidingPanel.js
@@ -58,11 +58,21 @@ var fluid_2_0 = fluid_2_0 || {};
                 "args": ["{that}.options.strings.showText"],
                 "priority": "first"
             },
+            "onPanelHide.setAriaLabel": {
+                "this": "{that}.dom.toggleButtonLabel",
+                "method": "attr",
+                "args": ["aria-label", "{that}.options.strings.showTextAriaLabel"]
+            },
             "onPanelShow.setText": {
                 "this": "{that}.dom.toggleButtonLabel",
                 "method": "text",
                 "args": ["{that}.options.strings.hideText"],
                 "priority": "first"
+            },
+            "onPanelShow.setAriaLabel": {
+                "this": "{that}.dom.toggleButtonLabel",
+                "method": "attr",
+                "args": ["aria-label", "{that}.options.strings.hideTextAriaLabel"]
             },
             "onPanelHide.operate": {
                 listener: "{that}.operateHide"

--- a/src/components/slidingPanel/js/SlidingPanel.js
+++ b/src/components/slidingPanel/js/SlidingPanel.js
@@ -25,9 +25,9 @@ var fluid_2_0 = fluid_2_0 || {};
             toggleButton: ".flc-slidingPanel-toggleButton",
             toggleButtonLabel: ".flc-slidingPanel-toggleButton"
         },
-        strings: {      
-            showText: "show",      
-            hideText: "hide"       
+        strings: {
+            showText: "show",
+            hideText: "hide"
         },
         events: {
             onPanelHide: null,

--- a/src/components/slidingPanel/js/SlidingPanel.js
+++ b/src/components/slidingPanel/js/SlidingPanel.js
@@ -45,6 +45,14 @@ var fluid_2_0 = fluid_2_0 || {};
                 listener: "{that}.applier.modelChanged.addListener",
                 args: ["isShowing", "{that}.refreshView"]
             },
+            "onCreate.setAriaControls":{
+                "this": "{that}.dom.toggleButton",
+                "method": "attr",
+                "args": {
+                    "role": "button",
+                    "aria-controls": "{that}.controlledId"
+                }
+            },
             "onCreate.setInitialState": {
                 listener: "{that}.refreshView"
             },
@@ -65,6 +73,16 @@ var fluid_2_0 = fluid_2_0 || {};
             },
             "onPanelShow.operate": {
                 listener: "{that}.operateShow"
+            }
+        },
+        members: {
+            controlledId: {
+                expander: {
+                    // create an id for iframe container
+                    // and set that.controlledId to the id value
+                    funcName: "fluid.allocateSimpleId",
+                    args: "{iframeRenderer}.container"
+                }
             }
         },
         invokers: {

--- a/src/components/slidingPanel/js/SlidingPanel.js
+++ b/src/components/slidingPanel/js/SlidingPanel.js
@@ -25,6 +25,10 @@ var fluid_2_0 = fluid_2_0 || {};
             toggleButton: ".flc-slidingPanel-toggleButton",
             toggleButtonLabel: ".flc-slidingPanel-toggleButton"
         },
+        strings: {      
+            showText: "show",      
+            hideText: "hide"       
+        },
         events: {
             onPanelHide: null,
             onPanelShow: null,

--- a/src/framework/preferences/html/PrefsEditorTemplate-lineSpace.html
+++ b/src/framework/preferences/html/PrefsEditorTemplate-lineSpace.html
@@ -2,9 +2,9 @@
     <h2><span class="fl-icon-line-space"></span><label class="flc-prefsEditor-line-space-label" for="line-space"></label></h2>
     <div class="fl-inputs">
         <div class="fl-force-left">
-            <div class="fl-icon-line-space-condensed" aria-label="Icon of 3 horizontal lines with narrow space" role="img"></div>
+            <div class="fl-icon-line-space-condensed" role="presentation"></div>
             <div class="flc-textfieldSlider-slider fl-force-left fl-slider fl-slider-horz"> </div>
-            <div class="fl-icon-line-space-expanded" aria-label="Icon of 3 horizontal lines with wide space" role="img"></div>
+            <div class="fl-icon-line-space-expanded" role="presentation"></div>
         </div>
         <div class="fl-slider-input"><input id="line-space" class="flc-textfieldSlider-field" type="text" /> <span class="flc-prefsEditor-multiplier"></span></div>
     </div>

--- a/src/framework/preferences/html/PrefsEditorTemplate-textSize.html
+++ b/src/framework/preferences/html/PrefsEditorTemplate-textSize.html
@@ -2,9 +2,9 @@
     <h2><span class="fl-icon-size"></span><label class="flc-prefsEditor-min-text-size-label" for="min-text-size"></label></h2>
     <div class="fl-inputs">
         <div class="fl-force-left">
-            <div class="fl-icon-small-a" aria-label="Icon of a small capital letter 'A'" role="img"></div>
+            <div class="fl-icon-small-a" role="presentation"></div>
             <div class="flc-textfieldSlider-slider fl-force-left fl-slider fl-slider-horz"> </div>
-            <div class="fl-icon-big-a" aria-label="Icon of a large capital letter 'A'" role="img"></div>            
+            <div class="fl-icon-big-a" role="presentation"></div>            
         </div>
         <div class="fl-slider-input"><input id="min-text-size" class="flc-textfieldSlider-field" type="text" /> <span class="flc-prefsEditor-multiplier"></span></div>
     </div>

--- a/src/framework/preferences/html/PrefsEditorTemplate-textSize.html
+++ b/src/framework/preferences/html/PrefsEditorTemplate-textSize.html
@@ -2,9 +2,9 @@
     <h2><span class="fl-icon-size"></span><label class="flc-prefsEditor-min-text-size-label" for="min-text-size"></label></h2>
     <div class="fl-inputs">
         <div class="fl-force-left">
-            <div class="fl-icon-small-a" aria-label="Icon of a small capital letter 'A'" role="img"></div>
+            <div class="fl-icon-small-a" role="presentation"></div>
             <div class="flc-textfieldSlider-slider fl-force-left fl-slider fl-slider-horz"> </div>
-			<div class="fl-icon-big-a" aria-label="Icon of a large capital letter 'A'" role="img"></div>           
+            <div class="fl-icon-big-a" role="presentation"></div>            
         </div>
         <div class="fl-slider-input"><input id="min-text-size" class="flc-textfieldSlider-field" type="text" /> <span class="flc-prefsEditor-multiplier"></span></div>
     </div>

--- a/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
+++ b/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
@@ -77,7 +77,7 @@ var fluid_2_0 = fluid_2_0 || {};
                         showText: "{that}.msgLookup.slidingPanelShowText",
                         hideText: "{that}.msgLookup.slidingPanelHideText",
                         showTextAriaLabel: "{that}.msgLookup.showTextAriaLabel",
-                        hideTextAriaLabel: "{that}.msgLookup.hideTextAriaLabel",
+                        hideTextAriaLabel: "{that}.msgLookup.hideTextAriaLabel"
                     },
                     invokers: {
                         operateShow: {

--- a/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
+++ b/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
@@ -75,7 +75,9 @@ var fluid_2_0 = fluid_2_0 || {};
                     gradeNames: ["fluid.prefs.msgLookup"],
                     strings: {
                         showText: "{that}.msgLookup.slidingPanelShowText",
-                        hideText: "{that}.msgLookup.slidingPanelHideText"
+                        hideText: "{that}.msgLookup.slidingPanelHideText",
+                        showTextAriaLabel: "{that}.msgLookup.showTextAriaLabel",
+                        hideTextAriaLabel: "{that}.msgLookup.hideTextAriaLabel",
                     },
                     invokers: {
                         operateShow: {

--- a/src/framework/preferences/messages/prefsEditor.json
+++ b/src/framework/preferences/messages/prefsEditor.json
@@ -1,4 +1,6 @@
 {
     "slidingPanelShowText": "+ Show Display Preferences",
-    "slidingPanelHideText": "- Hide"
+    "slidingPanelHideText": "- Hide",
+    "showTextAriaLabel": "Show Display Preferences",
+    "hideTextAriaLabel": "Hide Display Preferences"
 }

--- a/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
+++ b/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
@@ -83,9 +83,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         fluid.tests.prefs.assertPresent(prefsEditor, fluid.tests.prefs.expectedComponents["fluid.prefs.separatedPanel"]);
 
         var toggleButtonAriaPressedState = separatedPanel.slidingPanel.locate("toggleButton").attr("aria-pressed");
+        var toggleButtonAriaLabelState = separatedPanel.slidingPanel.locate("toggleButton").attr("aria-label");
         var ariaExpandedState = separatedPanel.locate("iframe").attr("aria-expanded");
 
         jqUnit.assertEquals("Show/hide button has correct aria-pressed", "false", toggleButtonAriaPressedState);
+        jqUnit.assertEquals("Show/hide button has correct aria-label", "Show Display Preferences", toggleButtonAriaLabelState);
         jqUnit.assertEquals("Panel has correct aria-expanded", "false", ariaExpandedState);
     };
 
@@ -98,13 +100,14 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             var resetButtonAriaControlsState = separatedPanel.locate("reset").attr("aria-controls");
             var toggleButtonAriaControlsState = separatedPanel.slidingPanel.locate("toggleButton").attr("aria-controls");
             var toggleButtonAriaPressedState = separatedPanel.slidingPanel.locate("toggleButton").attr("aria-pressed");
-            var panelId = separatedPanel.locate("iframe").attr("id");
+            var toggleButtonAriaLabelState = separatedPanel.slidingPanel.locate("toggleButton").attr("aria-label");
+            var panelId = separatedPanel.slidingPanel.panelId;
             var ariaExpandedState = separatedPanel.locate("iframe").attr("aria-expanded");
+
             jqUnit.assertEquals("Reset button has correct aria-controls", resetButtonAriaControlsState, panelId);
-            
             jqUnit.assertEquals("Show/hide button has correct aria-controls", toggleButtonAriaControlsState, panelId);
             jqUnit.assertEquals("Show/hide button has correct aria-pressed", "true", toggleButtonAriaPressedState);
-
+            jqUnit.assertEquals("Show/hide button has correct aria-label", "Hide Display Preferences", toggleButtonAriaLabelState);
             jqUnit.assertEquals("Panel has correct aria-expanded", "true", ariaExpandedState);
         };
     };
@@ -145,7 +148,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         modules: [{
             name: "Separated panel integration tests",
             tests: [{
-                expect: 29,
+                expect: 31,
                 name: "Separated panel integration tests",
                 sequence: [{
                     listener: "fluid.tests.testSeparatedPanel",


### PR DESCRIPTION
* aria-labels for icons removed with the addition of `display = "presentation"`
* aria-labels added for show/hide button

This pull request should be merged **after** [FLUID-5682](https://github.com/fluid-project/infusion/pull/619)