### PR TITLE
GPII 1550: Adds changes required for automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 products/
 node_modules/
 src/framework/preferences/css/*.css
+.bundle/
+.vagrant/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,6 +180,11 @@ module.exports = function(grunt) {
         },
         jsonlint: {
             all: ["src/**/*.json", "tests/**/*.json", "demos/**/*.json", "examples/**/*.json"]
+        },
+        shell: {
+            runTests: {
+                command: "vagrant ssh -c 'cd /home/vagrant/sync/; DISPLAY=:0 testem ci --file tests/testem.json'"
+            }
         }
     });
 
@@ -193,6 +198,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-jsonlint");
     grunt.loadNpmTasks("grunt-modulefiles");
     grunt.loadNpmTasks("grunt-contrib-stylus");
+    grunt.loadNpmTasks('grunt-shell');
 
     // Custom tasks:
 
@@ -238,4 +244,6 @@ module.exports = function(grunt) {
     grunt.registerTask("custom", ["build:custom"]);
 
     grunt.registerTask("lint", "Apply jshint and jsonlint", ["jshint", "jsonlint"]);
+
+    grunt.registerTask("tests", "Run tests", ["shell:runTests"]);
 };

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ To test a build it is advisable to serve the contents of this directory using a 
 
 Automated tests can be run by first [installing Testem](https://github.com/testem/testem/#installation) and then running ``testem ci --file tests/testem.json`` in this directory. Any browsers that Testem detects on your platform will be launched with test results returned in the [TAP](https://testanything.org/) format. You can use the ``testem launchers`` command to get a list of available browsers.
 
+A [Fedora VM](https://github.com/idi-ops/packer-fedora) can be automatically created using tools provided by the [Prosperity4All Quality Infrastructure](https://github.com/GPII/qi-development-environments/). Please ensure the [requirements](https://github.com/GPII/qi-development-environments/#requirements) have been met. The ``vagrant up`` command can then be used to provision a new VM. Typing ``grunt tests`` will run the Infusion tests using Testem in the VM and report the results in your console.
+
 ### Modules ###
 
 #### Framework Modules ####

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ By default, custom packages are given a name with the form _infusion-custom-<ver
 
     grunt custom --name="myPackage"    # this produces infusion-myPackage.js
 
+### How Do I Run Tests? ###
+
+To test a build it is advisable to serve the contents of this directory using a web server and then opening [tests/all-tests.html](https://github.com/fluid-project/infusion/blob/master/tests/all-tests.html) in a web browser. The browser will need to remain in the foreground because some of the tests require window focus. 
+
+Automated tests can be run by first [installing Testem](https://github.com/testem/testem/#installation) and then running ``testem ci --file tests/testem.json`` in this directory. Any browsers that Testem detects on your platform will be launched with test results returned in the [TAP](https://testanything.org/) format. You can use the ``testem launchers`` command to get a list of available browsers.
+
 ### Modules ###
 
 #### Framework Modules ####

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Please note that any browsers launched will need to remain in the foreground bec
 
 If installing Testem is not preferable, a [Fedora VM](https://github.com/idi-ops/packer-fedora) can be automatically created using tools provided by the [Prosperity4All Quality Infrastructure](https://github.com/GPII/qi-development-environments/). After meeting the [QI development VM requirements](https://github.com/GPII/qi-development-environments/#requirements) the ``vagrant up`` command can be used to launch a VM which will contain Testem and several browsers. Typing ``grunt tests`` will run the Infusion tests in the VM and the results will be displayed in your terminal.
 
+When this VM is first created Chrome and Firefox will be upgraded to the latest versions available in the Fedora and Google package repositories. The ``vagrant provision`` command can be used at a later time to trigger the browser upgrade and general VM provisioning mechanism.
+
 ### Modules ###
 
 #### Framework Modules ####

--- a/README.md
+++ b/README.md
@@ -107,11 +107,17 @@ By default, custom packages are given a name with the form _infusion-custom-<ver
 
 ### How Do I Run Tests? ###
 
-To test a build it is advisable to serve the contents of this directory using a web server and then opening [tests/all-tests.html](https://github.com/fluid-project/infusion/blob/master/tests/all-tests.html) in a web browser. The browser will need to remain in the foreground because some of the tests require window focus. 
+There are two options available for running tests. The first option involves using browsers installed on your computer and the second uses browsers available in a VM. 
 
-Automated tests can be run by first [installing Testem](https://github.com/testem/testem/#installation) and then running ``testem ci --file tests/testem.json`` in this directory. Any browsers that Testem detects on your platform will be launched with test results returned in the [TAP](https://testanything.org/) format. You can use the ``testem launchers`` command to get a list of available browsers.
+#### Run Tests Using Browsers Installed On Your Computer ####
 
-A [Fedora VM](https://github.com/idi-ops/packer-fedora) can be automatically created using tools provided by the [Prosperity4All Quality Infrastructure](https://github.com/GPII/qi-development-environments/). Please ensure the [requirements](https://github.com/GPII/qi-development-environments/#requirements) have been met. The ``vagrant up`` command can then be used to provision a new VM. Typing ``grunt tests`` will run the Infusion tests using Testem in the VM and report the results in your console.
+Using this option requires the installation of [Testem](https://github.com/testem/testem/#installation) and then running ``testem ci --file tests/testem.json`` in this directory. Any browsers that Testem finds on your platform will be launched sequentially with each browser running the full Infusion test suite. The results will be returned in your terminal in the [TAP](https://testanything.org/) format. You can use the ``testem launchers`` command to get a list of available browsers. 
+
+Please note that any browsers launched will need to remain in the foreground because some of the tests require window focus.
+
+#### Run Tests Using Browsers Installed In a VM ####
+
+If installing Testem is not preferable, a [Fedora VM](https://github.com/idi-ops/packer-fedora) can be automatically created using tools provided by the [Prosperity4All Quality Infrastructure](https://github.com/GPII/qi-development-environments/). After meeting the [QI development VM requirements](https://github.com/GPII/qi-development-environments/#requirements) the ``vagrant up`` command can be used to launch a VM which will contain Testem and several browsers. Typing ``grunt tests`` will run the Infusion tests in the VM and the results will be displayed in your terminal.
 
 ### Modules ###
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL
+    sudo dnf -y upgrade firefox google-chrome-stable
     sudo ansible-galaxy install -fr /home/vagrant/sync/provisioning/requirements.yml
     sudo PYTHONUNBUFFERED=1 ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure"
   SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,69 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+ansible_vars = YAML.load_file("provisioning/vars.yml")
+
+app_name = ansible_vars["nodejs_app_name"]
+
+app_directory = ansible_vars["nodejs_app_install_dir"]
+
+app_start_script = ansible_vars["nodejs_app_start_script"]
+
+# Check for the existence of the 'VM_HOST_TCP_PORT' environment variable. If it
+# doesn't exist and 'nodejs_app_tcp_port' is defined in vars.yml then use that
+# port. Failing that use defaults provided in this file.
+host_tcp_port = ENV["VM_HOST_TCP_PORT"] || ansible_vars["nodejs_app_tcp_port"] || 8081
+guest_tcp_port = ansible_vars["nodejs_app_tcp_port"] || 8081
+
+# By default this VM will use 2 processor cores and 2GB of RAM. The 'VM_CPUS' and
+# "VM_RAM" environment variables can be used to change that behaviour.
+cpus = ENV["VM_CPUS"] || 2
+ram = ENV["VM_RAM"] || 2048
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "inclusivedesign/fedora22"
+
+  # Your working directory will be synced to /home/vagrant/sync in the VM.
+  config.vm.synced_folder ".", "#{app_directory}"
+
+  # List additional directories to sync to the VM in your "Vagrantfile.local" file
+  # using the following format:
+  # config.vm.synced_folder "../path/on/your/host/os/your-project", "/home/vagrant/sync/your-project"
+
+  if File.exist? "Vagrantfile.local"
+    instance_eval File.read("Vagrantfile.local"), "Vagrantfile.local"
+  end
+
+  # Port forwarding takes place here. The 'guest' port is used inside the VM
+  # whereas the 'host' port is used by your host operating system.
+  config.vm.network "forwarded_port", guest: guest_tcp_port, host: host_tcp_port, protocol: "tcp",
+    auto_correct: true
+
+  config.vm.hostname = app_name
+
+  config.vm.provider :virtualbox do |vm|
+    vm.customize ["modifyvm", :id, "--memory", ram]
+    vm.customize ["modifyvm", :id, "--cpus", cpus]
+    vm.customize ["modifyvm", :id, "--vram", "128"]
+    vm.customize ["modifyvm", :id, "--accelerate3d", "on"]
+    vm.customize ["modifyvm", :id, "--audio", "null", "--audiocontroller", "ac97"]
+    vm.customize ["modifyvm", :id, "--ioapic", "on"]
+    vm.customize ["setextradata", "global", "GUI/SuppressMessages", "all"]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo ansible-galaxy install -fr /home/vagrant/sync/provisioning/requirements.yml
+    sudo PYTHONUNBUFFERED=1 ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure"
+  SHELL
+
+  # Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string
+  # "localhost" from the first line of /etc/hosts. This script reinserts it if it's missing.
+  # https://github.com/mitchellh/vagrant/pull/6203
+  config.vm.provision "shell",
+    inline: "/usr/local/bin/edit-hosts.sh",
+    run: "always"
+
+end

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "grunt-modulefiles": "git://github.com/fluid-project/grunt-modulefiles.git#0.2.1",
     "lodash": "~2.4.1",
     "grunt-contrib-jshint": "~0.9.0",
-    "grunt-jsonlint": "1.0.4"
+    "grunt-jsonlint": "1.0.4",
+    "grunt-shell": "^1.1.2"
   }
 }

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  user: root
+
+  vars_files:
+    - vars.yml
+
+  roles:
+    - facts
+    - nodejs
+

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,0 +1,6 @@
+- src: https://github.com/idi-ops/ansible-facts
+  name: facts
+
+- src: https://github.com/idi-ops/ansible-nodejs
+  name: nodejs
+

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -1,0 +1,19 @@
+---
+# Please refer to https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml
+# for documentation related to these variables
+
+nodejs_app_name: infusion
+
+nodejs_version: 0.10.40
+
+nodejs_app_npm_packages:
+  - testem
+
+nodejs_app_commands:
+  - npm install
+  - grunt
+
+nodejs_app_install_dir: /home/vagrant/sync
+
+nodejs_app_git_clone: false
+

--- a/tests/all-tests.html
+++ b/tests/all-tests.html
@@ -7,8 +7,9 @@
     <link rel="stylesheet" href="lib/qunit/css/qunit.css" type="text/css" media="screen">
     <link rel="stylesheet" href="lib/qunit/addons/composite/qunit-composite.css">
     <script src="lib/qunit/js/qunit.js"></script>
+    <script src="/testem.js"></script>
     <script src="lib/qunit/addons/composite/qunit-composite.js"></script>
-
+    
     <!--
         command line search:
         find . -name "*-test.html" | awk '{print "\""$1"\","}'

--- a/tests/testem.json
+++ b/tests/testem.json
@@ -1,0 +1,4 @@
+{
+    "test_page": "tests/all-tests.html",
+    "timeout": 300
+}


### PR DESCRIPTION
These changes let anyone launch installed browsers and have them run Infusion tests and also run the tests in a Fedora VM. Test results are displayed in the host operating system's console in both cases.