### PR TITLE
FLUID-5458: Updates .npmignore for 1.9.x branch.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,16 +5,15 @@ demos
 examples
 Gruntfile.js
 products
-project.xml
-project.properties
-pom.xml
 
 src/components
 src/lib/fonts
 src/lib/jquery/plugins
 src/lib/jquery/ui
 src/lib/json
+
 src/framework/core/css
+src/framework/preferences
 
 tests/3rd-party-tests
 tests/component-tests


### PR DESCRIPTION
This applies @jobara's FLUID-5458 changes to .npmignore to the 1.9.x branch. @jobara or @amb26, can you have a look and merge if it looks good? This should match the version in the new 2.0-era master.