### PR TITLE
FLUID-2845, FLUID-5669: Improved the binaryOp model transformation

### DIFF
--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -177,7 +177,7 @@ var fluid = fluid || fluid_2_0_0;
         "/": function (a, b) { return a / b; },
         "%": function (a, b) { return a % b; },
         "&&": function (a, b) { return a && b; },
-        "||": function (a, b) { return !!(a || b); } // FLUID-5845 ensure true/false is returned
+        "||": function (a, b) { return a || b; }
     };
 
     fluid.transforms.binaryOp = function (inputs, transformSpec, transformer) {

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -165,8 +165,8 @@ var fluid = fluid || fluid_2_0_0;
     });
 
     fluid.transforms.binaryLookup = {
-        "===": function (a, b) { return a === b; },
-        "!==": function (a, b) { return a !== b; },
+        "===": function (a, b) { return fluid.model.isSameValue(a, b); },
+        "!==": function (a, b) { return !fluid.model.isSameValue(a, b); },
         "<=": function (a, b) { return a <= b; },
         "<": function (a, b) { return a < b; },
         ">=": function (a, b) { return a >= b; },
@@ -177,7 +177,7 @@ var fluid = fluid || fluid_2_0_0;
         "/": function (a, b) { return a / b; },
         "%": function (a, b) { return a % b; },
         "&&": function (a, b) { return a && b; },
-        "||": function (a, b) { return a || b; }
+        "||": function (a, b) { return !!(a || b); } // FLUID-5845 ensure true/false is returned
     };
 
     fluid.transforms.binaryOp = function (inputs, transformSpec, transformer) {

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -383,12 +383,48 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         expected: true
     }, {
+        message: "binaryOp - === (FLUID-5669)",
+        transform: {
+            type: "fluid.transforms.binaryOp",
+            left: NaN,
+            operator: "===",
+            right: NaN
+        },
+        expected: true
+    }, {
+        message: "binaryOp - === (FLUID-5669)",
+        transform: {
+            type: "fluid.transforms.binaryOp",
+            left: 0.20000000000000004,
+            operator: "===",
+            right: 0.2
+        },
+        expected: true
+    }, {
         message: "binaryOp - !==",
         transform: {
             type: "fluid.transforms.binaryOp",
             left: 100,
             operator: "!==",
             rightPath: "hundred"
+        },
+        expected: false
+    }, {
+        message: "binaryOp - !== (FLUID-5669)",
+        transform: {
+            type: "fluid.transforms.binaryOp",
+            left: NaN,
+            operator: "!==",
+            right: NaN
+        },
+        expected: false
+    }, {
+        message: "binaryOp - !== (FLUID-5669)",
+        transform: {
+            type: "fluid.transforms.binaryOp",
+            left: 0.20000000000000004,
+            operator: "!==",
+            right: 0.2
         },
         expected: false
     }, {
@@ -488,6 +524,15 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             left: false,
             operator: "||",
             rightPath: "catsAreDecent"
+        },
+        expected: true
+    }, {
+        message: "binaryOp - || (FLUID-5845)",
+        transform: {
+            type: "fluid.transforms.binaryOp",
+            left: "false",
+            operator: "||",
+            right: false
         },
         expected: true
     }, {

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -527,15 +527,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         expected: true
     }, {
-        message: "binaryOp - || (FLUID-5845)",
-        transform: {
-            type: "fluid.transforms.binaryOp",
-            left: "false",
-            operator: "||",
-            right: false
-        },
-        expected: true
-    }, {
         message: "binaryOp - invalid operator",
         transform: {
             type: "fluid.transforms.binaryOp",


### PR DESCRIPTION
* Now uses fluid.model.isSameValue form comparison instead of === and !==
* the logical or (||) operator now always returns either true or false as opposed to returning the first value in case of false (which javascript does).
* Unit tests for new features