### PR TITLE
FLUID-5940: Correct problems with auto-deduping Infusion on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bugs": "http://issues.fluidproject.org/browse/FLUID",
     "homepage": "http://www.fluidproject.org/",
     "dependencies": {
-        "resolve": "1.1.6"
+        "fluid-resolve": "1.2.0"
     },
     "license": "(BSD-3-Clause OR ECL-2.0)",
     "keywords": [

--- a/src/module/fluid.js
+++ b/src/module/fluid.js
@@ -15,7 +15,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 var fs = require("fs"),
     path = require("path"),
     vm = require("vm"),
-    resolve = require("resolve");
+    // We use a forked version of this dependency to resolve FLUID-5940
+    // This can be removed once resolve's issue #106 is resolved
+    resolve = require("fluid-resolve");
 
 // Version of resolve.sync which does not throw when module is not found
 var resolveModuleSync = function (moduleId, fromPath) {

--- a/src/module/fluid.js
+++ b/src/module/fluid.js
@@ -38,13 +38,15 @@ var upPath = path.resolve(__dirname, "../../../../..");
 var upInfusionPath = resolveModuleSync("infusion", upPath);
 if (upInfusionPath) {
     upInfusion = require(upInfusionPath);
-    if (upInfusion && Object.keys(upInfusion).length !== 0) {
-        upInfusion.log("Resolved infusion from path " + __dirname + " to " + upInfusion.module.modules.infusion.baseDir);
-        module.exports = upInfusion;
-        return;
-    } else {
-        console.log(upInfusionPath + " resolved to current Infusion");
-    }
+}
+
+// Fix for FLUID-5940, when Infusion is a dependency of a Node.js project that is located in the
+// root of a filesystem we were resolving to the current version of Infusion. Doing a 'require'
+// on the same version of Infusion results in an empty object.
+if (upInfusion && upInfusion.module) {
+    upInfusion.log("Resolved infusion from path " + __dirname + " to " + upInfusion.module.modules.infusion.baseDir);
+    module.exports = upInfusion;
+    return;
 } else {
     console.log("Infusion at path " + moduleBaseDir + " is at top level ");
 }

--- a/src/module/fluid.js
+++ b/src/module/fluid.js
@@ -38,11 +38,13 @@ var upPath = path.resolve(__dirname, "../../../../..");
 var upInfusionPath = resolveModuleSync("infusion", upPath);
 if (upInfusionPath) {
     upInfusion = require(upInfusionPath);
-    if (upInfusion && Object.keys(upInfusion).length != 0) {
+    if (upInfusion && Object.keys(upInfusion).length !== 0) {
         upInfusion.log("Resolved infusion from path " + __dirname + " to " + upInfusion.module.modules.infusion.baseDir);
         module.exports = upInfusion;
         return;
-    } else { console.log(upInfusionPath + " resolved to current Infusion"); }
+    } else {
+        console.log(upInfusionPath + " resolved to current Infusion");
+    }
 } else {
     console.log("Infusion at path " + moduleBaseDir + " is at top level ");
 }

--- a/src/module/fluid.js
+++ b/src/module/fluid.js
@@ -38,9 +38,11 @@ var upPath = path.resolve(__dirname, "../../../../..");
 var upInfusionPath = resolveModuleSync("infusion", upPath);
 if (upInfusionPath) {
     upInfusion = require(upInfusionPath);
-    upInfusion.log("Resolved infusion from path " + __dirname + " to " + upInfusion.module.modules.infusion.baseDir);
-    module.exports = upInfusion;
-    return;
+    if (upInfusion && Object.keys(upInfusion).length != 0) {
+        upInfusion.log("Resolved infusion from path " + __dirname + " to " + upInfusion.module.modules.infusion.baseDir);
+        module.exports = upInfusion;
+        return;
+    } else { console.log(upInfusionPath + " resolved to current Infusion"); }
 } else {
     console.log("Infusion at path " + moduleBaseDir + " is at top level ");
 }


### PR DESCRIPTION
This pull request replaces #735 - in addition to the check made there, we also need to fix an underlying issue in the "resolve" module - see https://github.com/substack/node-resolve/issues/106 for details.

I've run the following test - firstly, the reproduction steps listed on #735 of checking out, for example, kettle in "C:\kettle", running npm install, and then npm test from the kettle directory itself. Also, I have run   https://github.com/GPII/universal with its infusion patched in-place to this version to check it starts up ok. Perhaps you can think of other tests. In general this issue is ludicrously hard to test because of its large number of environmental assumptions and dependencies, down to the use of a particular shell on Windows.