### PR TITLE
FLUID-4137: Update asynchronous unit tests

### DIFF
--- a/tests/framework-tests/core/js/CachingTests.js
+++ b/tests/framework-tests/core/js/CachingTests.js
@@ -90,7 +90,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.module("Caching Tests");
 
         function testSimpleCache(requestDelay) {
-            jqUnit.test("Simple caching test with delay " + requestDelay, function () {
+            jqUnit.asyncTest("Simple caching test with delay " + requestDelay, function () {
                 fluid.log("Begin with delay " + requestDelay);
                 fluid.fetchResources.clearResourceCache(fluid.tests.cacheTestUrl);
                 var fetches = 0;
@@ -108,7 +108,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 window.setTimeout(function () {
                     fluid.fetchResources(fluid.copy(defaults.resources), finalCallback);
                 }, 100);
-                jqUnit.stop();
             });
         }
 
@@ -117,7 +116,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         testSimpleCache(150);
 
         function testProleptickJoinset(delays, message, expectedFinal) {
-            jqUnit.test("Test proleptick joinsets: " + message + " (" + delays.cacheTestUrl3 + ", " + delays.cacheTestUrl4 + ")" , function () {
+            jqUnit.asyncTest("Test proleptick joinsets: " + message + " (" + delays.cacheTestUrl3 + ", " + delays.cacheTestUrl4 + ")" , function () {
                 fluid.log("Begin test " + message);
                 var fetches = {};
                 function countCallback(key) {
@@ -150,7 +149,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                         amalgamateClasses: ["slowTemplate", "fastTemplate"]
                     });
                 }, 100); // TODO: Stability of tests seems to be very sensitive to this timeout
-                jqUnit.stop();
             });
         }
 

--- a/tests/framework-tests/core/js/FluidViewTests.js
+++ b/tests/framework-tests/core/js/FluidViewTests.js
@@ -45,7 +45,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
 
         fluid.registerNamespace("fluid.tests.fluid5821");
-        
+
         fluid.tests.fluid5821.isEmptyJquery = function(message, element, checkSelector) {
             jqUnit.assertEquals(message + ": The element should have a length of zero...", 0, element.length);
             var fieldsToCheck = ["context", "selectorName"];
@@ -65,7 +65,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 emptyString: ""
             }
         });
-        
+
         fluid.tests.assertJQuery = function (message, node) {
             jqUnit.assertValue(message, node.jquery);
         };
@@ -210,7 +210,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         }
 
         function blurTest(message, provokeTarget, provokeOp, shouldBlur, excludeMaker) {
-            jqUnit.test("Dead man's blur test - " + message, function () {
+            jqUnit.asyncTest("Dead man's blur test - " + message, function () {
 
                 noteTime();
 
@@ -255,8 +255,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, blurrer.options.delay - 100);
 
                 window.setTimeout(blurOutwaiter, blurrer.options.delay + 300);
-
-                jqUnit.stop();
             });
         }
 


### PR DESCRIPTION
Update asynchronous unit tests to use asyncTest instead of stop() in
CachingTests.js and FluidViewTests.js

Test-
Tested by running the test.