### PR TITLE
FLUID-5192: Removed strings for slider icons

### DIFF
--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -663,8 +663,6 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         selectors: {
             textSize: ".flc-prefsEditor-min-text-size",
             label: ".flc-prefsEditor-min-text-size-label",
-            smallIcon: ".flc-prefsEditor-min-text-size-smallIcon",
-            largeIcon: ".flc-prefsEditor-min-text-size-largeIcon",
             multiplier: ".flc-prefsEditor-multiplier",
             textSizeDescr: ".flc-prefsEditor-text-size-descr"
         },
@@ -685,8 +683,6 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         },
         protoTree: {
             label: {messagekey: "textSizeLabel"},
-            smallIcon: {messagekey: "textSizeSmallIcon"},
-            largeIcon: {messagekey: "textSizeLargeIcon"},
             multiplier: {messagekey: "multiplier"},
             textSizeDescr: {messagekey: "textSizeDescr"}
         },
@@ -768,8 +764,6 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         selectors: {
             lineSpace: ".flc-prefsEditor-line-space",
             label: ".flc-prefsEditor-line-space-label",
-            narrowIcon: ".flc-prefsEditor-line-space-narrowIcon",
-            wideIcon: ".flc-prefsEditor-line-space-wideIcon",
             multiplier: ".flc-prefsEditor-multiplier",
             lineSpaceDescr: ".flc-prefsEditor-line-space-descr"
         },
@@ -790,8 +784,6 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         },
         protoTree: {
             label: {messagekey: "lineSpaceLabel"},
-            narrowIcon: {messagekey: "lineSpaceNarrowIcon"},
-            wideIcon: {messagekey: "lineSpaceWideIcon"},
             multiplier: {messagekey: "multiplier"},
             lineSpaceDescr: {messagekey: "lineSpaceDescr"}
         },

--- a/src/framework/preferences/messages/lineSpace.json
+++ b/src/framework/preferences/messages/lineSpace.json
@@ -1,7 +1,5 @@
 {
     "lineSpaceLabel": "Line Spacing",
-    "lineSpaceNarrowIcon": "icon of 3 horizontal lines with narrow spacing",
-    "lineSpaceWideIcon": "icon of 3 horizontal lines with wide spacing",
     "multiplier": "times",
     "lineSpaceDescr": "Adjust the spacing between lines of text"
 }

--- a/src/framework/preferences/messages/textSize.json
+++ b/src/framework/preferences/messages/textSize.json
@@ -1,7 +1,5 @@
 {
     "textSizeLabel": "Text Size",
-    "textSizeSmallIcon": "icon of a small capital letter 'A'",
-    "textSizeLargeIcon": "icon of a large capital letter 'A'",
     "multiplier": "times",
     "textSizeDescr": "Adjust text size"
 }

--- a/tests/framework-tests/preferences/data/lineSpace_en.json
+++ b/tests/framework-tests/preferences/data/lineSpace_en.json
@@ -1,6 +1,4 @@
 {
     "lineSpaceLabel": "Line Spacing",
-    "lineSpaceNarrowIcon": "icon of 3 horizontal lines with narrow spacing",
-    "lineSpaceWideIcon": "icon of 3 horizontal lines with wide spacing",
     "multiplier": "times"
 }

--- a/tests/framework-tests/preferences/data/textSize_en.json
+++ b/tests/framework-tests/preferences/data/textSize_en.json
@@ -1,6 +1,4 @@
 {
     "textSizeLabel": "Text Size",
-    "textSizeSmallIcon": "icon of a small capital letter 'A'",
-    "textSizeLargeIcon": "icon of a large capital letter 'A'",
     "multiplier": "times"
 }

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -477,14 +477,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         selectors: {
             textSize: ".flc-prefsEditor-min-val",
             label: ".flc-prefsEditor-min-val-label",
-            smallIcon: ".flc-prefsEditor-min-val-smallIcon",
-            largeIcon: ".flc-prefsEditor-min-val-largeIcon",
             multiplier: ".flc-prefsEditor-multiplier"
         },
         protoTree: {
             label: {messagekey: "textSizeLabel"},
-            smallIcon: {messagekey: "textSizeSmallIcon"},
-            largeIcon: {messagekey: "textSizeLargeIcon"},
             multiplier: {messagekey: "multiplier"},
             textSize: {
                 decorators: {
@@ -790,8 +786,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         selectors: {
             textSize: ".flc-prefsEditor-min-val",
             label: ".flc-prefsEditor-min-val-label",
-            smallIcon: ".flc-prefsEditor-min-val-smallIcon",
-            largeIcon: ".flc-prefsEditor-min-val-largeIcon",
             multiplier: ".flc-prefsEditor-multiplier"
         },
         selectorsToIgnore: ["textSize"],
@@ -815,8 +809,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         protoTree: {
             label: {messagekey: "textSizeLabel"},
-            smallIcon: {messagekey: "textSizeSmallIcon"},
-            largeIcon: {messagekey: "textSizeLargeIcon"},
             multiplier: {messagekey: "multiplier"}
         }
     });
@@ -826,8 +818,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         selectors: {
             textSize: ".flc-prefsEditor-min-val",
             label: ".flc-prefsEditor-min-val-label",
-            smallIcon: ".flc-prefsEditor-min-val-smallIcon",
-            largeIcon: ".flc-prefsEditor-min-val-largeIcon",
             multiplier: ".flc-prefsEditor-multiplier"
         },
         selectorsToIgnore: ["textSize"],
@@ -851,8 +841,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         protoTree: {
             label: {messagekey: "textSizeLabel"},
-            smallIcon: {messagekey: "textSizeSmallIcon"},
-            largeIcon: {messagekey: "textSizeLargeIcon"},
             multiplier: {messagekey: "multiplier"}
         }
     });
@@ -1381,8 +1369,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         messageBase: {
             "lineSpaceLabel": "Line Spacing",
-            "lineSpaceNarrowIcon": "icon of 3 horizontal lines with narrow spacing",
-            "lineSpaceWideIcon": "icon of 3 horizontal lines with wide spacing",
             "multiplier": "times",
             "lineSpaceDescr": "Adjust the spacing between lines of text"
         }


### PR DESCRIPTION
It was determined in FLUID-5680 that the icons for the sliders are presentational.
The labels were not being used either so I have removed all of the strings and associated
code to insert them into the DOM.

https://issues.fluidproject.org/browse/FLUID-5192