### PR TITLE
FLUID-5755: Fix to failed detection of non-plain objects in 2nd branch

### DIFF
--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1818,8 +1818,10 @@ var fluid = fluid || fluid_2_0;
     };
 
     // Cheapskate implementation which avoids dependency on DataBinding.js
+    // TODO: This is apparently still used by the core merging algorithm, for reasons we no longer understand, even though
+    // it has long been disused by DataBinding itself
     fluid.model.mergeModel = function (target, source) {
-        if (!fluid.isPrimitive(target)) {
+        if (fluid.isPlainObject(target)) {
             var copySource = fluid.copy(source);
             $.extend(true, source, target);
             $.extend(true, source, copySource);

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -220,6 +220,24 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var result = that.events.event.fire(false);
         jqUnit.assertUndefined("Event returned to nonpreventable through merge", result);
     });
+    
+    /** FLUID-5755 - another "exotic types" test - this time a native array **/
+    
+    fluid.defaults("fluid.tests.componentWithTypedArrayOption", {
+        gradeNames: "fluid.component",
+        buffer: new Float32Array([1, 1, 1, 1])
+    });
+
+    jqUnit.test("FLUID-5755: Typed Array Component Merging", function () {
+        var c = fluid.tests.componentWithTypedArrayOption();
+        jqUnit.assertDeepEq("The component's typed array should be set to the default value.", new Float32Array([1, 1, 1, 1]),
+            c.options.buffer);
+
+        c = fluid.tests.componentWithTypedArrayOption({
+            buffer: new Float32Array([2, 2, 2, 2])
+        });
+        jqUnit.assertDeepEq("The component's typed array should have been overriden.", new Float32Array([2, 2, 2, 2]), c.options.buffer);
+    });
 
     /** FLUID-5239 **/
 


### PR DESCRIPTION
of mergeOneImpl - this logic all needs revisiting for FLUID-4982

Thanks for the report and test case, @colinbdclark 