### PR TITLE
FLUID-5133/FLUID-5890/FLUID-5478: Improved support for inversion.

### DIFF
--- a/src/framework/core/js/DataBinding.js
+++ b/src/framework/core/js/DataBinding.js
@@ -926,7 +926,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
 
     fluid.priorityHolder.expand = function (priorities) {
         var array = fluid.parsePriorityRecords(priorities, "priorityHolder entry", true);
-        var togo = {}; // note that fluid.transforms.arrayToObject can't unpack this value
+        var togo = {}; // note that fluid.transforms.indexArrayByKey can't unpack this value
         fluid.each(array, function (element, index) {
             togo[element.namespace] = - index * 10;
         });

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -553,7 +553,7 @@ var fluid = fluid || fluid_2_0_0;
         return arg;
     };
 
-    /** Returns the sum of its two arguments. A useful utility to combine with fluid.accumulate to compute totals 
+    /** Returns the sum of its two arguments. A useful utility to combine with fluid.accumulate to compute totals
      * @param a {Number|Boolean} The first operand to be added
      * @param b {Number|Boolean} The second operand to be added
      * @return {Number} The sum of the two operands
@@ -737,7 +737,7 @@ var fluid = fluid || fluid_2_0_0;
     /** Converts a hash into an object by hoisting out the object's keys into an array element via the supplied String "key", and then transforming via an optional further function, which receives the signature
      * (newElement, oldElement, key) where newElement is the freshly cloned element, oldElement is the original hash's element, and key is the key of the element.
      * If the function is not supplied, the old element is simply deep-cloned onto the new element (same effect
-     * as transform fluid.transforms.objectToArray)
+     * as transform fluid.transforms.deindexIntoArrayByKey)
      */
     fluid.hashToArray = function (hash, keyName, func) {
         var togo = [];
@@ -1266,7 +1266,7 @@ var fluid = fluid || fluid_2_0_0;
             }
         }
     };
- 
+
     fluid.parsePriorityRecords = function (records, name, root) {
         var array = fluid.hashToArray(records, "namespace", function (newElement, oldElement, index) {
             if (!root) {

--- a/src/framework/core/js/ModelTransformation.js
+++ b/src/framework/core/js/ModelTransformation.js
@@ -220,15 +220,7 @@ var fluid = fluid || fluid_2_0_0;
             expdef = fluid.defaults("fluid.standardTransformFunction");
         }
         var transformArgs = [transformSpec, transform];
-        if (fluid.hasGrade(expdef, "fluid.standardInputTransformFunction")) {
-            var expanded = fluid.model.transform.getValue(transformSpec.inputPath, transformSpec.input, transform);
-
-            transformArgs.unshift(expanded);
-            // if the function has no input, the result is considered undefined, and this is returned
-            if (expanded === undefined) {
-                return undefined;
-            }
-        } else if (fluid.hasGrade(expdef, "fluid.multiInputTransformFunction")) {
+        if (fluid.hasGrade(expdef, "fluid.multiInputTransformFunction")) {
             var inputs = {};
             fluid.each(expdef.inputVariables, function (v, k) {
                 inputs[k] = function () {
@@ -240,6 +232,15 @@ var fluid = fluid || fluid_2_0_0;
                 };
             });
             transformArgs.unshift(inputs);
+        }
+        if (fluid.hasGrade(expdef, "fluid.standardInputTransformFunction")) {
+            var expanded = fluid.model.transform.getValue(transformSpec.inputPath, transformSpec.input, transform);
+
+            transformArgs.unshift(expanded);
+            // if the function has no input, the result is considered undefined, and this is returned
+            if (expanded === undefined) {
+                return undefined;
+            }
         }
         var transformed = transformFn.apply(null, transformArgs);
         if (fluid.hasGrade(expdef, "fluid.standardOutputTransformFunction")) {
@@ -402,9 +403,11 @@ var fluid = fluid || fluid_2_0_0;
 
         if (standardInput) {
             fluid.model.transform.accumulateStandardInputPath("input", transformSpec, transform, transform.inputPaths);
-        } else if (multiInput) {
+        }
+        if (multiInput) {
             fluid.model.transform.accumulateMultiInputPaths(defaults.inputVariables, transformSpec, transform, transform.inputPaths);
-        } else {
+        }
+        if (!multiInput && !standardInput) {
             var collector = defaults.collectInputPaths;
             if (collector) {
                 var collected = fluid.makeArray(fluid.invokeGlobalFunction(collector, [transformSpec, transform]));

--- a/src/framework/core/js/ModelTransformation.js
+++ b/src/framework/core/js/ModelTransformation.js
@@ -160,13 +160,13 @@ var fluid = fluid || fluid_2_0_0;
 
     // TODO: This cut and pasted code was hoisted out of the inverse of transforms - it needs to go into the
     // the inversion mechanism itself
-    fluid.model.transform.copyInversePaths = function (transformSpec, transformer) {
-        var togo = fluid.copy(transformSpec);
+    fluid.model.transform.invertPaths = function (transformSpec, transformer) {
         // TODO: this will not behave correctly in the face of compound "input" which contains
         // further transforms
-        togo.inputPath = fluid.model.composePaths(transformer.outputPrefix, transformSpec.outputPath);
-        togo.outputPath = fluid.model.composePaths(transformer.inputPrefix, transformSpec.inputPath);
-        return togo;
+        var oldOutput = fluid.model.composePaths(transformer.outputPrefix, transformSpec.outputPath);
+        transformSpec.outputPath = fluid.model.composePaths(transformer.inputPrefix, transformSpec.inputPath);
+        transformSpec.inputPath = oldOutput;
+        return transformSpec;
     };
 
 
@@ -382,9 +382,10 @@ var fluid = fluid || fluid_2_0_0;
     };
     // unsupported, NON-API function
     fluid.model.transform.handleInvertStrategy = function (transformSpec, transform, transformOpts) {
+        transformSpec = fluid.copy(transformSpec);
         // if we have a standardTransformFunction we can switch input and output arguments:
         if (fluid.hasGrade(transformOpts.defaults, "fluid.standardTransformFunction")) {
-            transformSpec = fluid.model.transform.copyInversePaths(transformSpec, transform);
+            transformSpec = fluid.model.transform.invertPaths(transformSpec, transform);
         }
         var invertor = transformOpts.defaults && transformOpts.defaults.invertConfiguration;
         if (invertor) {

--- a/src/framework/core/js/ModelTransformation.js
+++ b/src/framework/core/js/ModelTransformation.js
@@ -382,6 +382,10 @@ var fluid = fluid || fluid_2_0_0;
     };
     // unsupported, NON-API function
     fluid.model.transform.handleInvertStrategy = function (transformSpec, transform, transformOpts) {
+        // if we have a standardTransformFunction we can switch input and output arguments:
+        if (fluid.hasGrade(transformOpts.defaults, "fluid.standardTransformFunction")) {
+            transformSpec = fluid.model.transform.copyInversePaths(transformSpec, transform);
+        }
         var invertor = transformOpts.defaults && transformOpts.defaults.invertConfiguration;
         if (invertor) {
             var inverted = fluid.invokeGlobalFunction(invertor, [transformSpec, transform]);

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -118,7 +118,7 @@ var fluid = fluid || fluid_2_0_0;
 
 
     fluid.defaults("fluid.transforms.firstValue", {
-        gradeNames: "fluid.transformFunction"
+        gradeNames: "fluid.standardOutputTransformFunction"
     });
 
     fluid.transforms.firstValue = function (transformSpec, transformer) {

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -719,4 +719,42 @@ var fluid = fluid || fluid_2_0_0;
         return fluid.invokeGlobalFunction(transformSpec.func, args);
     };
 
+    fluid.defaults("fluid.transforms.quantize", {
+        gradeNames: "fluid.standardTransformFunction"
+    });
+
+    /**
+     * Quantize function maps a continuous range into discrete values. Given an input, it will
+     * be matched into a discrete bucket and the corresponding output will be done.
+     */
+    fluid.transforms.quantize = function (value, transformSpec, transform) {
+        if (!transformSpec.ranges || !transformSpec.ranges.length) {
+            fluid.fail("fluid.transforms.quantize should have a key called ranges containing an array defining ranges to quantize");
+        }
+        // TODO: error checking that upper bounds are all numbers and increasing
+        for (var i = 0; i < transformSpec.ranges.length; i++) {
+            var rangeSpec = transformSpec.ranges[i];
+            if (value <= rangeSpec.upperBound || rangeSpec.upperBound === undefined && value >= Number.NEGATIVE_INFINITY) {
+                return fluid.isPrimitive(rangeSpec.output) ? rangeSpec.output : transform.expand(rangeSpec.output);
+            }
+        }
+    };
+
+    /**
+     * inRange transformer checks whether a value is within a given range and returns true if it is,
+     * and false if it's not.
+     *
+     * The range is defined by the two inputs: "min" and "max" (both inclusive). If one of these inputs
+     * is not present it is considered -infinite and +infinite, respectively - In other words, if no
+     * `min` value is defined, any value below or equal to the given "max" value will result in true.
+     */
+    fluid.defaults("fluid.transforms.inRange", {
+        gradeNames: "fluid.standardTransformFunction"
+    });
+
+    fluid.transforms.inRange = function (value, transformSpec) {
+        return (transformSpec.min === undefined || transformSpec.min <= value) &&
+            (transformSpec.max === undefined ||  transformSpec.max >= value) ? true : false;
+    };
+
 })(jQuery, fluid_2_0_0);

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -159,7 +159,9 @@ var fluid = fluid || fluid_2_0_0;
 
     /* TODO: This inversion doesn't work if the value and factors are given as paths in the source model */
     fluid.transforms.linearScale.invert = function (transformSpec, transformer) {
-        var togo = fluid.model.transform.copyInversePaths(transformSpec, transformer);
+        // we can use this function since one of our inputs is named and behaves
+        // like input/inputPaths of the standardInputTransformFunction
+        var togo = fluid.model.transform.invertPaths(transformSpec, transformer);
 
         if (togo.factor !== undefined) {
             togo.factor = (togo.factor === 0) ? 0 : 1 / togo.factor;
@@ -397,14 +399,13 @@ var fluid = fluid || fluid_2_0_0;
      * * each [key]=value entry in the options is swapped to be: [value]=key
      */
     fluid.transforms.arrayToSetMembership.invertWithType = function (transformSpec, transformer, newType) {
-        var togo = fluid.copy(transformSpec);
-        togo.type = newType;
+        transformSpec.type = newType;
         var newOptions = {};
         fluid.each(transformSpec.options, function (path, oldKey) {
             newOptions[path] = oldKey;
         });
-        togo.options = newOptions;
-        return togo;
+        transformSpec.options = newOptions;
+        return transformSpec;
     };
 
     fluid.transforms.arrayToSetMembership.invert = function (transformSpec, transformer) {
@@ -554,19 +555,18 @@ var fluid = fluid || fluid_2_0_0;
     };
 
     fluid.transforms.arrayToObject.invert = function (transformSpec) {
-        var togo = fluid.copy(transformSpec);
-        togo.type = "fluid.transforms.objectToArray";
+        transformSpec.type = "fluid.transforms.objectToArray";
         // invert transforms from innerValue as well:
         // TODO: The Model Transformations framework should be capable of this, but right now the
         // issue is that we use a "private contract" to operate the "innerValue" slot. We need to
         // spend time thinking of how this should be formalised
-        if (togo.innerValue) {
-            var innerValue = togo.innerValue;
+        if (transformSpec.innerValue) {
+            var innerValue = transformSpec.innerValue;
             for (var i = 0; i < innerValue.length; ++i) {
                 innerValue[i] = fluid.model.transform.invertConfiguration(innerValue[i]);
             }
         }
-        return togo;
+        return transformSpec;
     };
 
 
@@ -606,19 +606,18 @@ var fluid = fluid || fluid_2_0_0;
     };
 
     fluid.transforms.objectToArray.invert = function (transformSpec) {
-        var togo = fluid.copy(transformSpec);
-        togo.type = "fluid.transforms.arrayToObject";
+        transformSpec.type = "fluid.transforms.arrayToObject";
         // invert transforms from innerValue as well:
         // TODO: The Model Transformations framework should be capable of this, but right now the
         // issue is that we use a "private contract" to operate the "innerValue" slot. We need to
         // spend time thinking of how this should be formalised
-        if (togo.innerValue) {
-            var innerValue = togo.innerValue;
+        if (transformSpec.innerValue) {
+            var innerValue = transformSpec.innerValue;
             for (var i = 0; i < innerValue.length; ++i) {
                 innerValue[i] = fluid.model.transform.invertConfiguration(innerValue[i]);
             }
         }
-        return togo;
+        return transformSpec;
     };
 
     fluid.defaults("fluid.transforms.limitRange", {

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -52,13 +52,6 @@ var fluid = fluid || fluid_2_0_0;
     };
 
 
-    fluid.defaults("fluid.transforms.arrayValue", {
-        gradeNames: "fluid.standardTransformFunction"
-    });
-
-    fluid.transforms.arrayValue = fluid.makeArray;
-
-
     fluid.defaults("fluid.transforms.stringToNumber", {
         gradeNames: ["fluid.standardTransformFunction", "fluid.lens"],
         invertConfiguration: "fluid.transforms.stringToNumber.invert"

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -426,9 +426,9 @@ var fluid = fluid || fluid_2_0_0;
         }
 
         var outputArr = [];
-        fluid.each(input, function (val, key) {
-            if (val === transformSpec.presentValue) {
-                outputArr.push(options[key]);
+        fluid.each(options, function (outputVal, key) {
+            if (input[key] === transformSpec.presentValue) {
+                outputArr.push(outputVal);
             }
         });
         return outputArr;

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -1216,6 +1216,17 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             values: ["hippo", "cat"]
         },
         expected: fluid.tests.transforms.source.hippo
+    }, {
+        message: "firstValue() should return the first non-undefined value in paths",
+        transform: {
+            type: "fluid.transforms.firstValue",
+            values: ["cat", "dog"],
+            outputPath: "whichanimal"
+        },
+        expected: {
+            whichanimal: fluid.tests.transforms.source.cat
+        },
+        method: "assertDeepEq"
     }];
 
     jqUnit.test("fluid.transforms.firstValue()", function () {

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -881,50 +881,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         });
     });
 
-    var arrayValueTests = [{
-        message: "arrayValue() should box a non-array value up as one.",
-        transformWrap: true,
-        transform: {
-            type: "fluid.transforms.arrayValue",
-            inputPath: "cat"
-        },
-        expected: [fluid.tests.transforms.source.cat]
-    }, {
-        message: "arrayValue() should not box up an array value.",
-        transformWrap: true,
-        transform: {
-            type: "fluid.transforms.arrayValue",
-            inputPath: "sheep"
-        },
-        expected: fluid.tests.transforms.source.sheep
-    }, {
-        message: "FLUID-5248: arrayValue() with a nested transformation",
-        transformWrap: false,
-        transform: {
-            "b": {
-                "transform": {
-                    "type": "fluid.transforms.arrayValue",
-                    "input": {
-                        "transform": {
-                            "type": "fluid.transforms.linearScale",
-                            "input": 5,
-                            "factor": 0.1
-                        }
-                    }
-                }
-            }
-        },
-        expected: {
-            "b": [0.5]
-        }
-    }];
-
-    jqUnit.test("fluid.transforms.arrayValue()", function () {
-        fluid.tests.transforms.testOneStructure(arrayValueTests, {
-            method: "assertDeepEq"
-        });
-    });
-
     var stringToNumberTests = [{
         message: "stringToNumber() converts integers.",
         transformWrap: true,

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -3699,6 +3699,53 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             ]
         },
         fullyInvertible: true
+    }, {
+        message: "Checking for missing / extra values",
+        model: {
+            detections: {
+                hasMouse: "supported",
+                hasKeyboard: "supported",
+                hasTrackpad: "not supported",
+                hasHeadtracker: "not supported",
+                hasTelephone: "supported"
+            }
+        },
+        transform: {
+            transform: {
+                type: "fluid.transforms.setMembershipToArray",
+                inputPath: "detections",
+                outputPath: "controls",
+                presentValue: "supported",
+                missingValue: "not supported",
+                options: {
+                    hasMouse: "mouse",
+                    hasKeyboard: "keyboard",
+                    hasTrackpad: "trackpad",
+                    hasHeadtracker: "headtracker"
+                }
+            }
+        },
+        expected: {
+            controls: [ "mouse", "keyboard" ]
+        },
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "detections",
+                    inputPath: "controls",
+                    presentValue: "supported",
+                    missingValue: "not supported",
+                    options: {
+                        mouse: "hasMouse",
+                        keyboard: "hasKeyboard",
+                        trackpad: "hasTrackpad",
+                        headtracker: "hasHeadtracker"
+                    }
+                }
+            ]
+        },
+        partlyInvertible: true
     }];
 
     jqUnit.test("setMembershipToArray transformation tests", function () {

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -3325,7 +3325,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         });
 
         fluid.tests.transforms.testOneStructure(fluid.tests.transforms.indexOfBoundaryTests, {
-            transformWrap: true
+            transformWrap: true,
+            partlyInvertible: true
         });
     });
 
@@ -3466,15 +3467,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             offset: 3
         },
         expected: undefined
-    }, {
-        message: "dereference() should return what's defined in the notFound when the value is not found in the array.",
-        transform: {
-            type: "fluid.transforms.dereference",
-            array: ["sheep", "dog"],
-            input: -1,
-            notFound: "notFound"
-        },
-        expected: "notFound"
     }];
 
     jqUnit.test("fluid.transforms.dereference()", function () {


### PR DESCRIPTION
* Rolled the switcheroo of inputPath and outputPath for standardTransformFunctions into the general framework inversion functions.
* Went through all transforms and checked for correctness and tests.
* Notes on invertibility will be added to the documentation (currently kept here: https://issues.fluidproject.org/browse/FLUID-5133) - will be added after discussion with antranig
* Added inRange and quantize functions (FLUID-5890)
* Added inverse function of stringToNumber (namely numberToString) - plus made both functions lenses
* Changed arrayToSetMembership and setMembershipToArray's grades to be standardTransformFunction
* Added a few tests where needed