### PR TITLE
FLUID-3797: Remove deprecated callbacks from progress component

### DIFF
--- a/src/components/progress/js/Progress.js
+++ b/src/components/progress/js/Progress.js
@@ -180,12 +180,10 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 args: ["{that}.ariaElement", "{that}.options.strings.ariaBusyText"]
             }],
             onProgressBegin: {
-                // Note: callback deprecated as of 1.5, use onProgressBegin event
-                func: "{that}.options.showAnimation.callback"
+                func: "{that}.options.showAnimation.onProgressBegin"
             },
             afterProgressHidden: {
-                // Note: callback deprecated as of 1.5, use afterProgressHidden event
-                func: "{that}.options.hideAnimation.callback"
+                func: "{that}.options.hideAnimation.afterProgressHidden"
             }
         },
         invokers: {
@@ -245,8 +243,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 opacity: "show"
             },
             duration: "slow",
-            //callback has been deprecated and will be removed as of 1.5, instead use onProgressBegin event
-            callback: fluid.identity
+            onProgressBegin: fluid.identity
         }, // equivalent of $().fadeIn("slow")
 
         hideAnimation: {
@@ -254,8 +251,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 opacity: "hide"
             },
             duration: "slow",
-            //callback has been deprecated and will be removed as of 1.5, instead use afterProgressHidden event
-            callback: fluid.identity
+            afterProgressHidden: fluid.identity
         }, // equivalent of $().fadeOut("slow")
 
         minWidth: 5, // 0 length indicators can look broken if there is a long pause between updates

--- a/tests/component-tests/progress/js/ProgressTests.js
+++ b/tests/component-tests/progress/js/ProgressTests.js
@@ -24,8 +24,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var progressELPaths = {
             listenersShowText:   "listeners.onProgressBegin",
             listenersHiddenText: "listeners.afterProgressHidden",
-            showAnimationText:   "showAnimation.callback",
-            hiddenAnimationText: "hideAnimation.callback"
+            showAnimationText:   "showAnimation.onProgressBegin",
+            hiddenAnimationText: "hideAnimation.afterProgressHidden"
         };
 
         // common steps for the progress


### PR DESCRIPTION
Fixes FLUID-3797

1. Removed callback with appropriate event.
2. Fixed tests for the same.

Test -
Progress-test is running successfully for the made changes.