### PR TITLE
Fluid-5874: Text overlaps on headers when default theme is used on chrome browser.

### DIFF
--- a/demos/uiOptions/css/uiOptions.css
+++ b/demos/uiOptions/css/uiOptions.css
@@ -46,6 +46,12 @@ main {
     columns: 12.5rem 4;
 }
 
+/*Remove overlapping text on headers with default theme on chrome browser*/
+ .demo-columns p{
+    -webkit-padding-end:2em;
+    -webkit-padding-after: 2em;
+}
+
 .demo-column {
     -webkit-column-break-inside: avoid;
     page-break-inside: avoid;


### PR DESCRIPTION
Overlapping text disappears when default theme is used on chrome.