### PR TITLE
FLUID-5695, etc.: Numerous improvements to ChangeApplier and model transforms

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,7 +198,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-jsonlint");
     grunt.loadNpmTasks("grunt-modulefiles");
     grunt.loadNpmTasks("grunt-contrib-stylus");
-    grunt.loadNpmTasks('grunt-shell');
+    grunt.loadNpmTasks("grunt-shell");
 
     // Custom tasks:
 

--- a/src/components/pager/js/PagedTable.js
+++ b/src/components/pager/js/PagedTable.js
@@ -81,7 +81,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         fluid.each(pagerBar.tooltipInfo, function (value, index) {
             idToContent[idMap["pageLink:"+index]] = fluid.stringTemplate(pagedTable.options.markup.rangeAnnotation, value);
         });
-        pagerBar.tooltip.applier.requestChange("idToContent", idToContent);
+        pagerBar.tooltip.applier.change("idToContent", idToContent);
     };
 
     fluid.defaults("fluid.pagedTable", {

--- a/src/components/pager/js/Pager.js
+++ b/src/components/pager/js/Pager.js
@@ -419,11 +419,11 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         if (arg.relativePage !== undefined) {
             newPageIndex = that.model.pageIndex + arg.relativePage;
         }
-        that.applier.requestChange("pageIndex", newPageIndex);
+        that.applier.change("pageIndex", newPageIndex);
     };
 
     fluid.pager.initiatePageSizeChangeListener = function (that, arg) {
-        that.applier.requestChange("pageSize", arg);
+        that.applier.change("pageSize", arg);
     };
 
     /*******************

--- a/src/components/pager/js/Table.js
+++ b/src/components/pager/js/Table.js
@@ -147,7 +147,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                     return false;
                 }
                 newModel.pageIndex = 0;
-                tableThat.applier.requestChange("", newModel);
+                tableThat.applier.change("", newModel);
                 // fluid.table.setModelSortHeaderClass(newModel, options); - done during rerender, surely
             }
             return false;

--- a/src/components/slidingPanel/js/SlidingPanel.js
+++ b/src/components/slidingPanel/js/SlidingPanel.js
@@ -79,11 +79,11 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 "args": ["{that}.options.animationDurations.show", "{that}.events.afterPanelShow.fire"]
             },
             hidePanel: {
-                func: "{that}.applier.requestChange",
+                func: "{that}.applier.change",
                 args: ["isShowing", false]
             },
             showPanel: {
-                func: "{that}.applier.requestChange",
+                func: "{that}.applier.change",
                 args: ["isShowing", true]
             },
             togglePanel: {
@@ -105,7 +105,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     });
 
     fluid.slidingPanel.togglePanel = function (that) {
-        that.applier.requestChange("isShowing", !that.model.isShowing);
+        that.applier.change("isShowing", !that.model.isShowing);
     };
 
     fluid.slidingPanel.refreshView = function (that) {

--- a/src/components/tableOfContents/js/TableOfContents.js
+++ b/src/components/tableOfContents/js/TableOfContents.js
@@ -67,7 +67,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         });
 
         var headingsModel = that.modelBuilder.assembleModel(headings, that.anchorInfo);
-        that.applier.requestChange("", headingsModel);
+        that.applier.change("", headingsModel);
 
         that.events.onRefresh.fire();
     };

--- a/src/components/uploader/js/UploaderCompatibility-Infusion1.2.js
+++ b/src/components/uploader/js/UploaderCompatibility-Infusion1.2.js
@@ -41,13 +41,19 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                     outputPath: "",
                     merge: true,
                     value: {
-                        strategy: {
-                            options: {
-                                styles: "decorators.0.options.styles"
-                            }
-                        },
-                        fileQueueView: "fileQueueView",
-                        totalProgressBar: "totalProgressBar"
+                        transform: [{ // TODO: We could recover the old compact form of this with some dedicated form of transform
+                            type: "fluid.transforms.value",
+                            outputPath: "strategy.options.styles",
+                            inputPath: "decorators.0.options.styles"
+                        }, {
+                            type: "fluid.transforms.value",
+                            inputPath: "fileQueueView",
+                            outputPath: "fileQueueView"
+                        }, {
+                            type: "fluid.transforms.value",
+                            inputPath: "totalProgressBar",
+                            outputPath: "totalProgressBar"
+                        }]
                     }
                 }
             ]

--- a/src/framework/core/js/DataBinding.js
+++ b/src/framework/core/js/DataBinding.js
@@ -356,7 +356,9 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 });
             }
             var shadow = fluid.shadowForComponent(that);
-            shadow.modelComplete = true; // technically this is a little early, but this flag is only read in fluid.connectModelRelay
+            if (shadow) { // Fix for FLUID-5869 - the component may have been destroyed during its own init transaction
+                shadow.modelComplete = true; // technically this is a little early, but this flag is only read in fluid.connectModelRelay
+            }
         });
 
         transac.commit(); // committing one representative transaction will commit them all

--- a/src/framework/core/js/DataBinding.js
+++ b/src/framework/core/js/DataBinding.js
@@ -773,6 +773,9 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 fluid.filterKeys(transformPackage, ["forwardAdapter", "backwardAdapter", "namespace", "priority"]));
             // Primarily, here, we want to get rid of "update" which is what signals to connectModelRelay that this is a invalidatable relay
         } else {
+            if (parsedSource.modelSegs) {
+                fluid.fail("Error in model relay definition: If a relay transform has a model dependency, you can not specify a \"source\" entry - please instead enter this as \"input\" in the transform specification. Definition was ", mrrec, " for component ", that);
+            }
             // This second call binds changes emitted from the relay document itself onto the relay ends (using the "half-transactional system")
             fluid.connectModelRelay(parsedSource.that || that, parsedSource.modelSegs, parsedTarget.that, parsedTarget.modelSegs, transformPackage);
         }

--- a/src/framework/core/js/DataBinding.js
+++ b/src/framework/core/js/DataBinding.js
@@ -834,8 +834,10 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         fluid.mergeModelListeners(that, optionsML);
 
         var enlist = fluid.enlistModelComponent(that);
-        fluid.each(optionsMR, function (mrrec) {
-            fluid.parseModelRelay(that, mrrec);
+        fluid.each(optionsMR, function (mrrec, key) {
+            for (var i = 0; i < mrrec.length; ++ i) {
+                fluid.parseModelRelay(that, mrrec[i], key);
+            }
         });
 
         // Note: this particular instance of "refCount" is disused. We only use the count made within fluid.makeTransformPackge
@@ -888,10 +890,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 func: fluid.arrayConcatPolicy // TODO: bug here in case a model consists of an array
             },
             modelListeners: fluid.makeMergeListenersPolicy(fluid.arrayConcatPolicy),
-            modelRelay: {
-                noexpand: true,
-                func: fluid.arrayConcatPolicy
-            }
+            modelRelay: fluid.makeMergeListenersPolicy(fluid.arrayConcatPolicy, true)
         }
     });
 

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -423,6 +423,21 @@ var fluid = fluid || fluid_2_0_0;
         return togo;
     };
 
+    /** Pushes an element or elements onto an array, initialising the array as a member of a holding object if it is
+     * not already allocated.
+     * @param holder {Array or Object} The holding object whose member is to receive the pushed element(s).
+     * @param member {String} The member of the <code>holder</code> onto which the element(s) are to be pushed
+     * @param topush {Array or Object} If an array, these elements will be added to the end of the array using Array.push.apply. If an object, it will be pushed to the end of the array using Array.push.
+     */
+    fluid.pushArray = function (holder, member, topush) {
+        var array = holder[member] ? holder[member] : (holder[member] = []);
+        if (fluid.isArrayable(topush)) {
+            array.push.apply(array, topush);
+        } else {
+            array.push(topush);
+        }
+    };
+
     function transformInternal(source, togo, key, args) {
         var transit = source[key];
         for (var j = 0; j < args.length - 1; ++j) {
@@ -533,6 +548,15 @@ var fluid = fluid || fluid_2_0_0;
             arg = fn(list[i], arg, i);
         }
         return arg;
+    };
+
+    /** Returns the sum of its two arguments. A useful utility to combine with fluid.accumulate to compute totals 
+     * @param a {Number|Boolean} The first operand to be added
+     * @param b {Number|Boolean} The second operand to be added
+     * @return {Number} The sum of the two operands
+     **/
+    fluid.add = function (a, b) {
+        return a + b;
     };
 
     /** Scan through an array or hash of objects, removing those which match a predicate. Similar to
@@ -1120,6 +1144,7 @@ var fluid = fluid || fluid_2_0_0;
     };
 
     // unsupported, NON-API function
+    // TODO: Note - no "fixedOnly = true" sites remain in the framework
     fluid.parsePriorityConstraint = function (constraint, fixedOnly, site) {
         var segs = constraint.split(":");
         var type = segs[0];
@@ -1182,6 +1207,7 @@ var fluid = fluid || fluid_2_0_0;
 
     fluid.honourConstraint = function (array, firstConstraint, c) {
         var constraint = array[c].priority.constraint;
+        // TODO: We should find the LAST entry for a namespace for an "after" type (this is only relevant for model listeners)
         var matchIndex = fluid.find(array, function (element, index) {
             return element.namespace === constraint.target ? index : undefined;
         }, -1);
@@ -1741,7 +1767,8 @@ var fluid = fluid || fluid_2_0_0;
         var indexFunc = typeof(indexSpec.indexFunc) === "function" ? indexSpec.indexFunc : fluid.getGlobalValue(indexSpec.indexFunc);
         var keys = indexFunc(defaults) || [];
         for (var j = 0; j < keys.length; ++ j) {
-            (index[keys[j]] = index[keys[j]] || []).push(defaultName);
+            fluid.pushArray(index, keys[j], defaultName);
+            // (index[keys[j]] = index[keys[j]] || []).push(defaultName);
         }
     };
 

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1207,7 +1207,6 @@ var fluid = fluid || fluid_2_0_0;
 
     fluid.honourConstraint = function (array, firstConstraint, c) {
         var constraint = array[c].priority.constraint;
-        // TODO: We should find the LAST entry for a namespace for an "after" type (this is only relevant for model listeners)
         var matchIndex = fluid.find(array, function (element, index) {
             return element.namespace === constraint.target ? index : undefined;
         }, -1);
@@ -1768,7 +1767,6 @@ var fluid = fluid || fluid_2_0_0;
         var keys = indexFunc(defaults) || [];
         for (var j = 0; j < keys.length; ++ j) {
             fluid.pushArray(index, keys[j], defaultName);
-            // (index[keys[j]] = index[keys[j]] || []).push(defaultName);
         }
     };
 

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1266,6 +1266,17 @@ var fluid = fluid || fluid_2_0_0;
             }
         }
     };
+ 
+    fluid.parsePriorityRecords = function (records, name, root) {
+        var array = fluid.hashToArray(records, "namespace", function (newElement, oldElement, index) {
+            if (!root) {
+                $.extend(newElement, oldElement);
+            }
+            newElement.priority = fluid.parsePriority(root ? oldElement : oldElement.priority, index, false, name);
+        });
+        fluid.sortByPriority(array);
+        return array;
+    };
 
     fluid.event.identifyListener = function (listener, soft) {
         if (typeof(listener) !== "string" && !listener.$$fluid_guid && !soft) {

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1539,12 +1539,16 @@ var fluid = fluid || fluid_2_0_0;
     };
 
     // unsupported, NON-API function
-    fluid.makeMergeListenersPolicy = function (merger) {
+    fluid.makeMergeListenersPolicy = function (merger, modelRelay) {
         return function (target, source) {
             target = target || {};
-            fluid.each(source, function (listeners, key) {
-                target[key] = merger(target[key], listeners, key);
-            });
+            if (modelRelay && (fluid.isArrayable(source) || typeof(source.target) === "string")) { // This form allowed for modelRelay
+                target[""] = merger(target[""], source, "");
+            } else {
+                fluid.each(source, function (listeners, key) {
+                    target[key] = merger(target[key], listeners, key);
+                });
+            }
             return target;
         };
     };

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -811,7 +811,7 @@ var fluid = fluid || fluid_2_0_0;
         fluid.each(tofreeze, function (value) {
             fluid.freezeRecursive(value);
         });
-        return Object.freeze(tofreeze);
+        return fluid.isPlainObject(tofreeze) ? Object.freeze(tofreeze) : tofreeze; // IE11 crashes on freeze of non-object
     };
 
     /** A set of special "marker values" used in signalling in function arguments and return values,

--- a/src/framework/core/js/FluidIoC.js
+++ b/src/framework/core/js/FluidIoC.js
@@ -1376,6 +1376,9 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
 
         fluid.getForComponent(that, "modelRelay");
         fluid.getForComponent(that, "model"); // trigger this as late as possible - but must be before components so that child component has model on its onCreate
+        if (fluid.isDestroyed(that)) {
+            return; // Further fix for FLUID-5869 - if we managed to destroy ourselves through some bizarre model self-reaction, bail out here
+        }
 
         var options = that.options;
         var components = options.components || {};

--- a/src/framework/core/js/FluidIoC.js
+++ b/src/framework/core/js/FluidIoC.js
@@ -1149,7 +1149,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     // TODO: overall efficiency could huge be improved by resorting to the hated PROTOTYPALISM as an optimisation
     // for this mergePolicy which occurs in every component. Although it is a deep structure, the root keys are all we need
     var addPolicyBuiltins = function (policy) {
-        fluid.each(["gradeNames", "mergePolicy", "argumentMap", "components", "dynamicComponents", "events", "listeners", "modelListeners", "distributeOptions", "transformOptions"], function (key) {
+        fluid.each(["gradeNames", "mergePolicy", "argumentMap", "components", "dynamicComponents", "events", "listeners", "modelListeners", "modelRelay", "distributeOptions", "transformOptions"], function (key) {
             fluid.set(policy, [key, "*", "noexpand"], true);
         });
         return policy;

--- a/src/framework/core/js/FluidIoC.js
+++ b/src/framework/core/js/FluidIoC.js
@@ -389,7 +389,6 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     fluid.pushDistributions = function (targetHead, selector, target, blocks) {
         var targetShadow = fluid.shadowForComponent(targetHead);
         var id = fluid.allocateGuid();
-        var distributions = (targetShadow.distributions = targetShadow.distributions || []);
         var distribution = {
             id: id, // This id is used in clearDistributions
             target: target, // Here for improved debuggability - info is duplicated in "selector"
@@ -398,7 +397,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         };
         Object.freeze(distribution);
         Object.freeze(distribution.blocks);
-        distributions.push(distribution);
+        fluid.pushArray(targetShadow, "distributions", distribution);
         return id;
     };
 
@@ -891,11 +890,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
 
     fluid.recordListener = function (event, listener, shadow, listenerId) {
         if (event.ownerId !== shadow.that.id) { // don't bother recording listeners registered from this component itself
-            var listeners = shadow.listeners;
-            if (!listeners) {
-                listeners = shadow.listeners = [];
-            }
-            listeners.push({event: event, listener: listener, listenerId: listenerId});
+            fluid.pushArray(shadow, "listeners", {event: event, listener: listener, listenerId: listenerId});
         }
     };
 
@@ -1770,6 +1765,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         var transRecs = fluid.transform(records, function (record) {
             // TODO: FLUID-5242 fix - we copy here since distributeOptions does not copy options blocks that it distributes and we can hence corrupt them.
             // need to clarify policy on options sharing - for slightly better efficiency, copy should happen during distribution and not here
+            // Note that fluid.mergeModelListeners expects to write to these too
             var expanded = fluid.isPrimitive(record) || record.expander ? {listener: record} : fluid.copy(record);
             var methodist = fluid.recordToApplicable(record, that);
             if (methodist) {

--- a/src/framework/core/js/FluidIoC.js
+++ b/src/framework/core/js/FluidIoC.js
@@ -1619,7 +1619,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             apply: function (noThis, args) {
                 var parsed = fluid.parseValidModelReference(that, "changePath listener record", record.changePath);
                 var value = fluid.expandOptions(record.value, that, {}, {"arguments": args});
-                fluid.fireSourcedChange(parsed.applier, parsed.path, value, record.source);
+                fluid.fireSourcedChange(parsed.applier, parsed.modelSegs, value, record.source);
             }
         };
     };

--- a/src/framework/core/js/ModelTransformation.js
+++ b/src/framework/core/js/ModelTransformation.js
@@ -83,30 +83,33 @@ var fluid = fluid || fluid_2_0_0;
         return !prefix ? suffix : (!suffix ? prefix : prefix + "." + suffix);
     };
 
-    fluid.model.transform.accumulateInputPath = function (inputPath, transform, paths) {
+    fluid.model.transform.accumulateInputPath = function (inputPath, transformer, paths) {
         if (inputPath !== undefined) {
-            paths.push(fluid.model.composePaths(transform.inputPrefix, inputPath));
+            paths.push(fluid.model.composePaths(transformer.inputPrefix, inputPath));
         }
     };
 
-    fluid.model.transform.accumulateStandardInputPath = function (input, transformSpec, transform, paths) {
-        fluid.model.transform.getValue(undefined, transformSpec[input], transform);
-        fluid.model.transform.accumulateInputPath(transformSpec[input + "Path"], transform, paths);
+    fluid.model.transform.accumulateStandardInputPath = function (input, transformSpec, transformer, paths) {
+        fluid.model.transform.getValue(undefined, transformSpec[input], transformer);
+        fluid.model.transform.accumulateInputPath(transformSpec[input + "Path"], transformer, paths);
     };
 
-    fluid.model.transform.accumulateMultiInputPaths = function (inputVariables, transformSpec, transform, paths) {
+    fluid.model.transform.accumulateMultiInputPaths = function (inputVariables, transformSpec, transformer, paths) {
         fluid.each(inputVariables, function (v, k) {
-            fluid.model.transform.accumulateStandardInputPath(k, transformSpec, transform, paths);
+            fluid.model.transform.accumulateStandardInputPath(k, transformSpec, transformer, paths);
         });
     };
 
-    fluid.model.transform.getValue = function (inputPath, value, transform) {
+    fluid.model.transform.getValue = function (inputPath, value, transformer) {
         var togo;
         if (inputPath !== undefined) { // NB: We may one day want to reverse the crazy jQuery-like convention that "no path means root path"
-            togo = fluid.get(transform.source, fluid.model.composePaths(transform.inputPrefix, inputPath), transform.resolverGetConfig);
+            togo = fluid.get(transformer.source, fluid.model.composePaths(transformer.inputPrefix, inputPath), transformer.resolverGetConfig);
         }
         if (togo === undefined) {
-            togo = fluid.isPrimitive(value) ? value : transform.expand(value);
+            // FLUID-5867 - actually helpful behaviour here rather than the insane original default of expecting a short-form value document
+            togo = fluid.isPrimitive(value) ? value :
+                ("literalValue" in value ? value.literalValue :
+                (value.transform === undefined ? value : transformer.expand(value)));
         }
         return togo;
     };
@@ -116,13 +119,13 @@ var fluid = fluid || fluid_2_0_0;
     // in a compound transform definition
     fluid.model.transform.NONDEFAULT_OUTPUT_PATH_RETURN = {};
 
-    fluid.model.transform.setValue = function (userOutputPath, value, transform) {
+    fluid.model.transform.setValue = function (userOutputPath, value, transformer) {
         // avoid crosslinking to input object - this might be controlled by a "nocopy" option in future
         var toset = fluid.copy(value);
-        var outputPath = fluid.model.composePaths(transform.outputPrefix, userOutputPath);
+        var outputPath = fluid.model.composePaths(transformer.outputPrefix, userOutputPath);
         // TODO: custom resolver config here to create non-hash output model structure
         if (toset !== undefined) {
-            transform.applier.change(outputPath, toset);
+            transformer.applier.change(outputPath, toset);
         }
         return userOutputPath ? fluid.model.transform.NONDEFAULT_OUTPUT_PATH_RETURN : toset;
     };
@@ -132,8 +135,8 @@ var fluid = fluid || fluid_2_0_0;
      * or expanding otherwise. <def> defines the default value if unableto resolve the key. If no
      * default value is given undefined is returned
      */
-    fluid.model.transform.resolveParam = function (transformSpec, transform, key, def) {
-        var val = fluid.model.transform.getValue(transformSpec[key + "Path"], transformSpec[key], transform);
+    fluid.model.transform.resolveParam = function (transformSpec, transformer, key, def) {
+        var val = fluid.model.transform.getValue(transformSpec[key + "Path"], transformSpec[key], transformer);
         return (val !== undefined) ? val : def;
     };
 

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -32,12 +32,7 @@ var fluid = fluid || fluid_2_0_0;
     fluid.transforms.value = fluid.identity;
 
     fluid.transforms.value.invert = function (transformSpec, transformer) {
-        var togo = fluid.copy(transformSpec);
-        // TODO: this will not behave correctly in the face of compound "value" which contains
-        // further transforms
-        togo.inputPath = fluid.model.composePaths(transformer.outputPrefix, transformSpec.outputPath);
-        togo.outputPath = fluid.model.composePaths(transformer.inputPrefix, transformSpec.inputPath);
-        return togo;
+        return fluid.model.transform.copyInversePaths(transformSpec, transformer);
     };
 
     // Export the use of the "value" transform under the "identity" name for FLUID-5293
@@ -45,6 +40,13 @@ var fluid = fluid || fluid_2_0_0;
     fluid.defaults("fluid.transforms.identity", {
         gradeNames: "fluid.transforms.value"
     });
+
+    // A helpful utility function to be used when a transform's inverse is the identity
+    fluid.transforms.invertToIdentity = function (transformSpec, transformer) {
+        var togo = fluid.model.transform.copyInversePaths(transformSpec, transformer);
+        togo.type = "fluid.transforms.identity";
+        return togo;
+    };
 
     fluid.defaults("fluid.transforms.literalValue", {
         gradeNames: "fluid.standardOutputTransformFunction"
@@ -81,7 +83,8 @@ var fluid = fluid || fluid_2_0_0;
 
 
     fluid.defaults("fluid.transforms.round", {
-        gradeNames: "fluid.standardTransformFunction"
+        gradeNames: ["fluid.standardTransformFunction", "fluid.lens"],
+        invertConfiguration: "fluid.transforms.invertToIdentity"
     });
 
     fluid.transforms.round = function (value) {
@@ -95,7 +98,7 @@ var fluid = fluid || fluid_2_0_0;
 
     fluid.transforms["delete"] = function (transformSpec, transformer) {
         var outputPath = fluid.model.composePaths(transformer.outputPrefix, transformSpec.outputPath);
-        transformer.applier.requestChange(outputPath, null, "DELETE");
+        transformer.applier.change(outputPath, null, "DELETE");
     };
 
 
@@ -121,7 +124,8 @@ var fluid = fluid || fluid_2_0_0;
         gradeNames: [ "fluid.multiInputTransformFunction", "fluid.standardOutputTransformFunction", "fluid.lens" ],
         invertConfiguration: "fluid.transforms.linearScale.invert",
         inputVariables: {
-            value: null,
+            value: null, // This is now deprecated, as per FLUID-5294
+            input: null,
             factor: 1,
             offset: 0
         }
@@ -130,6 +134,12 @@ var fluid = fluid || fluid_2_0_0;
     /* simple linear transformation */
     fluid.transforms.linearScale = function (inputs) {
         var value = inputs.value();
+        if (fluid.isValue(value)) {
+            fluid.log(fluid.logLevel.WARN, "The input \"value\" is deprecated and will be renamed to \"input\" for all transforms");
+        } else {
+            value = inputs.input();
+        }
+
         var factor = inputs.factor();
         var offset = inputs.offset();
 
@@ -140,19 +150,15 @@ var fluid = fluid || fluid_2_0_0;
     };
 
     /* TODO: This inversion doesn't work if the value and factors are given as paths in the source model */
-    fluid.transforms.linearScale.invert = function  (transformSpec, transformer) {
-        var togo = fluid.copy(transformSpec);
+    fluid.transforms.linearScale.invert = function (transformSpec, transformer) {
+        var togo = fluid.model.transform.copyInversePaths(transformSpec, transformer);
 
-        if (togo.factor) {
+        if (togo.factor !== undefined) {
             togo.factor = (togo.factor === 0) ? 0 : 1 / togo.factor;
         }
-        if (togo.offset) {
+        if (togo.offset !== undefined) {
             togo.offset = - togo.offset * (togo.factor !== undefined ? togo.factor : 1);
         }
-        // TODO: This rubbish should be done by the inversion machinery by itself. We shouldn't have to repeat it in every
-        // inversion rule
-        togo.valuePath = fluid.model.composePaths(transformer.outputPrefix, transformSpec.outputPath);
-        togo.outputPath = fluid.model.composePaths(transformer.inputPrefix, transformSpec.valuePath);
         return togo;
     };
 
@@ -655,9 +661,7 @@ var fluid = fluid || fluid_2_0_0;
     };
 
     fluid.transforms.invertArrayIndexation = function (transformSpec, transformer) {
-        var togo = fluid.copy(transformSpec);
-        togo.inputPath = fluid.model.composePaths(transformer.outputPrefix, transformSpec.outputPath);
-        togo.outputPath = fluid.model.composePaths(transformer.inputPrefix, transformSpec.inputPath);
+        var togo = fluid.model.transform.copyInversePaths(transformSpec, transformer);
         if (!isNaN(Number(togo.offset))) {
             togo.offset = Number(togo.offset) * (-1);
         }

--- a/src/framework/enhancement/js/ContextAwareness.js
+++ b/src/framework/enhancement/js/ContextAwareness.js
@@ -145,11 +145,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         if (contextAwareRecord.checks && contextAwareRecord.checks.contextValue) {
             fluid.fail("Nesting error in contextAwareness record ", contextAwareRecord, " - the \"checks\" entry must contain a hash and not a contextValue/gradeNames record at top level");
         }
-        var checkList = fluid.hashToArray(contextAwareRecord.checks, "namespace", function (newElement, oldElement, index) {
-            $.extend(newElement, oldElement);
-            newElement.priority = fluid.parsePriority(oldElement.priority, index);
-        });
-        fluid.sortByPriority(checkList);
+        var checkList = fluid.parsePriorityRecords(contextAwareRecord.checks, "contextAwareness checkRecord");
         return fluid.find(checkList, function (check) {
             if (!check.contextValue) {
                 fluid.fail("Cannot perform check for contextAwareness record ", check, " without a valid field named \"contextValue\"");
@@ -164,11 +160,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     // unsupported, NON-API function
     fluid.contextAware.check = function (that, contextAwarenessOptions) {
         var gradeNames = [];
-        var contextAwareList = fluid.hashToArray(contextAwarenessOptions, "namespace", function (newElement, oldElement, index) {
-            $.extend(newElement, oldElement);
-            newElement.priority = fluid.parsePriority(oldElement.priority, index, false, "context awareness records");
-        });
-        fluid.sortByPriority(contextAwareList);
+        var contextAwareList = fluid.parsePriorityRecords(contextAwarenessOptions, "contextAwareness adaptationRecord");
         fluid.each(contextAwareList, function (record) {
             var matched = fluid.contextAware.checkOne(that, record);
             gradeNames = gradeNames.concat(fluid.makeArray(matched));

--- a/tests/framework-tests/core/js/DataBindingTests.js
+++ b/tests/framework-tests/core/js/DataBindingTests.js
@@ -952,7 +952,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     input: {
                         screenChaundles: "{that}.model.screenChaundles",
                         position: "{that}.model.position",
-                        step: "{that}.model.dataRange.step"
+                        dataRange: "{that}.model.dataRange"
                     }
                 }
             },
@@ -961,10 +961,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 singleTransform: {
                     type: "fluid.tests.fluid5865.rescalePosition",
                     input: {
-                        position: "{that}.model.visWindow",
-                        step: "{that}.model.dataRange.step"
+                        screenChaundles: "{that}.model.screenChaundles",
+                        visWindow: "{that}.model.visWindow",
+                        dataRange: "{that}.model.dataRange"
                     }
-                }
+                },
+                priority: "before:positionToVis"
             }
         }
     });
@@ -977,7 +979,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var dataRange = model.dataRange,
             position = model.position;
         // that.model.position holds scrollbar's index, which is between 0 and dataRange width / step
-        if (!dataRange || !dataRange.start) {
+        if (!dataRange || dataRange.start === undefined) {
             return;
         }
         var visStart = dataRange.start + position * dataRange.step;

--- a/tests/framework-tests/core/js/DataBindingTests.js
+++ b/tests/framework-tests/core/js/DataBindingTests.js
@@ -1109,6 +1109,31 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertEquals("Two changes after change", 2, that.changes);
     });
 
+    /** FLUID-5847: Relay transforms which have both "source" and a transform model dependency **/
+
+    fluid.defaults("fluid.tests.fluid5847.root", {
+        gradeNames: "fluid.modelComponent",
+        model: {
+            source: 35,
+            sideValue: 50
+        },
+        modelRelay: {
+            source: "source",
+            target: "target",
+            singleTransform: {
+                type: "fluid.transforms.identity",
+                sideValue: "{that}.model.sideValue"
+            }
+        }
+    });
+
+    jqUnit.test("FLUID-5847: Relay transforms with both \"source\" and transform model dependency", function () {
+        // TODO: in theory, we could detect this at fluid.defaults() time, with a lot more work
+        jqUnit.expectFrameworkDiagnostic("Framework diagnostic for relay with both source and transform model dependency", function () {
+            fluid.tests.fluid5847.root();
+        }, "source");
+    });
+
     /** Demonstrate resolving a set of model references which is cyclic in components (although not in values), as well as
      * double relay and longer "transform" form of relay specification */
 
@@ -2219,6 +2244,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return togo;
     };
 
-    fluid.test.runTests(["fluid.tests.fluid5659root"]);
+    // fluid.test.runTests(["fluid.tests.fluid5659root"]);
 
 })(jQuery);

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -2513,7 +2513,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     jqUnit.test("Invoker resolution tests", function () {
         var that = fluid.tests.invokerGrandParent();
         var newValue = 2;
-        that.invokerwrapper.parent2.applier.requestChange("testValue", newValue);
+        that.invokerwrapper.parent2.applier.change("testValue", newValue);
         jqUnit.assertEquals("The invoker for second subcomponent should return the value from its parent",
             newValue, that.invokerwrapper.parent2.checkTestValue());
     });

--- a/tests/framework-tests/core/js/FluidIoCTests.js
+++ b/tests/framework-tests/core/js/FluidIoCTests.js
@@ -3147,7 +3147,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertEquals("Args changed", 6, that.argsInvoker(2, 2));
     });
 
-    /** FLUID-5127 - Test cases for compact invokers, listeners and expandesr **/
+    /** FLUID-5127 - Test cases for compact invokers, listeners and expanders **/
 
     fluid.tests.fluid5127listener = function (value1, value2, that) {
         that.fireValue = value1 + value2;
@@ -3214,6 +3214,19 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertEquals("Multiple compact listeners", 4, that.fireValue);
 
         jqUnit.assertEquals("Invoker", 3, that.addOne(1));
+    });
+
+    /** Unresolvable expander function **/
+
+    fluid.defaults("fluid.tests.unresolvableExpander", {
+        gradeNames: "fluid.component",
+        badExpander: "@expand:fluid.tests.nonexistent()"
+    });
+
+    jqUnit.test("Unresolvable expander function", function () {
+        jqUnit.expectFrameworkDiagnostic("Unresolvable expander function", function () {
+            fluid.tests.unresolvableExpander();
+        }, ["expander record", "fluid.tests.nonexistent"]);
     });
 
     /** FLUID-5663 - Malformed syntax in compact invokers **/

--- a/tests/framework-tests/core/js/FluidJSTests.js
+++ b/tests/framework-tests/core/js/FluidJSTests.js
@@ -49,6 +49,58 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         });
     });
 
+    jqUnit.test("fluid.makeArray tests", function () {
+        jqUnit.assertDeepEq("fluid.makeArray on non-array", [1], fluid.makeArray(1));
+        jqUnit.assertDeepEq("fluid.makeArray on null", [], fluid.makeArray(null));
+        jqUnit.assertDeepEq("fluid.makeArray on undefined", [], fluid.makeArray(undefined));
+        var inputArray = [1];
+        var outputArray = fluid.makeArray(inputArray);
+        jqUnit.assertDeepEq("fluid.makeArray on array - deep equality", inputArray, outputArray);
+        jqUnit.assertNotEquals("fluid.makeArray on array - cloning", inputArray, outputArray);
+    });
+
+    fluid.tests.pushArray = [{
+        message: "nonexistent element - nonarray",
+        holder: {},
+        topush: 1,
+        expected: {
+            m1: [1]
+        }
+    }, {
+        message: "nonexistent element - array",
+        holder: {},
+        topush: [1],
+        expected: {
+            m1: [1]
+        }
+    }, {
+        message: "existent element - nonarray",
+        holder: {
+            m1: [1]
+        },
+        topush: 2,
+        expected: {
+            m1: [1, 2]
+        }
+    }, {
+        message: "existent element - array",
+        holder: {
+            m1: [1]
+        },
+        topush: [2, 3],
+        expected: {
+            m1: [1, 2, 3]
+        }
+    }
+    ];
+
+    jqUnit.test("fluid.pushArray tests", function () {
+        fluid.each(fluid.tests.pushArray, function (fixture) {
+            var holder = fluid.copy(fixture.holder);
+            fluid.pushArray(holder, "m1", fixture.topush);
+            jqUnit.assertDeepEq("fluid.pushArray - " + fixture.message, fixture.expected, holder);
+        });
+    });
 
     function isOdd(i) {
         return i % 2 === 1;

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -265,7 +265,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             value: {
                 transform: {
                     type: "fluid.transforms.linearScale",
-                    valuePath: "dozen"
+                    valuePath: "dozen" // Revert to "inputPath" once FLUID-5294 is resolved
                 }
             }
         },
@@ -273,7 +273,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             transform: [{
                 type: "fluid.transforms.linearScale",
                 outputPath: "dozen",
-                valuePath: "value"
+                inputPath: "value"
             }]
         },
         method: "assertDeepEq",
@@ -302,7 +302,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             transform: [{
                 type: "fluid.transforms.linearScale",
                 outputPath: "dozen",
-                valuePath: "value",
+                inputPath: "value",
                 factor: 4
             }]
         },
@@ -320,7 +320,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             value: {
                 transform: {
                     type: "fluid.transforms.linearScale",
-                    valuePath: "dozen",
+                    inputPath: "dozen",
                     factor: 0.50,
                     offset: 100
                 }
@@ -330,7 +330,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             transform: [{
                 type: "fluid.transforms.linearScale",
                 outputPath: "dozen",
-                valuePath: "value",
+                inputPath: "value",
                 factor: 2,
                 offset: -200
             }]

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -625,10 +625,18 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 type: "fluid.transforms.condition",
                 conditionPath: "catsAreDecent",
                 "true": {
-                    "Antranig": "cat"
+                    transform: {
+                        type: "fluid.transforms.value",
+                        outputPath: "Antranig",
+                        inputPath: "cat"
+                    }
                 },
                 "false": {
-                    "Kasper": "polar"
+                    transform: {
+                        type: "fluid.transforms.value",
+                        outputPath: "Kasper",
+                        inputPath: "polar"
+                    }
                 }
             },
             method: "assertDeepEq",
@@ -707,22 +715,29 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             method: "assertEquals",
             expected: fluid.tests.transforms.source.cat
         }, {
-            message: "Where the path is a rules object, the result should be an expanded version of it.",
-            transform: {
+            message: "Where input is another transform, the result should be the expanded version of it.",
+            transform: { // FLUID-5867: NOONE wants the original behaviour here of expanding short-form value transforms automatically
                 type: "fluid.transforms.value",
                 input: {
-                    alligator: {
-                        transform: {
-                            type: "fluid.transforms.value",
-                            inputPath: "hamster"
+                    transform: [{
+                        type: "fluid.transforms.value",
+                        outputPath: "alligator",
+                        input: {
+                            transform: {
+                                type: "fluid.transforms.value",
+                                inputPath: "hamster"
+                            }
                         }
-                    },
-                    tiger: {
-                        transform: {
-                            type: "fluid.transforms.value",
-                            inputPath: "hamster.wheel"
+                    }, {
+                        type: "fluid.transforms.value",
+                        outputPath: "tiger",
+                        input: {
+                            transform: {
+                                type: "fluid.transforms.value",
+                                inputPath: "hamster.wheel"
+                            }
                         }
-                    }
+                    }]
                 }
             },
             method: "assertDeepEq",

--- a/tests/framework-tests/preferences/js/BuilderTests.js
+++ b/tests/framework-tests/preferences/js/BuilderTests.js
@@ -856,14 +856,14 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     listener: "fluid.tests.composite.tester.initialRendering",
                     event: "{compositePrefsEditor prefsEditor prefsEditorLoader prefsEditor}.events.onReady"
                 }, {
-                    func: "{prefsEditor}.prefsEditorLoader.prefsEditor.applier.requestChange",
+                    func: "{prefsEditor}.prefsEditorLoader.prefsEditor.applier.change",
                     args: ["preferences.fluid_tests_composite_pref_increaseSize", true]
                 }, {
                     listener: "fluid.tests.composite.tester.conditionalCreation",
                     event: "{prefsEditor}.prefsEditorLoader.prefsEditor.increasing.events.afterRender",
                     priority: "last"
                 }, {
-                    func: "{prefsEditor}.prefsEditorLoader.prefsEditor.applier.requestChange",
+                    func: "{prefsEditor}.prefsEditorLoader.prefsEditor.applier.change",
                     args: ["preferences.fluid_tests_composite_pref_increaseSize", false]
                 }, {
                     listener: "fluid.tests.composite.tester.conditionalDestruction",

--- a/tests/framework-tests/preferences/js/EnactorsTests.js
+++ b/tests/framework-tests/preferences/js/EnactorsTests.js
@@ -192,10 +192,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
         jqUnit.assertEquals("The style class is not applied by default", defaultStyle, that.container.attr("class"));
 
-        that.applier.requestChange("value", "test");
+        that.applier.change("value", "test");
         jqUnit.assertEquals("The style class has been applied", defaultStyle + " " + expectedClass, that.container.attr("class"));
 
-        that.applier.requestChange("value", "");
+        that.applier.change("value", "");
         jqUnit.assertEquals("The style class has been removed", defaultStyle, that.container.attr("class"));
     };
 
@@ -257,7 +257,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var initialREMSize = fluid.prefs.enactor.getTextSizeInPx(remTestElm, fontSizeMap);
 
         jqUnit.assertEquals("Check that the size is pulled from the container correctly", expectedInitialSize, that.initialSize);
-        that.applier.requestChange("value", muliplier);
+        that.applier.change("value", muliplier);
         jqUnit.assertEquals("The size should be doubled", (expectedInitialSize * muliplier) + "px", that.root.css("fontSize"));
         jqUnit.assertEquals("The font size specified in rem units should be doubled", initialREMSize * muliplier, fluid.prefs.enactor.getTextSizeInPx(remTestElm, fontSizeMap));
 
@@ -383,7 +383,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     fluid.tests.testLineSpace = function (that) {
         jqUnit.assertEquals("Check that the size is pulled from the container correctly", 2, Math.round(that.initialSize));
         jqUnit.assertEquals("Check the line spacing size in pixels", "12px", convertLineHeightFactor(that.container.css("lineHeight"), that.container.css("fontSize")));
-        that.applier.requestChange("value", 2);
+        that.applier.change("value", 2);
         jqUnit.assertEquals("The size should be doubled", "24px", convertLineHeightFactor(that.container.css("lineHeight"), that.container.css("fontSize")));
     };
 

--- a/tests/framework-tests/preferences/js/IntegrationTestsCommon.js
+++ b/tests/framework-tests/preferences/js/IntegrationTestsCommon.js
@@ -77,7 +77,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     fluid.tests.prefs.applierRequestChanges = function (prefsEditor, selectionOptions) {
-        prefsEditor.applier.requestChange("", selectionOptions);
+        prefsEditor.applier.change("", selectionOptions);
     };
 
     fluid.defaults("fluid.tests.prefs.globalSettingsStore", {

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -426,7 +426,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             assertNotInitialized(that, "conditionalPanel2");
             that.events.afterRender.removeListener("pref1_true");
         }, "pref1_true", "last");
-        that.applier.requestChange("some_pref_1", true);
+        that.applier.change("some_pref_1", true);
 
         // set some.pref.1 to false
         jqUnit.expect(10);
@@ -439,7 +439,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             assertNotInitialized(that, "conditionalPanel2");
             that.events.afterRender.removeListener("pref1_false");
         }, "pref1_false", "last");
-        that.applier.requestChange("some_pref_1", false);
+        that.applier.change("some_pref_1", false);
 
         // set some.pref.2 to true
         jqUnit.expect(11);
@@ -453,7 +453,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             assertText(that, "conditionalPanel2", "conditionalPanel2");
             that.events.afterRender.removeListener("pref2_true");
         }, "pref2_true", "last");
-        that.applier.requestChange("some_pref_2", true);
+        that.applier.change("some_pref_2", true);
 
         // set some.pref.2 to false
         jqUnit.expect(10);
@@ -466,7 +466,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             assertNotInitialized(that, "conditionalPanel2");
             that.events.afterRender.removeListener("pref2_false");
         }, "pref2_false", "last");
-        that.applier.requestChange("some_pref_2", false);
+        that.applier.change("some_pref_2", false);
 
     });
 
@@ -901,8 +901,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assert("The initial state with the min value for slider1 has been set properly", 0, $(".flc-tests-panel-slider1 .flc-textfieldSlider-slider").slider("value"));
         jqUnit.assert("The initial state with the min value for slider2 has been set properly", 1, $(".flc-tests-panel-slider2 .flc-textfieldSlider-slider").slider("value"));
 
-        that.slider1.applier.requestChange("value", 100);
-        that.slider2.applier.requestChange("value", 100);
+        that.slider1.applier.change("value", 100);
+        that.slider2.applier.change("value", 100);
         that.refreshView();
         jqUnit.assert("The max value for slider1 has been set properly", 10, $(".flc-tests-panel-slider1 .flc-textfieldSlider-slider").slider("value"));
         jqUnit.assert("The max value for slider2 has been set properly", 100, $(".flc-tests-panel-slider2 .flc-textfieldSlider-slider").slider("value"));

--- a/tests/framework-tests/preferences/js/PrefsEditorTests.js
+++ b/tests/framework-tests/preferences/js/PrefsEditorTests.js
@@ -356,7 +356,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     fluid.tests.prefs.applierRequestChanges = function (prefsEditor, selectionOptions) {
         ["textFont", "theme", "textSize", "lineSpace"].forEach(function (pref) {
-            prefsEditor.applier.requestChange(["preferences", pref], selectionOptions.preferences[pref]);
+            prefsEditor.applier.change(["preferences", pref], selectionOptions.preferences[pref]);
         });
     };
 

--- a/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
+++ b/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
@@ -622,7 +622,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
         jqUnit.test("FLUID-5280: The relayed new value takes precedence over the default model value", function () {
             var that = fluid.tests.fluid5280(".flc-fluid5280-main");
-            that.applier.requestChange("audio", fluid.tests.fluid5280.newValue);
+            that.applier.change("audio", fluid.tests.fluid5280.newValue);
             that.refreshView();
         });
 
@@ -1726,8 +1726,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             var that = fluid.tests.fluid5099("#FLUID-5099");
             var test = that.locate("test");
             jqUnit.assertEquals("Original value is correct", "TEST", test.val());
-            // TODO: Source tracking is not supported in current applier
-            fluid.addSourceGuardedListener(that.applier, "test", "test", function () {
+            // TODO: The renderer does not fire sourced changes automatically
+            that.applier.modelChanged.addListener({excludeSource: "test", path: "test"}, function () {
                 jqUnit.assert("Listener is applied correctly.");
             });
             fluid.changeElementValue(test, "NEW VALUE");

--- a/tests/test-core/utils/js/IoCTestUtils.js
+++ b/tests/test-core/utils/js/IoCTestUtils.js
@@ -391,8 +391,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     fluid.test.decoders.changeEvent = function (testCaseState, fixture) {
         var event = testCaseState.expand(fixture.changeEvent);
         var listener = fluid.test.decodeListener(testCaseState, fixture);
-        var that = fluid.test.makeBinder(listener,
-           function (wrapped) {
+        var that = fluid.test.makeBinder(listener, function (wrapped) {
             var spec = fixture.path === undefined ? fixture.spec : {path: fixture.path};
             if (spec === undefined || spec.path === undefined) {
                 fluid.fail("Error in changeEvent fixture ", fixture,


### PR DESCRIPTION
FLUID-5695: Allow "invalidation-style" model listeners to listen to multiple paths
FLUID-5848: Detect indirect references to model components from model listeners and relay rules