### PR TITLE
FLUID-3921 and FLUID-2779: Fix style for the selected page and prev/next link in the pager demo

### DIFF
--- a/demos/pager/css/pager.css
+++ b/demos/pager/css/pager.css
@@ -1,7 +1,7 @@
 /* pager demo styles */
 
 .demo-pager-container {
-    width:95%;
+    width: 95%;
 }
 
 .demo-pager-container input {
@@ -12,13 +12,9 @@
     display: none;
 }
 
-.demo-pager-container a:visited {
-    color: blue;
-}
-
 .demo-pager-container a:hover{
     outline: 2px #000 solid;
-    padding:0px;
+    padding: 0px;
 }
 
 /***********************************************
@@ -58,8 +54,8 @@
 }
 
 .demo-pager-bar  li  {
-    display:inline;
-    float:left;
+    display: inline;
+    float: left;
 }
 
 /***********************************************
@@ -78,12 +74,11 @@
 
 .demo-pager-pageLink-default a {
     /* Using display:block and float:left, it creates helps create a horizontal list with fixed width elements.*/
-    display:block;
-    float:left;
-
-    width:3em;
-    text-align:center;
-    margin:2px;
+    display: block;
+    float: left;
+    width: 3em;
+    text-align: center;
+    margin: 2px;
     border: 1px solid #afafaf;
 }
 
@@ -92,15 +87,13 @@
 }
 
 .demo-pager-links .fl-pager-currentPage {
-    color: #fff;
-    display:block;
-    width:3em;
-    float:left;
-    background: #000;
-    padding:0px;
-    margin:2px;
+    display: block;
+    width: 3em;
+    float: left;
+    padding: 0px;
+    margin: 2px;
     border: 1px solid #000;
-    text-align:center;
+    text-align: center;
 }
 
 .demo-pager-links .fl-pager-currentPage:visited {
@@ -108,8 +101,8 @@
 }
 
 .demo-pager-head a {
-    display:block;
-    width:100%;
+    display: block;
+    width: 100%;
 }
 
 /***********************************************

--- a/demos/pager/index.html
+++ b/demos/pager/index.html
@@ -57,13 +57,13 @@
         <div class="flc-pager-summary">Summary goes here</div>
 
         <div class="flc-pager-top">
-            <ul class="demo-pager-bar fl-force-left fl-focus">
+            <ul class="demo-pager-bar fl-force-left fl-focus fl-pager-ui">
                 <li class="flc-pager-previous demo-pager-previous"><a href="#" title="Previous Page">&lt; Previous</a></li>
                 <li>
                     <ul class="flc-pager-links demo-pager-links">
-                        <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
+                        <li class="flc-pager-pageLink demo-pager-pageLink-default fl-pager-links"><a href="#">1</a></li>
                         <li class="flc-pager-pageLink-skip demo-pager-pageLink-skip ">...</li>
-                        <li class="flc-pager-pageLink"><a href="#">2</a></li>
+                        <li class="flc-pager-pageLink demo-pager-pageLink-default fl-pager-links"><a href="#">2</a></li>
                     </ul>
                 </li>
                 <li class="demo-pager-next flc-pager-next"><a href="#" title="Next Page">Next &gt;</a></li>

--- a/src/components/pager/css/Pager.css
+++ b/src/components/pager/css/Pager.css
@@ -18,41 +18,47 @@
 /* Pager UI */
 /* Class name for the list container */
 .fl-pager .fl-pager-ui {
-    margin:0; padding:0;
+    margin: 0;
+    padding: 0;
 }
 .fl-pager .fl-pager-ui li {
-    list-style-type:none;
-    display:inline;
+    list-style-type: none;
+    display: inline;
 }
 .fl-pager .fl-pager-ui a {
-    padding:0 3px;
-    margin:0 2px;
+    margin: 0 2px;
 }
 .fl-pager .fl-pager-ui .fl-pager-links a {
-    border:1px solid #ccc;
-    background-color:#fff;
-    zoom:1;
+    border: 1px solid #ccc;
+    background-color: #fff;
+    zoom: 1;
 }
-.fl-pager .fl-pager-ui .fl-pager-disabled,
 .fl-pager .fl-pager-ui .fl-pager-links .fl-pager-currentPage {
-    color:#000;
-    border:none;
-    background-color:transparent;
-    text-decoration:none;
+    color: #fff;
+    border: none;
+    background-color: #000;
+    text-decoration: none;
+    pointer-events: none;
+    cursor: default;
 }
-.fl-pager .fl-pager-ui .fl-pager-links a:hover {
-    background-color:#0287C5;
-    color:#fff;
-    text-decoration:none;
+.fl-pager .fl-pager-ui .fl-pager-disabled a {
+    color: #afafaf;
+    pointer-events: none;
+    cursor: default;
 }
-.fl-pager .fl-pager-ui .fl-pager-disabled:hover,
 .fl-pager .fl-pager-ui .fl-pager-links .fl-pager-currentPage:hover {
-    background-color:transparent;
-    color:#000;
-    text-decoration:none;
-    cursor:default;
+    background-color: #000;
+    color: #fff;
+    text-decoration: none;
+    cursor: default;
+    pointer-events: none;
+    cursor: default;
 }
-
+.fl-pager .fl-pager-ui .fl-pager-disabled a:hover {
+    color: #afafaf;
+    pointer-events: none;
+    cursor: default;
+}
 
 /***********************************************************/
 /** THEMES - High Contrast **/


### PR DESCRIPTION
Fixes [FLUID-3921](https://issues.fluidproject.org/browse/FLUID-3921) and [FLUID-2779](https://issues.fluidproject.org/browse/FLUID-2779)

Added style to current page link and prev/next link of pager demo for -
1. When a page link is active, cursor is arrow not the hand that appears for links.
2. prev/next links are grayed out when current page link is first or last.

Test -
Tested in the pager demo for which change was intended. 

Minor fix : Indent fix for the .demo-pager-page-size class