### PR TITLE
FLUID-5800: Basics for fixing "baseless merge" issues

### DIFF
--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1821,6 +1821,9 @@ var fluid = fluid || fluid_2_0_0;
     // it has long been disused by DataBinding itself
     fluid.model.mergeModel = function (target, source) {
         if (fluid.isPlainObject(target)) {
+            if (source === fluid.NO_VALUE) {
+                console.log("NOW");
+            }
             var copySource = fluid.copy(source);
             $.extend(true, source, target);
             $.extend(true, source, copySource);

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -349,10 +349,6 @@ var fluid = fluid || fluid_2_0_0;
         return obj && typeof (obj.nodeType) === "number";
     };
 
-    fluid.isDOMish = function (obj) {
-        return fluid.isDOMNode(obj) || obj.jquery;
-    };
-
     fluid.isComponent = function (obj) {
         return obj && obj.constructor === fluid.componentConstructor;
     };
@@ -376,7 +372,7 @@ var fluid = fluid || fluid_2_0_0;
     };
 
     fluid.isUncopyable = function (totest) {
-        return fluid.isPrimitive(totest) || fluid.isDOMish(totest) || !fluid.isPlainObject(totest);
+        return fluid.isPrimitive(totest) || !fluid.isPlainObject(totest);
     };
 
     fluid.copyRecurse = function (tocopy, segs) {
@@ -1816,21 +1812,6 @@ var fluid = fluid || fluid_2_0_0;
         fluid.setGlobalValue(componentName, creator);
     };
 
-    // Cheapskate implementation which avoids dependency on DataBinding.js
-    // TODO: This is apparently still used by the core merging algorithm, for reasons we no longer understand, even though
-    // it has long been disused by DataBinding itself
-    fluid.model.mergeModel = function (target, source) {
-        if (fluid.isPlainObject(target)) {
-            if (source === fluid.NO_VALUE) {
-                console.log("NOW");
-            }
-            var copySource = fluid.copy(source);
-            $.extend(true, source, target);
-            $.extend(true, source, copySource);
-        }
-        return source;
-    };
-
     var emptyPolicy = {};
     // unsupported, NON-API function
     fluid.derefMergePolicy = function (policy) {
@@ -1887,8 +1868,7 @@ var fluid = fluid || fluid_2_0_0;
         var primitiveTarget = fluid.isPrimitive(thisTarget);
 
         if (thisSource !== undefined) {
-            if (!newPolicy.func && thisSource !== null && fluid.isPlainObject(thisSource) &&
-                    !fluid.isDOMish(thisSource) && thisSource !== fluid.VALUE && !newPolicy.nomerge) {
+            if (!newPolicy.func && thisSource !== null && fluid.isPlainObject(thisSource) && !newPolicy.nomerge) {
                 if (primitiveTarget) {
                     togo = thisTarget = fluid.freshContainer(thisSource);
                 }
@@ -1899,7 +1879,7 @@ var fluid = fluid || fluid_2_0_0;
                 if (newPolicy.func) {
                     togo = newPolicy.func.call(null, thisTarget, thisSource, segs[i - 1], segs, i); // NB - change in this mostly unused argument
                 } else {
-                    togo = fluid.isValue(thisTarget) ? fluid.model.mergeModel(thisTarget, thisSource) : thisSource;
+                    togo = thisSource;
                 }
             }
         }

--- a/src/framework/core/js/FluidIoC.js
+++ b/src/framework/core/js/FluidIoC.js
@@ -1973,7 +1973,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     fluid.fetchExpandChildren = function (target, i, segs, source, mergePolicy, options) {
         if (source.expander) { // possible expander at top level
             var expanded = fluid.expandExpander(target, source, options);
-            if (fluid.isPrimitive(expanded) || fluid.isDOMish(expanded) || !fluid.isPlainObject(expanded) || (fluid.isArrayable(expanded) ^ fluid.isArrayable(target))) {
+            if (fluid.isPrimitive(expanded) || !fluid.isPlainObject(expanded) || (fluid.isArrayable(expanded) ^ fluid.isArrayable(target))) {
                 return expanded;
             }
             else { // make an attempt to preserve the root reference if possible

--- a/tests/framework-tests/core/all-tests.html
+++ b/tests/framework-tests/core/all-tests.html
@@ -28,7 +28,7 @@
             "./html/FluidIoC-test.html",
             "./html/FluidIoCStandalone-test.html",
             "./html/FluidIoCView-test.html",
-            "./html/WebWorkerTest-test.html"
+            "./html/WebWorker-test.html"
         ]);
     </script>
 </head>

--- a/tests/framework-tests/core/html/FluidIoC-test.html
+++ b/tests/framework-tests/core/html/FluidIoC-test.html
@@ -1,4 +1,4 @@
-s<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/tests/framework-tests/core/js/DataBindingTests.js
+++ b/tests/framework-tests/core/js/DataBindingTests.js
@@ -138,31 +138,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertEquals("Queried resolved and strategised value", 4, resolved2);
     });
 
-    // NB - this implementation is in Fluid.js, but test is grouped with the one above
-    jqUnit.test("FLUID 4585 test: mergeModel with nested model", function () {
-        var defaults = {
-            twoLevels: {
-                one: 1,
-                two: 2,
-                three: 3
-            }
-        };
-        var options = {
-            twoLevels: {
-                two: "two"
-            }
-        };
-        var expected = {
-            twoLevels: {
-                one: 1,
-                two: "two",
-                three: 3
-            }
-        };
-        var result = fluid.model.mergeModel(defaults, options);
-        jqUnit.assertDeepEq("Model should be properly merged", expected, result);
-    });
-
     jqUnit.test("FLUID-3729 test: application into nothing", function () {
         var model = {};
         var holder = {model: model};

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -740,11 +740,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.expect(2);
 
         var that = fluid.tests.FLUID5800();
-        console.log(that);
         jqUnit.assertValue("Successfully constructed instance (basic test)", that);
         that.events.onUserToken.fire(that);
         jqUnit.assertEquals("Listeners have merged correctly", 3, that.eventCount);
-        // Failure IS observable through this route, but it is not economic to fix this without rewriting the entire default merge workflow - 
+        // Failure IS observable through this route, but it is not economic to fix this without rewriting the entire default merge workflow -
         // See FLUID-5800 JIRA comment
         // var midDefaults = fluid.defaults("fluid.tests.FLUID5800mid");
         // jqUnit.assertEquals("Listeners were designated correctly in abstract grade", 3, midDefaults.listeners.onUserToken.length);

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -708,23 +708,32 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         listeners: {
             onUserToken: [{
-               priority: "first",
-               listener: "gpii.flowManager.setUserToken",
-               args: ["{that}", "{arguments}.0"]
+                listener: "fluid.identity",
+                args: ["{that}", "{arguments}.0"]
             }, "{that}.getPreferences"]
+        },
+        invokers: {
+            getPreferences: "fluid.identity",
+            getDeviceContext: "fluid.identity"
+        }
+    });
+
+    fluid.defaults("fluid.tests.FLUID5800mid", { // this used to throw on registration
+        gradeNames: "fluid.tests.FLUID5800base",
+        listeners: {
+            onUserToken: "{that}.getDeviceContext"
         }
     });
     
+    fluid.defaults("fluid.tests.FLUID5800", {
+        gradeNames: ["fluid.component", "fluid.tests.FLUID5800mid"]
+    });
+    
     jqUnit.test("FLUID-5800 merge corruption", function () {
-        jqUnit.expect(1); // this used to throw on registration
-        fluid.defaults("fluid.tests.FLUID5800mid", {
-            gradeNames: "fluid.tests.FLUID5800base",
-            listeners: {
-                onUserToken: "{that}.getDeviceContext"
-            }
-        });
-        var def = fluid.defaults("fluid.tests.FLUID5800mid");
-        console.log(def);
+        jqUnit.expect(1);
+
+        var that = fluid.tests.FLUID5800();
+        jqUnit.assertValue("Successfully constructed instance (basic test)", that);
     });
 
     /** Listener merging tests **/

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -701,6 +701,31 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         });
         jqUnit.assertLeftHand("Merged grades in correct left-to-right order with direct grade arguments", expected, merged2.options);
     });
+    
+    fluid.defaults("fluid.tests.FLUID5800base", {
+        events: {
+            onUserToken: null
+        },
+        listeners: {
+            onUserToken: [{
+               priority: "first",
+               listener: "gpii.flowManager.setUserToken",
+               args: ["{that}", "{arguments}.0"]
+            }, "{that}.getPreferences"]
+        }
+    });
+    
+    jqUnit.test("FLUID-5800 merge corruption", function () {
+        jqUnit.expect(1); // this used to throw on registration
+        fluid.defaults("fluid.tests.FLUID5800mid", {
+            gradeNames: "fluid.tests.FLUID5800base",
+            listeners: {
+                onUserToken: "{that}.getDeviceContext"
+            }
+        });
+        var def = fluid.defaults("fluid.tests.FLUID5800mid");
+        console.log(def);
+    });
 
     /** Listener merging tests **/
 

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -706,17 +706,24 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         events: {
             onUserToken: null
         },
+        members: {
+            eventCount: 0
+        },
         listeners: {
             onUserToken: [{
-                listener: "fluid.identity",
+                listener: "fluid.tests.fluid5800count",
                 args: ["{that}", "{arguments}.0"]
             }, "{that}.getPreferences"]
         },
         invokers: {
-            getPreferences: "fluid.identity",
-            getDeviceContext: "fluid.identity"
+            getPreferences: "fluid.tests.fluid5800count",
+            getDeviceContext: "fluid.tests.fluid5800count"
         }
     });
+    
+    fluid.tests.fluid5800count = function (that) {
+        ++ that.eventCount;
+    };
 
     fluid.defaults("fluid.tests.FLUID5800mid", { // this used to throw on registration
         gradeNames: "fluid.tests.FLUID5800base",
@@ -730,10 +737,17 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
     
     jqUnit.test("FLUID-5800 merge corruption", function () {
-        jqUnit.expect(1);
+        jqUnit.expect(2);
 
         var that = fluid.tests.FLUID5800();
+        console.log(that);
         jqUnit.assertValue("Successfully constructed instance (basic test)", that);
+        that.events.onUserToken.fire(that);
+        jqUnit.assertEquals("Listeners have merged correctly", 3, that.eventCount);
+        // Failure IS observable through this route, but it is not economic to fix this without rewriting the entire default merge workflow - 
+        // See FLUID-5800 JIRA comment
+        // var midDefaults = fluid.defaults("fluid.tests.FLUID5800mid");
+        // jqUnit.assertEquals("Listeners were designated correctly in abstract grade", 3, midDefaults.listeners.onUserToken.length);
     });
 
     /** Listener merging tests **/


### PR DESCRIPTION
The configuration at least no longer throws on registration, even if merged result is still incorrect. However, the removal of the cognitively lost "mergeModel" and other cruft from the mergeOneImpl loop is highly worthwhile since this loop is very hot as well as poorly understood. Also able to remove fluid.isDOMish since the new fluid.isPlainObject is powerful enough to reject markers as well as anything DOMlike even in IE9 (which is itself 1 revision below our minimum support).
These were never entered into our documentation as inherently suspicious.