### PR TITLE
FLUID-5209: Adding namespaces to listeners in the Prefs Framework

### DIFF
--- a/src/framework/preferences/js/Enactors.js
+++ b/src/framework/preferences/js/Enactors.js
@@ -387,7 +387,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                         }
                     },
                     listeners: {
-                        afterRender: "{fluid.prefs.enactor.tableOfContents}.events.afterTocRender"
+                        "afterRender.boilAfterTocRender": "{fluid.prefs.enactor.tableOfContents}.events.afterTocRender"
                     }
                 }
             }

--- a/src/framework/preferences/js/FullNoPreviewPrefsEditor.js
+++ b/src/framework/preferences/js/FullNoPreviewPrefsEditor.js
@@ -26,12 +26,14 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                 container: "{that}.container",
                 options: {
                     listeners: {
-                        afterReset: [{
+                        "afterReset.applyChanges": {
                             listener: "{that}.applyChanges"
-                        }, {
-                            listener: "{that}.save"
-                        }],
-                        onReady: {
+                        },
+                        "afterReset.save": {
+                            listener: "{that}.save",
+                            priority: "after:applyChanges"
+                        },
+                        "onReady.boilOnReady": {
                             listener: "{fullNoPreview}.events.onReady",
                             args: "{fullNoPreview}"
                         }

--- a/src/framework/preferences/js/FullPreviewPrefsEditor.js
+++ b/src/framework/preferences/js/FullPreviewPrefsEditor.js
@@ -34,13 +34,13 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                             container: "{prefsEditor}.dom.previewFrame",
                             options: {
                                 listeners: {
-                                    onReady: "{fullPreview}.events.onPreviewReady"
+                                    "onReady.boilOnPreviewReady": "{fullPreview}.events.onPreviewReady"
                                 }
                             }
                         }
                     },
                     listeners: {
-                        onReady: "{fullPreview}.events.onPrefsEditorReady"
+                        "onReady.boilOnPrefsEditorReady": "{fullPreview}.events.onPrefsEditorReady"
                     },
                     distributeOptions: {
                         source: "{that}.options.preview",

--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -810,7 +810,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             }
         },
         listeners: {
-            afterRender: "{that}.style"
+            "afterRender.style": "{that}.style"
         },
         selectors: {
             themeRow: ".flc-prefsEditor-themeRow",
@@ -984,7 +984,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     fluid.defaults("fluid.prefs.selectDecorator", {
         gradeNames: ["fluid.viewComponent"],
         listeners: {
-            onCreate: "fluid.prefs.selectDecorator.decorateOptions"
+            "onCreate.decorateOptions": "fluid.prefs.selectDecorator.decorateOptions"
         },
         styles: {
             preview: "fl-preview-theme"

--- a/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
+++ b/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
@@ -62,11 +62,11 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             iframe: ".flc-prefsEditor-iframe"
         },
         listeners: {
-            onReady: {
+            "onReady.bindEvents": {
                 listener: "fluid.prefs.separatedPanel.bindEvents",
                 args: ["{separatedPanel}.prefsEditor", "{iframeRenderer}.iframeEnhancer", "{separatedPanel}"]
             },
-            onCreate: {
+            "onCreate.hideReset": {
                 listener: "fluid.prefs.separatedPanel.hideReset",
                 args: ["{separatedPanel}"]
             }
@@ -150,13 +150,13 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
                         updateEnhancerModel: "{that}.events.modelChanged"
                     },
                     listeners: {
-                        modelChanged: "{that}.save",
-                        onCreate: {
+                        "modelChanged.save": "{that}.save",
+                        "onCreate.bindReset": {
                             listener: "{separatedPanel}.bindReset",
                             args: ["{that}.reset"]
                         },
-                        afterReset: "{that}.applyChanges",
-                        onReady: {
+                        "afterReset.applyChanges": "{that}.applyChanges",
+                        "onReady.boilOnReady": {
                             listener: "{separatedPanel}.events.onReady",
                             args: "{separatedPanel}"
                         }


### PR DESCRIPTION
Added namespaces to the listeners in the prefs framework. The exception is when listeners are bound to events of other components using IoC. These have not be namespace due to [FLUID-5948](https://issues.fluidproject.org/browse/FLUID-5948)

https://issues.fluidproject.org/browse/FLUID-5209