### PR TITLE
FLUID-5886: Fix for failure to deduplicate model listeners by namespace

### DIFF
--- a/src/framework/core/js/DataBinding.js
+++ b/src/framework/core/js/DataBinding.js
@@ -348,7 +348,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             var that = recel.that;
             var transac = transacs[that.id];
             if (recel.completeOnInit) {
-                fluid.initModelEvent(that, that.applier, transac, that.applier.changeListeners.listeners);
+                fluid.initModelEvent(that, that.applier, transac, that.applier.listeners.sortedListeners);
             } else {
                 fluid.each(recel.initModels, function (initModel) {
                     transac.fireChangeRequest({type: "ADD", segs: [], value: initModel});
@@ -564,22 +564,22 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 }
             }
         };
-        sourceListener.relayListenerId = fluid.allocateGuid();
+        var spec;
         if (sourceSegs) {
-            fluid.log(fluid.logLevel.TRACE, "Adding relay listener with id " + sourceListener.relayListenerId + " to source applier with id " +
-                sourceApplier.applierId + " from target applier with id " + applierId + " for target component with id " + target.id);
-            sourceApplier.modelChanged.addListener({
+            spec = sourceApplier.modelChanged.addListener({
                 isRelay: true,
                 segs: sourceSegs,
                 transactional: options.transactional
             }, sourceListener);
+            fluid.log(fluid.logLevel.TRACE, "Adding relay listener with listenerId " + spec.listenerId + " to source applier with id " +
+                sourceApplier.applierId + " from target applier with id " + applierId + " for target component with id " + target.id);
         }
         if (source) { // TODO - we actually may require to register on THREE sources in the case modelRelay is attached to a
             // component which is neither source nor target. Note there will be problems if source, say, is destroyed and recreated,
             // and holder is not - relay will in that case be lost. Need to integrate relay expressions with IoCSS.
-            fluid.recordChangeListener(source, sourceApplier, sourceListener);
+            fluid.recordChangeListener(source, sourceApplier, sourceListener, spec.listenerId);
             if (target !== source) {
-                fluid.recordChangeListener(target, sourceApplier, sourceListener);
+                fluid.recordChangeListener(target, sourceApplier, sourceListener, spec.listenerId);
             }
         }
     };
@@ -1276,6 +1276,9 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     };
 
     fluid.notifyModelChanges = function (listeners, changeMap, newHolder, oldHolder, changeRequest, transaction, applier, that) {
+        if (!listeners) {
+            return;
+        }
         var transRec = transaction && fluid.getModelTransactionRec(that, transaction.id);
         for (var i = 0; i < listeners.length; ++ i) {
             var spec = listeners[i];
@@ -1374,17 +1377,16 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         options = fluid.model.defaultAccessorConfig(options);
         var applierId = fluid.allocateGuid();
         var that = new fluid.ChangeApplier();
+        var name = fluid.isComponent(holder) ? "ChangeApplier for component " + fluid.dumpThat(holder) : "ChangeApplier with id " + applierId;
         $.extend(that, {
             applierId: applierId,
             holder: holder,
-            changeListeners: {
-                listeners: [],
-                transListeners: []
-            },
+            listeners: fluid.makeEventFirer({name: "Internal change listeners for " + name}),
+            transListeners: fluid.makeEventFirer({name: "External change listeners for " + name}),
             options: options,
             modelChanged: {},
-            preCommit: fluid.makeEventFirer({name: "preCommit event for ChangeApplier " }),
-            postCommit: fluid.makeEventFirer({name: "postCommit event for ChangeApplier "})
+            preCommit: fluid.makeEventFirer({name: "preCommit event for " + name}),
+            postCommit: fluid.makeEventFirer({name: "postCommit event for " + name})
         });
         that.destroy = function () {
             that.preCommit.destroy();
@@ -1394,13 +1396,12 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         that.modelChanged.addListener = function (spec, listener, namespace, softNamespace) {
             if (typeof(spec) === "string") {
                 spec = {
-                    path: spec,
-                    listenerId: fluid.event.identifyListener(listener)
+                    path: spec
                 };
             } else {
                 spec = fluid.copy(spec);
             }
-            spec.listenerId = spec.listenerId || fluid.event.identifyListener(listener); // analogous to listenerId in IoC listener records
+            spec.listenerId = spec.listenerId || fluid.allocateGuid(); // FLUID-5151: don't use identifyListener since event.addListener will use this as a namespace
             spec.namespace = namespace;
             spec.softNamespace = softNamespace;
             if (typeof(listener) === "string") { // The reason for "globalName" is so that listener names can be resolved on first use and not on registration
@@ -1418,7 +1419,6 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                     spec.segsArray = [spec.segs];
                 }
             }
-            var collection = that.changeListeners[spec.transactional ? "transListeners" : "listeners"];
             fluid.parseSourceExclusionSpec(spec, spec);
             spec.wildcard = fluid.accumulate(fluid.transform(spec.segsArray, function (segs) {
                 return fluid.contains(segs, "*");
@@ -1426,20 +1426,13 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             if (spec.wildcard && spec.segsArray.length > 1) {
                 fluid.fail("Error in model listener specification ", spec, " - you may not supply a wildcard pattern as one of a set of multiple paths to be matched");
             }
-
-            spec.priority = fluid.parsePriority(spec.priority, collection.length, false, "model listener");
-            collection.push(spec);
-            return spec;
+            var firer = that[spec.transactional ? "transListeners" : "listeners"];
+            firer.addListener(spec);
+            return spec; // return is used in registerModelListeners
         };
-        // TODO: Reorganise when we refactor transactions - this duplicates the function of standard fluid.event.removeListener
         that.modelChanged.removeListener = function (listener) {
-            var id = fluid.event.identifyListener(listener);
-            var namespace = typeof(listener) === "string" ? listener : null;
-            var removePred = function (record) { // listenerId is ALWAYS set, namespace is not always - same alg but variant impl from plain events because we don't have index here
-                return record.listenerId === id || record.listenerId === namespace || (namespace && record.namespace === namespace);
-            };
-            fluid.remove_if(that.changeListeners.listeners, removePred);
-            fluid.remove_if(that.changeListeners.transListeners, removePred);
+            that.listeners.removeListener(listener);
+            that.transListeners.removeListener(listener);
         };
         that.fireChangeRequest = function (changeRequest) {
             var ation = that.initiate("local", changeRequest.source);
@@ -1475,7 +1468,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                     if (trans.changeRecord.changes > 0) {
                         var oldHolder = {model: holder.model};
                         holder.model = trans.newHolder.model;
-                        fluid.notifyModelChanges(that.changeListeners.transListeners, trans.changeRecord.changeMap, holder, oldHolder, null, trans, that, holder);
+                        fluid.notifyModelChanges(that.transListeners.sortedListeners, trans.changeRecord.changeMap, holder, oldHolder, null, trans, that, holder);
                     }
                     if (!defeatPost) {
                         that.postCommit.fire(trans, that, code);
@@ -1485,7 +1478,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                     fluid.preFireChangeRequest(that, changeRequest);
                     changeRequest.transactionId = trans.id;
                     var deltaMap = fluid.model.applyHolderChangeRequest(trans.newHolder, changeRequest, trans.changeRecord);
-                    fluid.notifyModelChanges(that.changeListeners.listeners, deltaMap, trans.newHolder, holder, changeRequest, trans, that, holder);
+                    fluid.notifyModelChanges(that.listeners.sortedListeners, deltaMap, trans.newHolder, holder, changeRequest, trans, that, holder);
                 },
                 hasChangeSource: function (source) {
                     return trans.fullSources[source];

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1341,9 +1341,9 @@ var fluid = fluid || fluid_2_0_0;
     /** Construct an "event firer" object which can be used to register and deregister
      * listeners, to which "events" can be fired. These events consist of an arbitrary
      * function signature. General documentation on the Fluid events system is at
-     * http://wiki.fluidproject.org/display/fluid/The+Fluid+Event+System .
+     * http://docs.fluidproject.org/infusion/development/InfusionEventSystem.html .
      * @param {Object} options - A structure to configure this event firer. Supported fields:
-     *     {String} name - a name for this firer
+     *     {String} name - a readable name for this firer to be used in diagnostics and debugging
      *     {Boolean} preventable - If <code>true</code> the return value of each handler will
      * be checked for <code>false</code> in which case further listeners will be shortcircuited, and this
      * will be the return value of fire()
@@ -1357,7 +1357,15 @@ var fluid = fluid || fluid_2_0_0;
             that.listeners = {};
             that.byId = {};
             that.sortedListeners = [];
-            // TODO: arguments after 2nd are not part of public API - reform to use "options form" for all of these
+            // arguments after 3rd are not part of public API
+            // listener as Object is used only by ChangeApplier to tunnel path, segs, etc as part of its "spec"
+            /** Adds a listener to this event.
+              * @param listener {Function|String} The listener function to be added, or a global name resolving to a function. The signature of the function is arbitrary and matches that sent to event.fire()
+              * @param namespace {String} (Optional) A namespace for this listener. At most one listener with a particular namespace can be active on an event at one time. Removing successively added listeners with a particular
+              * namespace will expose previously added ones in a stack idiom
+              * @param priority {String|Number} A priority for the listener relative to others, perhaps expressed with a constraint relative to the namespace of another - see
+              * http://docs.fluidproject.org/infusion/development/Priorities.html
+              */
             that.addListener = function (listener, namespace, priority, softNamespace, listenerId) {
                 var record;
                 if (that.destroyed) {
@@ -1407,6 +1415,10 @@ var fluid = fluid || fluid_2_0_0;
             addListener: function () {
                 lazyInit.apply(null, arguments);
             },
+            /** Removes a listener previously registered with this event.
+              * @param toremove {Function|String} Either the listener function, the namespace of a listener (in which case a previous listener with that namespace may be uncovered) or an id sent to the undocumented
+              * `listenerId` argument of `addListener
+              */
             // Can be supplied either listener, namespace, or id (which may match either listener function's guid or original listenerId argument)
             removeListener: function (listener) {
                 if (!that.listeners) { return; }
@@ -1444,6 +1456,7 @@ var fluid = fluid || fluid_2_0_0;
                 }
                 that.sortedListeners = fluid.event.sortListeners(that.listeners);
             },
+            /** Fires this event to all listeners which are active. They will be notified in order of priority. The signature of this method is free **/
             fire: function () {
                 var listeners = that.sortedListeners;
                 if (!listeners || that.destroyed) { return; }

--- a/src/framework/core/js/Fluid.js
+++ b/src/framework/core/js/Fluid.js
@@ -1379,9 +1379,8 @@ var fluid = fluid || fluid_2_0_0;
                     listener = record.listener;
                     namespace = record.namespace;
                     priority = record.priority;
+                    softNamespace = record.softNamespace;
                     listenerId = record.listenerId;
-                } else {
-                    record = {};
                 }
                 if (typeof(listener) === "string") {
                     listener = {globalName: listener};

--- a/tests/framework-tests/core/js/DataBindingTests.js
+++ b/tests/framework-tests/core/js/DataBindingTests.js
@@ -435,7 +435,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var that = fluid.tests.fluid4258head();
         function assertListenerCount(count) {
             // blatant white-box testing - make sure that the outer applier has the expected number of listeners
-            jqUnit.assertEquals("Expected external model listener count ", count, that.applier.changeListeners.transListeners.length);
+            jqUnit.assertEquals("Expected external model listener count ", count, that.applier.transListeners.sortedListeners.length);
         }
         assertListenerCount(2);
         that.applier.change("thing1.nest1", 3);
@@ -776,6 +776,36 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         that2.child1.applier.change("celsius", 30);
         var expected2 = [1, 1, "last", "last"];
         jqUnit.assertDeepEq("Model notifications globally sorted by priority, with actioned listener removal", expected2, that2.priorityLog);
+    });
+
+    /** FLUID-5886: Deduplication of listeners by namespace at a single applier **/
+    
+    fluid.defaults("fluid.tests.fluid5886head", {
+        gradeNames: "fluid.modelComponent",
+        members: {
+            listenerCount: 0
+        },
+        modelListeners: {
+            target: [{
+                namespace: "deduplicate",
+                funcName: "fluid.tests.fluid5886count",
+                args: "{that}"
+            }, {
+                namespace: "deduplicate",
+                funcName: "fluid.tests.fluid5886count",
+                args: "{that}"
+            }]
+        }
+    });
+    
+    fluid.tests.fluid5886count = function (that) {
+        that.listenerCount++;
+    };
+    
+    jqUnit.test("FLUID-5886: Deduplication of model listeners by namespace at single applier", function () {
+        var that = fluid.tests.fluid5886head();
+        that.applier.change("target", true);
+        jqUnit.assertEquals("Just one listener registered", 1, that.listenerCount);
     });
 
     /** FLUID-5695: New-style multiple paths and namespaces for model listeners **/
@@ -2159,7 +2189,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             singleTransform: {
                 type: "fluid.transforms.indexOf",
                 array: "{that}.options.lang",
-                value: "{that}.model.lang",
+                input: "{that}.model.lang",
                 offset: 1
             }
         }, {
@@ -2244,6 +2274,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return togo;
     };
 
-    // fluid.test.runTests(["fluid.tests.fluid5659root"]);
+    fluid.test.runTests(["fluid.tests.fluid5659root"]);
 
 })(jQuery);

--- a/tests/framework-tests/core/js/FluidJSTests.js
+++ b/tests/framework-tests/core/js/FluidJSTests.js
@@ -27,7 +27,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     fluid.tests.plainObjectTrue = {
         "object": {},
-        "array": [],
         "noproto": Object.create(null),
         "malignNoProto": Object.create(null, {"constructor": {value: "thing"}})
     };
@@ -43,10 +42,14 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     jqUnit.test("fluid.isPlainObject tests", function () {
         fluid.each(fluid.tests.plainObjectTrue, function (totest, key) {
             jqUnit.assertEquals("Expected plain: " + key, true, fluid.isPlainObject(totest));
+            jqUnit.assertEquals("Expected plain in strict: " + key, true, fluid.isPlainObject(totest, true));
         });
         fluid.each(fluid.tests.plainObjectFalse, function (totest, key) {
             jqUnit.assertEquals("Expected nonplain: " + key, false, fluid.isPlainObject(totest));
+            jqUnit.assertEquals("Expected nonplain in strict: " + key, false, fluid.isPlainObject(totest, true));
         });
+        jqUnit.assertEquals("Array is plain by standard", true, fluid.isPlainObject([]));
+        jqUnit.assertEquals("Array is nonplain in strict", false, fluid.isPlainObject([], true));
     });
 
     jqUnit.test("fluid.makeArray tests", function () {

--- a/tests/test-core/utils/js/IoCTestUtils.js
+++ b/tests/test-core/utils/js/IoCTestUtils.js
@@ -391,19 +391,21 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     fluid.test.decoders.changeEvent = function (testCaseState, fixture) {
         var event = testCaseState.expand(fixture.changeEvent);
         var listener = fluid.test.decodeListener(testCaseState, fixture);
+        var listenerId = fluid.allocateGuid();
         var that = fluid.test.makeBinder(listener, function (wrapped) {
             var spec = fixture.path === undefined ? fixture.spec : {path: fixture.path};
             if (spec === undefined || spec.path === undefined) {
                 fluid.fail("Error in changeEvent fixture ", fixture,
                    ": could not find path specification named \"path\" or \"spec\"");
             }
+            spec.listenerId = listenerId;
             spec.transactional = true;
             if (spec.priority === undefined) {
                 spec.priority = "last:testing";
             }
             event.addListener(spec, wrapped, fixture.namespace);
-        }, function (wrapped) {
-            event.removeListener(wrapped);
+        }, function () {
+            event.removeListener(listenerId);
         });
         return that;
     };


### PR DESCRIPTION
at a single applier. This rebalances the implementation of change events and standard events, with the former now implemented in terms of the latter. This introduces a new options-based API for event.addListener and an improved fluid.isPlainObject.