### PR TITLE
FLUID-4770: Temporary fix for misalignment.

### DIFF
--- a/demos/uploader/css/uploader.css
+++ b/demos/uploader/css/uploader.css
@@ -11,3 +11,11 @@
 .fl-uploader {
     width: 31.5rem
 }
+
+.fl-uploader-browse {
+    width:8em;
+}
+
+.fl-uploader-browse.fl-uploader-browseMore {
+   width: 7em;
+}


### PR DESCRIPTION
Added the code that changes the width of the button to the uploader.css in
the uploader demo. Somehow the text size increases by adding
foundation.css and normalise.css so changing the width in css of the
uploader component itself is meaningless as a change in text size would
make the button misaligned again. Good for a temporary fix so that the demo
work fine. Tested in firefox/IE/Edge/Chrome.
