### PR TITLE
FLUID-5730: removed qunit-fixture element

### DIFF
--- a/tests/framework-tests/preferences/html/SelfVoicingEnactor-test.html
+++ b/tests/framework-tests/preferences/html/SelfVoicingEnactor-test.html
@@ -45,11 +45,9 @@
         <div id="qunit-testrunner-toolbar"></div>
         <h2 id="qunit-userAgent"></h2>
         <ol id="qunit-tests"></ol>
-        <div id="qunit-fixture">
-            <p class="flc-selfVoicing">
-                Reading text from DOM
-                <img src="" alt="no image" />
-            </p>
-        </div>
+        <p class="flc-selfVoicing" style="display: none">
+            Reading text from DOM
+            <img src="" alt="no image" />
+        </p>
     </body>
 </html>

--- a/tests/framework-tests/preferences/js/SelfVoicingEnactorTests.js
+++ b/tests/framework-tests/preferences/js/SelfVoicingEnactorTests.js
@@ -139,6 +139,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     fluid.defaults("fluid.tests.selfVoicingTests", {
         gradeNames: ["fluid.test.testEnvironment"],
+        markupFixture: ".flc-selfVoicing",
         components: {
             selfVoicing: {
                 type: "fluid.tests.prefs.enactor.selfVoicingEnactor",


### PR DESCRIPTION
The test markup had been inside a qunit-fixture; however, qunit was clearing out
the markup causing the test component to initialize without all of the markup it
was expecting. This was only an issue in IE. I've removed the fixture as there
is only one test that uses the markup.

https://issues.fluidproject.org/browse/FLUID-5730