### PR TITLE
FLUID-3258: Extra <div> in Image Reorderer demo markup not necessary

### DIFF
--- a/demos/reorderer/imageReorderer/index.html
+++ b/demos/reorderer/imageReorderer/index.html
@@ -54,8 +54,6 @@
              <p><strong>Keyboard instructions:</strong> Direction keys (arrow keys or i-j-k-m) move focus. CTRL + direction keys move the item. View an image by using the 'Return' or 'Enter' key.</p>
 
             <form action="#" id="reorder-images-form" class="flc-imageReorderer fl-imageReorderer fl-reorderer-horizontalLayout fl-focus">
-
-                <div>
                     <a href="images/Dragonfruit.jpg" class="flc-imageReorderer-item fl-imageReorderer-item">
                         <img src="images/Dragonfruit.jpg" alt="Dragonfruit thumbnail" />
                         <span class="flc-reorderer-imageTitle  fl-imageReorderer-caption">Dragonfruit</span>
@@ -92,7 +90,6 @@
                         <span class="flc-reorderer-imageTitle  fl-imageReorderer-caption">Grapes</span>
                         <input name="Grapes" value="0" type="hidden" />
                     </a>
-               </div>
             </form>
 
             <script type="text/javascript">


### PR DESCRIPTION
FLUID-3258: Extra < div> in Image Reorderer demo markup not necessary.
The extra < div> tag removed.