### PR TITLE
FLUID-5743: Removed ARABIC GRADES from the framework - 

### DIFF
--- a/demos/prefsFramework/js/prefsEditorDemo.js
+++ b/demos/prefsFramework/js/prefsEditorDemo.js
@@ -130,7 +130,7 @@ var demo = demo || {};
      * Simplify content based upon the model value.
      **********************************************************************************/
     fluid.defaults("demo.prefsEditor.simplifyEnactor", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor"],
+        gradeNames: ["fluid.prefs.enactor", "fluid.viewComponent"],
         preferenceMap: {
             "demo.prefs.simplify": {
                 "model.simplify": "default"

--- a/src/components/inlineEdit/js/InlineEdit.js
+++ b/src/components/inlineEdit/js/InlineEdit.js
@@ -712,7 +712,7 @@ var fluid_2_0 = fluid_2_0 || {};
      */
 
     fluid.defaults("fluid.inlineEdit", {
-        gradeNames: ["fluid.viewComponent", "fluid.undoable"],
+        gradeNames: ["fluid.undoable", "fluid.viewComponent"],
         mergePolicy: {
             "strings.defaultViewText": "defaultViewText"
         },

--- a/src/components/pager/js/Pager.js
+++ b/src/components/pager/js/Pager.js
@@ -215,7 +215,7 @@ var fluid_2_0 = fluid_2_0 || {};
     };
 
     fluid.defaults("fluid.pager.renderedPageList", {
-        gradeNames: ["fluid.rendererComponent", "fluid.pager.pageList"],
+        gradeNames: ["fluid.pager.pageList", "fluid.rendererComponent"],
         rendererOptions: {
             idMap: {},
             cutpoints: [

--- a/src/components/tableOfContents/js/TableOfContents.js
+++ b/src/components/tableOfContents/js/TableOfContents.js
@@ -236,7 +236,7 @@ var fluid_2_0 = fluid_2_0 || {};
     fluid.registerNamespace("fluid.tableOfContents.modelBuilder.headingCalculator");
 
     fluid.tableOfContents.modelBuilder.headingCalculator.getHeadingLevel = function (that, heading) {
-        return $.inArray(heading.tagName, that.options.levels) + 1;
+        return that.options.levels.indexOf(heading.tagName) + 1;
     };
 
     fluid.defaults("fluid.tableOfContents.modelBuilder.headingCalculator", {

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -2593,7 +2593,7 @@ var fluid = fluid || fluid_2_0;
     // unsupported, non-API function
     fluid.parseSelector = function (selstring, strategy) {
         var togo = [];
-        selstring = $.trim(selstring);
+        selstring = selstring.trim();
         //ws-(ss*)[ws/>]
         var regexp = strategy.regexp;
         regexp.lastIndex = 0;

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1583,7 +1583,8 @@ var fluid = fluid || fluid_2_0;
         else {
             gradeNames = fluid.makeArray(gradeNames);
         }
-        fluid.each(gradeNames, function (gradeName) {
+        for (var i = gradeNames.length - 1; i >= 0; -- i) {
+            var gradeName = gradeNames[i];
             if (gradeName && !gs.gradeHash[gradeName]) {
                 var isDynamic = gradeName.charAt(0) === "{";
                 var options = (isDynamic ? null : (raw ? fluid.rawDefaults(gradeName) : fluid.getGradedDefaults(gradeName))) || {};
@@ -1593,8 +1594,8 @@ var fluid = fluid || fluid_2_0;
                 gs.gradeChain.push(gradeName);
                 gs.optionsChain.push(options);
                 var oGradeNames = fluid.makeArray(options.gradeNames);
-                for (var i = 0; i < oGradeNames.length; ++ i) {
-                    var oGradeName = oGradeNames[i];
+                for (var j = oGradeNames.length - 1; j >= 0; -- j) { // from stronger to weaker grades
+                    var oGradeName = oGradeNames[j];
                     if (raw) {
                         resolveGradesImpl(gs, oGradeName);
                     } else {
@@ -1605,7 +1606,7 @@ var fluid = fluid || fluid_2_0;
                     }
                 }
             }
-        });
+        }
         return gs;
     };
 
@@ -1617,8 +1618,9 @@ var fluid = fluid || fluid_2_0;
             gradeHash: {},
             optionsChain: []
         };
-        // stronger grades appear to the left in defaults - dynamic grades are stronger still - FLUID-5085
-        return resolveGradesImpl(gradeStruct, (fluid.makeArray(gradeNames).reverse() || []).concat([defaultName]), true);
+        // stronger grades appear to the right in defaults - dynamic grades are stronger still - FLUID-5085 
+        // we supply these in reverse order to resolveGradesImpl with weak grades at the right
+        return resolveGradesImpl(gradeStruct, [defaultName].concat(fluid.makeArray(gradeNames)), true);
     };
 
     var mergedDefaultsCache = {};
@@ -1644,7 +1646,7 @@ var fluid = fluid || fluid_2_0;
         }
         mergeArgs = [mergePolicy, {}].concat(mergeArgs);
         var mergedDefaults = fluid.merge.apply(null, mergeArgs);
-        mergedDefaults.gradeNames = gradeStruct.gradeChain;
+        mergedDefaults.gradeNames = gradeStruct.gradeChain.reverse();
         return {defaults: mergedDefaults, lastTick: gradeStruct && gradeStruct.lastTick};
     };
 

--- a/src/framework/core/js/FluidView.js
+++ b/src/framework/core/js/FluidView.js
@@ -257,6 +257,11 @@ var fluid_2_0 = fluid_2_0 || {};
      * @param {Object} that the component instance to attach the new DOM Binder to
      */
     fluid.initDomBinder = function (that, selectors) {
+        if (!that.container) {
+            fluid.fail("fluid.initDomBinder called for component with typeName " + that.typeName +
+                " without an initialised container - this has probably resulted from placing \"fluid.viewComponent\" in incorrect position in grade merging order. " +
+                " Make sure to place it to the right of any non-view grades in the gradeNames list to ensure that it overrides properly: resolved gradeNames is ", that.options.gradeNames, " for component ", that);
+        }
         that.dom = fluid.createDomBinder(that.container, selectors || that.options.selectors || {});
         that.locate = that.dom.locate;
         return that.dom;

--- a/src/framework/core/js/jquery.standalone.js
+++ b/src/framework/core/js/jquery.standalone.js
@@ -79,6 +79,10 @@ var fluid = fluid || fluid_2_0;
             for (key in obj) {}
             return key === undefined || hasOwn.call( obj, key );
         },
+        
+        trim: function (str) {
+            return str.trim();
+        },
 
         isEmptyObject: function (obj) {
             var name;

--- a/src/framework/core/js/jquery.standalone.js
+++ b/src/framework/core/js/jquery.standalone.js
@@ -29,15 +29,10 @@ var fluid = fluid || fluid_2_0;
     // Save a reference to some core methods
     var toString = Object.prototype.toString;
     var hasOwn = Object.prototype.hasOwnProperty;
-    var indexOf = Array.prototype.indexOf;
     // Map over jQuery in case of overwrite
     var _jQuery = window.jQuery;
     // Map over the $ in case of overwrite
     var _$ = window.$;
-    // Used for trimming whitespace
-    var trimLeft = /^\s+/,
-        trimRight = /\s+$/,
-        trim = String.prototype.trim;
 
     var jQuery = fluid.jQueryStandalone = {
 
@@ -56,15 +51,6 @@ var fluid = fluid || fluid_2_0;
 
         isArray: Array.isArray || function (obj) {
             return toString.call(obj) === "[object Array]";
-        },
-
-        // Use native String.trim function wherever possible
-        trim: trim ? function( text ) {
-            return text === null ? "" : trim.call( text );
-        } :
-        // Otherwise use our own trimming functionality
-        function( text ) {
-            return text === null ? "" : text.toString().replace( trimLeft, "" ).replace( trimRight, "" );
         },
 
         // A crude way of determining if an object is a window
@@ -100,18 +86,6 @@ var fluid = fluid || fluid_2_0;
                 return false;
             }
             return true;
-        },
-
-        inArray: function (elem, array) {
-            if (indexOf) {
-                return indexOf.call( array, elem );
-            }
-            for (var i = 0, length = array.length; i < length; i++) {
-                if (array[i] === elem) {
-                    return i;
-                }
-            }
-            return -1;
         },
 
         extend: function () {

--- a/src/framework/preferences/js/AuxBuilder.js
+++ b/src/framework/preferences/js/AuxBuilder.js
@@ -370,7 +370,7 @@ var fluid_2_0 = fluid_2_0 || {};
             // TODO: Replace this cumbersome scheme with one based on an extensible lookup to handlers
             var type = "panel";
             // Ignore the subpanels that are only for composing composite panels
-            if (category[type] && $.inArray(prefName, auxSchema.panelsToIgnore) === -1) {
+            if (category[type] && !fluid.contains(auxSchema.panelsToIgnore, prefName)) {
                 fluid.prefs.expandSchemaComponents(auxSchema, "panels", category.type, category[type], fluid.get(indexes, type),
                     fluid.get(elementCommonOptions, type), fluid.get(elementCommonOptions, type + "Model"), mappedDefaults);
             }

--- a/src/framework/preferences/js/Builder.js
+++ b/src/framework/preferences/js/Builder.js
@@ -26,7 +26,7 @@ var fluid_2_0 = fluid_2_0 || {};
             expander: {
                 func: "fluid.prefs.builder.generateGrade",
                 args: ["prefsEditor", "{that}.options.auxSchema.namespace", {
-                    gradeNames: ["fluid.viewComponent", "fluid.prefs.assembler.prefsEd"],
+                    gradeNames: ["fluid.prefs.assembler.prefsEd", "fluid.viewComponent"],
                     componentGrades: "{that}.options.constructedGrades",
                     loaderGrades: "{that}.options.auxSchema.loaderGrades"
                 }]

--- a/src/framework/preferences/js/Enactors.js
+++ b/src/framework/preferences/js/Enactors.js
@@ -72,7 +72,7 @@ var fluid_2_0 = fluid_2_0 || {};
      *******************************************************************************/
 
     fluid.defaults("fluid.prefs.enactor.classSwapper", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor"],
+        gradeNames: ["fluid.prefs.enactor", "fluid.viewComponent"],
         classes: {},  // Must be supplied by implementors
         invokers: {
             clearClasses: {
@@ -128,7 +128,7 @@ var fluid_2_0 = fluid_2_0 || {};
 
     // Note that the implementors need to provide the container for this view component
     fluid.defaults("fluid.prefs.enactor.emphasizeLinks", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor.styleElements"],
+        gradeNames: ["fluid.prefs.enactor.styleElements", "fluid.viewComponent"],
         preferenceMap: {
             "fluid.prefs.emphasizeLinks": {
                 "model.value": "default"
@@ -146,7 +146,7 @@ var fluid_2_0 = fluid_2_0 || {};
 
     // Note that the implementors need to provide the container for this view component
     fluid.defaults("fluid.prefs.enactor.inputsLarger", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor.styleElements"],
+        gradeNames: ["fluid.prefs.enactor.styleElements", "fluid.viewComponent"],
         preferenceMap: {
             "fluid.prefs.inputsLarger": {
                 "model.value": "default"
@@ -216,7 +216,7 @@ var fluid_2_0 = fluid_2_0 || {};
 
     // Note that the implementors need to provide the container for this view component
     fluid.defaults("fluid.prefs.enactor.textSize", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor"],
+        gradeNames: ["fluid.prefs.enactor", "fluid.viewComponent"],
         preferenceMap: {
             "fluid.prefs.textSize": {
                 "model.value": "default"
@@ -272,7 +272,7 @@ var fluid_2_0 = fluid_2_0 || {};
 
     // Note that the implementors need to provide the container for this view component
     fluid.defaults("fluid.prefs.enactor.lineSpace", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor"],
+        gradeNames: ["fluid.prefs.enactor", "fluid.viewComponent"],
         preferenceMap: {
             "fluid.prefs.lineSpace": {
                 "model.value": "default"
@@ -360,7 +360,7 @@ var fluid_2_0 = fluid_2_0 || {};
 
     // Note that the implementors need to provide the container for this view component
     fluid.defaults("fluid.prefs.enactor.tableOfContents", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor"],
+        gradeNames: ["fluid.prefs.enactor", "fluid.viewComponent"],
         preferenceMap: {
             "fluid.prefs.tableOfContents": {
                 "model.toc": "default"

--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -57,7 +57,7 @@ var fluid_2_0 = fluid_2_0 || {};
      ***********************************************/
 
     fluid.defaults("fluid.prefs.panel", {
-        gradeNames: ["fluid.rendererComponent", "fluid.prefs.msgLookup"],
+        gradeNames: ["fluid.prefs.msgLookup", "fluid.rendererComponent"],
         events: {
             onDomBind: null
         },
@@ -187,7 +187,7 @@ var fluid_2_0 = fluid_2_0 || {};
         target = fluid.makeArray(target);
         source = fluid.makeArray(source);
         fluid.each(source, function (selector) {
-            if ($.inArray(selector, target) < 0) {
+            if (target.indexOf(selector) < 0) {
                 target.push(selector);
             }
         });
@@ -491,7 +491,7 @@ var fluid_2_0 = fluid_2_0 || {};
             if (fluid.prefs.compositePanel.isPanel(compOpts.type, compOpts.options)) {
                 var opts = fluid.prefs.compositePanel.prefetchComponentOptions(compOpts.type, compOpts.options);
                 fluid.each(opts.selectors, function (selector, selName) {
-                    if (!opts.selectorsToIgnore || $.inArray(selName, opts.selectorsToIgnore) < 0) {
+                    if (!opts.selectorsToIgnore || opts.selectorsToIgnore.indexOf(selName) < 0) {
                         fluid.set(selectors,  fluid.prefs.compositePanel.rebaseSelectorName(compName, selName), selectors[compName] + " " + selector);
                     }
                 });

--- a/src/framework/preferences/js/PrefsEditor.js
+++ b/src/framework/preferences/js/PrefsEditor.js
@@ -27,7 +27,7 @@ var fluid_2_0 = fluid_2_0 || {};
      * @param {Object} options
      */
     fluid.defaults("fluid.prefs.prefsEditorLoader", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.settingsGetter", "fluid.prefs.initialModel"],
+        gradeNames: ["fluid.prefs.settingsGetter", "fluid.prefs.initialModel", "fluid.viewComponent"],
         defaultLocale: "en",
         members: {
             settings: {
@@ -273,7 +273,7 @@ var fluid_2_0 = fluid_2_0 || {};
      * @param {Object} options
      */
     fluid.defaults("fluid.prefs.prefsEditor", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.settingsGetter", "fluid.prefs.settingsSetter", "fluid.prefs.initialModel"],
+        gradeNames: ["fluid.prefs.settingsGetter", "fluid.prefs.settingsSetter", "fluid.prefs.initialModel", "fluid.viewComponent"],
         invokers: {
             /**
              * Updates the change applier and fires modelChanged on subcomponent fluid.prefs.controls

--- a/src/framework/preferences/js/SelfVoicingEnactor.js
+++ b/src/framework/preferences/js/SelfVoicingEnactor.js
@@ -71,7 +71,7 @@ var fluid_2_0 = fluid_2_0 || {};
      *******************************************************************************/
 
     fluid.defaults("fluid.prefs.enactor.selfVoicing", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor.speak"],
+        gradeNames: ["fluid.prefs.enactor.speak", "fluid.viewComponent"],
         modelListeners: {
             "enabled": {
                 listener: "{that}.handleSelfVoicing",

--- a/tests/component-tests/pager/html/PagedTable-test.html
+++ b/tests/component-tests/pager/html/PagedTable-test.html
@@ -53,7 +53,7 @@
     <div id="qunit-fixture">
         <div id="gradebook">
             <ul id="pager-top" class="flc-pager-top">
-                 <li id="top1" class="flc-pager-pageLink"><a href="#">1</a></li>
+                <li id="top1" class="flc-pager-pageLink"><a href="#">1</a></li>
                 <li id="top2" class="flc-pager-pageLink"><a href="#">2</a></li>
                 <li id="top3" class="flc-pager-pageLink"><a href="#">3</a></li>
                 <li id="previous-top" class="flc-pager-previous">&lt; previous</li>

--- a/tests/component-tests/pager/js/PagedTableTests.js
+++ b/tests/component-tests/pager/js/PagedTableTests.js
@@ -166,7 +166,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             sequence.push({
                 event: "{trackTooltips}.events.notifyFocusChange",
                 listener: function () {
-                    fluid.tests.tooltip.assertVisible("The contents of the tooltip should be set", pager, targetIds, null, function (tooltip) {
+                    fluid.tests.tooltip.assertVisible(message, pager, targetIds, null, function (tooltip) {
                         jqUnit.assertNode("The contents of the tooltip should be set", tooltipContents[0], $("b", tooltip));
                     });
                 }

--- a/tests/component-tests/uploader/js/ErrorPanelTests.js
+++ b/tests/component-tests/uploader/js/ErrorPanelTests.js
@@ -52,7 +52,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             jqUnit.assertEquals("The section instance should have " + expectedNumFiles + " files in its model.",
                 expectedNumFiles, section.model.files.length);
             jqUnit.assertEquals("The newly added file should be at index " + expectedIdx + " in the section's model.",
-                expectedIdx, $.inArray(file.name, section.model.files));
+                expectedIdx, section.model.files.indexOf(file.name));
         };
 
         jqUnit.test("errorPanel.section.addFile()", function () {

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -621,6 +621,38 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         };
         jqUnit.assertLeftHand("Correctly merged options", expected, that.uiEnhancer.options);
     });
+    
+    /** FLUID-5743 - Arabic Grades **/
+    
+    fluid.defaults("fluid.tests.componentOne", {
+        gradeNames: "fluid.component",
+        option1: "TEST1",
+        option3: "TEST1"
+    });
+
+    fluid.defaults("fluid.tests.componentTwo", {
+        gradeNames: "fluid.component",
+        option1: "TEST2",
+        option2: "TEST2"
+    });
+
+    fluid.defaults("fluid.tests.combinedComponent", {
+        gradeNames: ["fluid.tests.componentOne", "fluid.tests.componentTwo"]
+    });
+    
+    jqUnit.test("FLUID-5743 Arabic grade merging", function () {
+        var merged = fluid.tests.combinedComponent();
+        var expected = {
+            option1: "TEST2",
+            option2: "TEST2",
+            option3: "TEST1"
+        };
+        jqUnit.assertLeftHand("Merged grades in correct left-to-right order", expected, merged.options);
+        var merged2 = fluid.tests.componentOne({
+            gradeNames: "fluid.tests.componentTwo"
+        });
+        jqUnit.assertLeftHand("Merged grades in correct left-to-right order with direct grade arguments", expected, merged2.options);
+    });
 
     /** Listener merging tests **/
 
@@ -2371,7 +2403,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 gradeNames: ["fluid.tests.defaultTemplateLoader"]
             }
         });
-        var expectedGrades = ["fluid.tests.defaultTemplateLoader", "fluid.component"];
+        var expectedGrades = ["fluid.component", "fluid.tests.defaultTemplateLoader"];
 
         jqUnit.assertDeepEq("The option grades are merged into the target component", expectedGrades, prefsEditor.templateLoader.options.gradeNames);
         jqUnit.assertEquals("The user option from the grade component is transmitted", 10, prefsEditor.templateLoader.options.userOption);

--- a/tests/framework-tests/enhancement/js/ContextAwarenessTests.js
+++ b/tests/framework-tests/enhancement/js/ContextAwarenessTests.js
@@ -152,7 +152,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var that = fluid.tests.contextAware.multiple();
         var indexFood = that.options.gradeNames.indexOf("food.carrots");
         var indexUrgency = that.options.gradeNames.indexOf("urgency.high");
-        jqUnit.assertTrue("Context awareness gradenames must appear in priority order ", indexFood !== -1 && indexUrgency !== -1 && indexUrgency > indexFood);
+        jqUnit.assertTrue("Context awareness gradenames must appear in priority order ", indexFood !== -1 && indexUrgency !== -1 && indexUrgency < indexFood);
     });
     
     fluid.tests.contextAware.isResolvable = function (typeName) {

--- a/tests/framework-tests/preferences/js/AuxBuilderTests.js
+++ b/tests/framework-tests/preferences/js/AuxBuilderTests.js
@@ -1149,7 +1149,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
 
     fluid.defaults("fluid.prefs.enactor.subPanel2", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor"],
+        gradeNames: ["fluid.prefs.enactor", "fluid.viewComponent"],
         preferenceMap: {
             "fluid.prefs.subPanel2": {
                 "model.value": "default"
@@ -1432,7 +1432,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
 
     fluid.defaults("fluid.prefs.enactor.subPanel4", {
-        gradeNames: ["fluid.viewComponent", "fluid.prefs.enactor"],
+        gradeNames: ["fluid.prefs.enactor", "fluid.viewComponent"],
         preferenceMap: {
             "fluid.prefs.subPanel4": {
                 "model.value": "default"

--- a/tests/framework-tests/preferences/js/BuilderTests.js
+++ b/tests/framework-tests/preferences/js/BuilderTests.js
@@ -21,7 +21,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertNotUndefined("The grade should be created", grade);
 
         fluid.each(grades, function (baseGrade) {
-            jqUnit.assertTrue(gradeName + " should have the base grade '" + baseGrade + "'", $.inArray(baseGrade, grade.gradeNames) >= 0);
+            jqUnit.assertTrue(gradeName + " should have the base grade '" + baseGrade + "'", grade.gradeNames.indexOf(baseGrade) >= 0);
         });
     };
 
@@ -30,7 +30,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertNotUndefined("The grade should be created", grade);
 
         fluid.each(grades, function (baseGrade) {
-            jqUnit.assertFalse(gradeName + " should not have the base grade '" + baseGrade + "'", $.inArray(baseGrade, grade.gradeNames) >= 0);
+            jqUnit.assertFalse(gradeName + " should not have the base grade '" + baseGrade + "'", grade.gradeNames.indexOf(baseGrade) >= 0);
         });
     };
 

--- a/tests/framework-tests/preferences/js/PanelTestUtils.js
+++ b/tests/framework-tests/preferences/js/PanelTestUtils.js
@@ -17,7 +17,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     fluid.registerNamespace("fluid.tests.panels.utils");
 
     fluid.defaults("fluid.tests.panels.utils.defaultTestPanel", {
-        gradeNames: ["fluid.component"],
         strings: {},
         testMessages: {},
         parentBundle: {

--- a/tests/framework-tests/preferences/js/PrefsEditorTests.js
+++ b/tests/framework-tests/preferences/js/PrefsEditorTests.js
@@ -119,7 +119,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     fluid.tests.prefs.messagePrefix = "../../../../src/framework/preferences/messages";
 
     fluid.defaults("fluid.tests.prefs.commonLoader", {
-        gradeNames: ["fluid.prefs.prefsEditorLoader", "fluid.prefs.initialModel.starter"],
+        gradeNames: ["fluid.prefs.initialModel.starter", "fluid.prefs.prefsEditorLoader"],
         terms: {
             templatePrefix: fluid.tests.prefs.templatePrefix,
             messagePrefix: fluid.tests.prefs.messagePrefix

--- a/tests/test-core/jqUnit/js/jqUnit.js
+++ b/tests/test-core/jqUnit/js/jqUnit.js
@@ -239,14 +239,14 @@ var jqUnit = jqUnit || {};
         jqUnit.assertDeepEq(message, expected2, actual2);
     };
 
-    /** Assert that the actual value object is a subset (considered in terms of shallow key coincidence) of the
-     * expected value object (this method is the one that will be most often used in practice) **/
+    /** Assert that the actual value object is a superset (considered in terms of shallow key coincidence) of the
+     * expected value object (this method is the one that will be most often used in practice). "Left hand" (expected) is a subset of actual. **/
 
     jqUnit.assertLeftHand = function (message, expected, actual) {
         jqUnit.assertDeepEq(message, expected, fluid.filterKeys(actual, fluid.keys(expected)));
     };
 
-    /** Assert that the actual value object is a superset of the expected value object **/
+    /** Assert that the actual value object is a subset of the expected value object **/
 
     jqUnit.assertRightHand = function (message, expected, actual) {
         jqUnit.assertDeepEq(message, fluid.filterKeys(expected, fluid.keys(actual)), actual);


### PR DESCRIPTION
overriding order is now left to right. Also eliminated $.inArray from our jQuery standalone, in favour of plain Array.indexOf in environments where only an array is expected (or fluid.contains which has always worked). Corrected comments for assertLeftHand/assertRightHand which exhibit a similar lack of ability to distinguish things which either are larger or smaller than another thing or lie to the left or right of it.

@colinbdclark  - one for you