### PR TITLE
Updates Fedora to 23 and Node.js to the LTS branch.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ ram = ENV["VM_RAM"] || 2048
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "inclusivedesign/fedora22"
+  config.vm.box = "inclusivedesign/fedora23"
 
   # Your working directory will be synced to /home/vagrant/sync in the VM.
   config.vm.synced_folder ".", "#{app_directory}"

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -4,7 +4,7 @@
 
 nodejs_app_name: infusion
 
-nodejs_version: 0.10.40
+nodejs_branch: lts
 
 nodejs_app_npm_packages:
   - testem
@@ -16,4 +16,3 @@ nodejs_app_commands:
 nodejs_app_install_dir: /home/vagrant/sync
 
 nodejs_app_git_clone: false
-


### PR DESCRIPTION
Spinning up a vagrant box was failing for me. I'm assuming it's related to someone upstream removing the recipe for Node.js 0.10.40 since it's so old. This pull request updates us to the latest LTS version of Node.js, as well as to Fedora 23.