### PR TITLE
FLUID-5985: Fix trunk-breaking bug introduced by FLUID-5973 in non-browser contexts

### DIFF
--- a/src/framework/enhancement/js/ContextAwareness.js
+++ b/src/framework/enhancement/js/ContextAwareness.js
@@ -207,7 +207,13 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     // Context awareness for the platform (operating system)
 
     fluid.contextAware.getPlatformName = function () {
-        return navigator.platform ? navigator.platform : undefined;
+        // Gets platform name in browser contexts
+        if (navigator) {
+            return navigator.platform ? navigator.platform : undefined;
+        // Gets platform name in node contexts    
+        } else if (os.platform) {
+            return os.platform();
+        }
     };
 
     fluid.contextAware.makeChecks({

--- a/src/framework/enhancement/js/ContextAwareness.js
+++ b/src/framework/enhancement/js/ContextAwareness.js
@@ -204,14 +204,19 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         }
     });
 
-    // Context awareness for the platform (operating system)
+    // Context awareness for the reported platform name (operating system)
+    // Note that navigator.platform (in-browser) and os.platform()
+    // have different return values - this simply registers the
+    // reported value as a string rather than doing any more 
+    // sophisticated detection
 
     fluid.contextAware.getPlatformName = function () {
         // Gets platform name in browser contexts
-        if (navigator) {
+        if (typeof(navigator) !== "undefined" && navigator) {
             return navigator.platform ? navigator.platform : undefined;
-        // Gets platform name in node contexts    
-        } else if (os.platform) {
+        // Gets platform name in node contexts
+        } else {
+            var os = require('os');
             return os.platform();
         }
     };

--- a/src/framework/enhancement/js/ContextAwareness.js
+++ b/src/framework/enhancement/js/ContextAwareness.js
@@ -206,16 +206,15 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
 
     // Context awareness for the reported browser platform name (operating system)
 
-    fluid.contextAware.getBrowserPlatformName = function () {
-        // Gets platform name in browser contexts
-        if (typeof(navigator) !== "undefined" && navigator) {
-            return navigator.platform ? navigator.platform : undefined;
-        }
+    fluid.registerNamespace("fluid.contextAware.browser");
+
+    fluid.contextAware.browser.getPlatformName = function () {
+        return typeof(navigator) !== "undefined" && navigator.platform ? navigator.platform : undefined;
     };
 
     fluid.contextAware.makeChecks({
-        "fluid.browserPlatformName": {
-            funcName: "fluid.contextAware.getBrowserPlatformName"
+        "fluid.browser.platformName": {
+            funcName: "fluid.contextAware.browser.getPlatformName"
         }
     });
 

--- a/src/framework/enhancement/js/ContextAwareness.js
+++ b/src/framework/enhancement/js/ContextAwareness.js
@@ -204,26 +204,18 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         }
     });
 
-    // Context awareness for the reported platform name (operating system)
-    // Note that navigator.platform (in-browser) and os.platform()
-    // have different return values - this simply registers the
-    // reported value as a string rather than doing any more 
-    // sophisticated detection
+    // Context awareness for the reported browser platform name (operating system)
 
-    fluid.contextAware.getPlatformName = function () {
+    fluid.contextAware.getBrowserPlatformName = function () {
         // Gets platform name in browser contexts
         if (typeof(navigator) !== "undefined" && navigator) {
             return navigator.platform ? navigator.platform : undefined;
-        // Gets platform name in node contexts
-        } else {
-            var os = require('os');
-            return os.platform();
         }
     };
 
     fluid.contextAware.makeChecks({
-        "fluid.platformName": {
-            funcName: "fluid.contextAware.getPlatformName"
+        "fluid.browserPlatformName": {
+            funcName: "fluid.contextAware.getBrowserPlatformName"
         }
     });
 

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -263,7 +263,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             supportsPauseResume: {
                 checks: {
                     supportsPauseResume: {
-                        contextValue: "{fluid.platform.isLinux}",
+                        contextValue: "{fluid.platform.isBrowserLinux}",
                         equals: false,
                         gradeNames: ["fluid.tests.textToSpeech.supportsPauseResume"]
                     }

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -263,7 +263,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             supportsPauseResume: {
                 checks: {
                     supportsPauseResume: {
-                        contextValue: "{fluid.platform.isBrowserLinux}",
+                        contextValue: "{fluid.browser.platform.isLinux}",
                         equals: false,
                         gradeNames: ["fluid.tests.textToSpeech.supportsPauseResume"]
                     }

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -83,11 +83,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         });
     };
 
-    // Adds context awarenes of the browser's reported platform (operating
-    // system) for aiding in executing platform-specific tests, or skipping
-    // those known to fail on a particular platform due to lack of browser
-    // support for features
-
     // Checks string-based contextAwareness check values to see if they
     // contain the searchValue string
     fluid.test.conditionalTestUtils.contextValueContains = function (searchValue, checkValue) {
@@ -95,7 +90,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return value.indexOf(searchValue) >= 0;
     };
 
-    // Functions for platform reporting for makeChecks
+    // Functions for browser platform reporting for makeChecks
     fluid.test.conditionalTestUtils.isLinux = function () {
         return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.platformName}");
     };

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -95,26 +95,18 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return value.indexOf(searchValue) >= 0;
     };
 
-    fluid.test.conditionalTestUtils.getPlatformName = function () {
-        return navigator.platform ? navigator.platform : undefined;
-    };
-
     // Functions for platform reporting for makeChecks
     fluid.test.conditionalTestUtils.isLinux = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.platform}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.platformName}");
     };
 
     fluid.test.conditionalTestUtils.isMac = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.platform}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.platformName}");
     };
 
     fluid.test.conditionalTestUtils.isWindows = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.platform}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.platformName}");
     };
-
-    fluid.contextAware.makeChecks({
-        "fluid.platform": "fluid.test.conditionalTestUtils.getPlatformName"
-    });
 
     fluid.contextAware.makeChecks({
         "fluid.platform.isLinux": "fluid.test.conditionalTestUtils.isLinux",

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -91,22 +91,22 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     // Functions for browser platform reporting for makeChecks
-    fluid.test.conditionalTestUtils.isBrowserLinux = function () {
+    fluid.test.conditionalTestUtils.isBrowserOnLinux = function () {
         return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.browser.platformName}");
     };
 
-    fluid.test.conditionalTestUtils.isBrowserMac = function () {
+    fluid.test.conditionalTestUtils.isBrowserOnMac = function () {
         return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.browser.platformName}");
     };
 
-    fluid.test.conditionalTestUtils.isBrowserWindows = function () {
+    fluid.test.conditionalTestUtils.isBrowserOnWindows = function () {
         return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.browser.platformName}");
     };
 
     fluid.contextAware.makeChecks({
-        "fluid.browser.platform.isLinux": "fluid.test.conditionalTestUtils.isBrowserLinux",
-        "fluid.browser.platform.isMac": "fluid.test.conditionalTestUtils.isBrowserMac",
-        "fluid.browser.platform.isWindows": "fluid.test.conditionalTestUtils.isBrowserWindows"
+        "fluid.browser.platform.isLinux": "fluid.test.conditionalTestUtils.isBrowserOnLinux",
+        "fluid.browser.platform.isMac": "fluid.test.conditionalTestUtils.isBrowserOnMac",
+        "fluid.browser.platform.isWindows": "fluid.test.conditionalTestUtils.isBrowserOnWindows"
     });
 
 })();

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -92,21 +92,21 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     // Functions for browser platform reporting for makeChecks
     fluid.test.conditionalTestUtils.isBrowserLinux = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.browserPlatformName}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.browser.platformName}");
     };
 
     fluid.test.conditionalTestUtils.isBrowserMac = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.browserPlatformName}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.browser.platformName}");
     };
 
     fluid.test.conditionalTestUtils.isBrowserWindows = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.browserPlatformName}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.browser.platformName}");
     };
 
     fluid.contextAware.makeChecks({
-        "fluid.platform.isBrowserLinux": "fluid.test.conditionalTestUtils.isBrowserLinux",
-        "fluid.platform.isBrowserMac": "fluid.test.conditionalTestUtils.isBrowserMac",
-        "fluid.platform.isBrowserWindows": "fluid.test.conditionalTestUtils.isBrowserWindows"
+        "fluid.browser.platform.isLinux": "fluid.test.conditionalTestUtils.isBrowserLinux",
+        "fluid.browser.platform.isMac": "fluid.test.conditionalTestUtils.isBrowserMac",
+        "fluid.browser.platform.isWindows": "fluid.test.conditionalTestUtils.isBrowserWindows"
     });
 
 })();

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -91,22 +91,22 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     // Functions for browser platform reporting for makeChecks
-    fluid.test.conditionalTestUtils.isLinux = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.platformName}");
+    fluid.test.conditionalTestUtils.isBrowserLinux = function () {
+        return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.browserPlatformName}");
     };
 
-    fluid.test.conditionalTestUtils.isMac = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.platformName}");
+    fluid.test.conditionalTestUtils.isBrowserMac = function () {
+        return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.browserPlatformName}");
     };
 
-    fluid.test.conditionalTestUtils.isWindows = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.platformName}");
+    fluid.test.conditionalTestUtils.isBrowserWindows = function () {
+        return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.browserPlatformName}");
     };
 
     fluid.contextAware.makeChecks({
-        "fluid.platform.isLinux": "fluid.test.conditionalTestUtils.isLinux",
-        "fluid.platform.isMac": "fluid.test.conditionalTestUtils.isMac",
-        "fluid.platform.isWindows": "fluid.test.conditionalTestUtils.isWindows"
+        "fluid.platform.isBrowserLinux": "fluid.test.conditionalTestUtils.isBrowserLinux",
+        "fluid.platform.isBrowserMac": "fluid.test.conditionalTestUtils.isBrowserMac",
+        "fluid.platform.isBrowserWindows": "fluid.test.conditionalTestUtils.isBrowserWindows"
     });
 
 })();


### PR DESCRIPTION
This fixes the bug introduced by FLUID-5973 when running Infusion in non-browser contexts, as mentioned by @amb26 at https://github.com/fluid-project/infusion/pull/577#issuecomment-255065212 & encountered by @the-t-in-rtf 

The `fluid.contextAware.getBrowserPlatformName` function now makes sure a `navigator` object actually exists before attempting to access any properties.

I've also updated various variable and function names to make it clear this functionality only currently extends to the OS platform as reported in the browser context.

Confirmed both the in-browser tests and `basic-node-tests.js` are now passing.