### PR TITLE
overlapping of text is handled by changing the orientation of text

### DIFF
--- a/demos/uiOptions/css/uiOptions.css
+++ b/demos/uiOptions/css/uiOptions.css
@@ -28,7 +28,7 @@
 
 
 body {
-    font-family: LatoLight, Helvetica, Tahoma, Verdana, sans-serif;
+    font-family: LatoLight, Helvetica, Tahoma, Verdana, sans-serif;z
 }
 img {
     box-shadow: rgba(0,0,0,0.4) 0px 0px 5px 1px;
@@ -41,9 +41,10 @@ main {
 }
 
 .demo-columns {
-    -webkit-columns: 12.5rem 4;
-    -moz-columns: 12.5rem 4;
-    columns: 12.5rem 4;
+
+    -webkit-columns: 20%;
+    -moz-columns: 20%;
+    columns: 20%;
 }
 
 .demo-column {

--- a/demos/uiOptions/css/uiOptions.css
+++ b/demos/uiOptions/css/uiOptions.css
@@ -28,7 +28,7 @@
 
 
 body {
-    font-family: LatoLight, Helvetica, Tahoma, Verdana, sans-serif;z
+    font-family: LatoLight, Helvetica, Tahoma, Verdana, sans-serif;
 }
 img {
     box-shadow: rgba(0,0,0,0.4) 0px 0px 5px 1px;

--- a/demos/uiOptions/index.html
+++ b/demos/uiOptions/index.html
@@ -95,7 +95,6 @@
             </div>
         </div>
         <!-- END markup for Preference Editor -->
-
         <main class="fl-centered">
             <div class="flc-toc-tocContainer toc"> </div>
 


### PR DESCRIPTION
continuation of pull request #688 

when you open it in google chrome web browser there is some overlapping of text is found(in firefox it works fine).
I changed it by changing the orientation of text.
overlapping removed.