### PR TITLE
FLUID-5759: A bug fix for the auxiliary schema builder

### DIFF
--- a/src/framework/preferences/js/AuxBuilder.js
+++ b/src/framework/preferences/js/AuxBuilder.js
@@ -248,7 +248,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             // 2. an object that describes what panels should be always rendered,
             //    and what panels should be rendered when a preference is turned on
             // The loop below is only needed for processing the latter.
-            if (!fluid.isPrimitive(thisCompositeOptions.panels) && !fluid.isArrayable(thisCompositeOptions.panels)) {
+            if (fluid.isPlainObject(thisCompositeOptions.panels) && !fluid.isArrayable(thisCompositeOptions.panels)) {
                 fluid.each(thisCompositeOptions.panels, function (subpanelArray, pref) {
                     subPanelList = subPanelList.concat(subpanelArray);
                     if (pref !== "always") {

--- a/src/framework/preferences/js/AuxBuilder.js
+++ b/src/framework/preferences/js/AuxBuilder.js
@@ -243,9 +243,12 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             var subPanels = {};
             var subPanelRenderOn = {};
 
-            // panels can contain an array of always on panels, or an object
-            // describing which panels are always and which are initialized by a preference value
-            if (!fluid.isPrimitive(thisCompositeOptions.panels)) {
+            // thisCompositeOptions.panels can be in two forms:
+            // 1. an array of names of panels that should always be rendered;
+            // 2. an object that describes what panels should be always rendered,
+            //    and what panels should be rendered when a preference is turned on
+            // The loop below is only needed for processing the latter.
+            if (!fluid.isPrimitive(thisCompositeOptions.panels) && !fluid.isArrayable(thisCompositeOptions.panels)) {
                 fluid.each(thisCompositeOptions.panels, function (subpanelArray, pref) {
                     subPanelList = subPanelList.concat(subpanelArray);
                     if (pref !== "always") {

--- a/tests/framework-tests/preferences/js/AuxBuilderTests.js
+++ b/tests/framework-tests/preferences/js/AuxBuilderTests.js
@@ -1202,11 +1202,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "template": "%templatePrefix/combinedBoth.html",
                 "message": "%messagePrefix/combinedBoth.json",
                 "type": "fluid.prefs.panel.combinedBoth",
-                "panels": ["subPanel1", "subPanel2"],
+                "panels": ["x", "y"],
                 "extraOption": 1
             }
         },
-        "subPanel1": {
+        "x": {
             "type": "fluid.prefs.subPanel1",
             "enactor": {
                 "type": "fluid.prefs.enactor.subPanel1",
@@ -1220,7 +1220,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "subPanelOption": 1
             }
         },
-        "subPanel2": {
+        "y": {
             "type": "fluid.prefs.subPanel2",
             "enactor": {
                 "type": "fluid.prefs.enactor.subPanel2",
@@ -1250,11 +1250,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "template": "%templatePrefix/combinedBoth.html",
                 "message": "%messagePrefix/combinedBoth.json",
                 "type": "fluid.prefs.panel.combinedBoth",
-                "panels": ["subPanel1", "subPanel2"],
+                "panels": ["x", "y"],
                 "extraOption": 1
             }
         },
-        "subPanel1": {
+        "x": {
             "type": "fluid.prefs.subPanel1",
             "enactor": {
                 "type": "fluid.prefs.enactor.subPanel1",
@@ -1268,7 +1268,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "subPanelOption": 1
             }
         },
-        "subPanel2": {
+        "y": {
             "type": "fluid.prefs.subPanel2",
             "enactor": {
                 "type": "fluid.prefs.enactor.subPanel2",
@@ -1353,7 +1353,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }
             }
         },
-        panelsToIgnore: ["subPanel1", "subPanel2"]
+        panelsToIgnore: ["x", "y"]
     };
 
     fluid.tests.auxSchema.expandedCompositeFull = $.extend(true, {}, fluid.tests.auxSchema.expandedComposite, {
@@ -1619,7 +1619,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }
             }
         },
-        panelsToIgnore: ["subPanel1", "subPanel2", "subPanel3", "subPanel4"]
+        panelsToIgnore: ["x", "y", "subPanel3", "subPanel4"]
     };
 
     fluid.tests.auxSchema.multiCompositePanelSchema = $.extend(true, {}, fluid.tests.auxSchema.compositePanelSchema, fluid.tests.auxSchema.anotherCompositePanelSchema);


### PR DESCRIPTION
When more than one panel names defined in the aux schema use single letters, and these panels compose a composite panel using the expression of "panels: ["x", "y", ...], the builder mistakenly sets the renderOnPrefs option to true for some panels even though all panels should always be rendered.

@jobara, can you review this pull request? Thanks.