### PR TITLE
FLUID-5872: Setting the iframe source programmatically

### DIFF
--- a/tests/component-tests/tooltip/html/Tooltip-test.html
+++ b/tests/component-tests/tooltip/html/Tooltip-test.html
@@ -53,7 +53,7 @@
              <a class="testDelegateTooltip" id="anchor-2" href="#">tooltip anchor 2</a>
          </div>
          <div class="FLUID-5846">
-             <iframe src="iframe.html" class="FLUID-5846-iframe"></iframe>
+             <iframe class="FLUID-5846-iframe"></iframe>
          </div>
       </div>
       <script>

--- a/tests/component-tests/tooltip/js/TooltipTests.js
+++ b/tests/component-tests/tooltip/js/TooltipTests.js
@@ -212,7 +212,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
 
     fluid.tests.tooltip.FLUID5846.setupIframe = function (that, iframeSrc, iframe) {
-        $(iframe).attr("src", iframeSrc);
         $(iframe).load(function () {
             // DO NOT MOVE this property access outside this function!
             var dokkument = iframe.contentDocument;
@@ -221,6 +220,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             that.iframeBody = iframejQuery("body", dokkument);
             that.events.iframeReady.fire();
         });
+
+        // Programmatically setting the iframe src to ensure that the load event
+        // is triggered after we have bound our listener.
+        // see: https://issues.fluidproject.org/browse/FLUID-5872
+        $(iframe).attr("src", iframeSrc);
     };
 
     fluid.defaults("fluid.tests.tooltip.FLUID5846.parent", {

--- a/tests/component-tests/tooltip/js/TooltipTests.js
+++ b/tests/component-tests/tooltip/js/TooltipTests.js
@@ -211,7 +211,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     });
 
-    fluid.tests.tooltip.FLUID5846.setupIframe = function (that, iframe) {
+    fluid.tests.tooltip.FLUID5846.setupIframe = function (that, iframeSrc, iframe) {
+        $(iframe).attr("src", iframeSrc);
         $(iframe).load(function () {
             // DO NOT MOVE this property access outside this function!
             var dokkument = iframe.contentDocument;
@@ -234,8 +235,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             afterClose: null
         },
         listeners: {
-            "onCreate.setupIframe": "fluid.tests.tooltip.FLUID5846.setupIframe({that}, {that}.dom.iframe.0)"
+            "onCreate.setupIframe": "fluid.tests.tooltip.FLUID5846.setupIframe({that}, {that}.options.iframeSrc, {that}.dom.iframe.0)"
         },
+        iframeSrc: "iframe.html",
         components: {
             tooltip: {
                 type: "fluid.tests.tooltip.FLUID5846",


### PR DESCRIPTION
When the iframe source was set in the document, it could load before the load event is bound.
This prevented the test from working as it was waiting for the load event.

https://issues.fluidproject.org/browse/FLUID-5872