### PR TITLE
FLUID-5980: Adjusting the height calculation.

### DIFF
--- a/src/components/inlineEdit/js/InlineEdit.js
+++ b/src/components/inlineEdit/js/InlineEdit.js
@@ -221,8 +221,10 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             content: that.options.tooltipText,
             position: {
                 my: "left top",
-                at: "left bottom",
-                offset: "0 5"
+                at: "left bottom+25%", // add a 25% offset to keep the tooltip from overlapping the element it is for
+                // setting the "of" property to ensure that the tooltip is positioned relative to that.viewEl
+                // even when keyboard focus is on that.textEditButton
+                of: that.viewEl
             },
             target: "*",
             delay: that.options.tooltipDelay,

--- a/src/components/inlineEdit/js/InlineEdit.js
+++ b/src/components/inlineEdit/js/InlineEdit.js
@@ -353,6 +353,13 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             editModeInstruction.show();
 
             var editFieldPosition = editField.offset();
+            // For FLUID-5980 (https://issues.fluidproject.org/browse/FLUID-5980)
+            //
+            // From the jQuery height docs (http://api.jquery.com/height/)
+            // "As of jQuery 1.8, this may require retrieving the CSS height plus
+            // box-sizing property and then subtracting any potential border and
+            // padding on each element when the element has box-sizing: border-box.
+            // To avoid this penalty, use .css( "height" ) rather than .height()."
             var editFieldHeight = parseInt(editField.css("height"), 10);
             editModeInstruction.css({left: editFieldPosition.left});
             editModeInstruction.css({top: editFieldPosition.top + editFieldHeight + 5});

--- a/src/components/inlineEdit/js/InlineEdit.js
+++ b/src/components/inlineEdit/js/InlineEdit.js
@@ -353,8 +353,9 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             editModeInstruction.show();
 
             var editFieldPosition = editField.offset();
+            var editFieldHeight = parseInt(editField.css("height"), 10);
             editModeInstruction.css({left: editFieldPosition.left});
-            editModeInstruction.css({top: editFieldPosition.top + editField.height() + 5});
+            editModeInstruction.css({top: editFieldPosition.top + editFieldHeight + 5});
         });
     };
 

--- a/src/components/tooltip/js/Tooltip.js
+++ b/src/components/tooltip/js/Tooltip.js
@@ -209,8 +209,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         },
         position: {
             my: "left top",
-            at: "left bottom",
-            offset: "0 5"
+            at: "left bottom"
         },
         items: "*",
         delay: 300


### PR DESCRIPTION
From the jQuery height docs (http://api.jquery.com/height/)
"As of jQuery 1.8, this may require retrieving the CSS height plus box-sizing property and then subtracting any potential border and padding on each element when the element has box-sizing: border-box. To avoid this penalty, use .css( "height" ) rather than .height()."

https://issues.fluidproject.org/browse/FLUID-5980