### PR TITLE
FLUID-5986: Integration of basic-node-tests.js with Testem runner

### DIFF
--- a/tests/node-tests/README.md
+++ b/tests/node-tests/README.md
@@ -1,15 +1,23 @@
+# Node module packaging test fixture for Infusion
+
 This directory contains a simple test fixture to verify the basic packaging of Fluid Infusion as a node module
 performed by the material in src/module/fluid.js .
 
 To run the tests, execute
 
-    node basic-node-tests.js
+    `node basic-node-tests.js`
 
 from the command line. They must terminate with the message
 
-    Infusion node.js internal tests OK - n/n tests passed
+    `Infusion node.js internal tests OK - n/n tests passed`
 
 (for some n) - if the last line of the process output isn't of this form,
 the tests are a failure.
 
 The comprehensive test suite for Infusion should be run in the browser by loading the markup file `tests/all-tests.html`
+
+## TAP output for Testem Integration
+
+The test can optionally output a TAP-formatted report in addition to its usual reporting, for integration with the Testem test runner (https://github.com/testem/testem#processes-with-tap-output) that runs the browser-based tests (see the main README.md for details)
+
+This mode is invoked by executing `node basic-node-tests.js --tap`

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -15,32 +15,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 var fluid = require("../../src/module/fluid.js"),
     path = require("path");
 
-// For accumulating TAP messages for parsing by testem custom launcher
-var tapOutput = "";
 // Number of expected assertions
 var expectedAsserts = 20;
 // Number of expected test cases
 var expectedTestCases = 10;
-
-// Set boolean for the  presence of the --tap command line option to output a
-// TAP report for consumption by testem when used as a custom launcher
-var shouldOutputTAP = process.argv.findIndex(function (argument) {
-    return argument.indexOf("--tap") > -1;
-}) > -1;
-
-// Function to output a TAP  failure report
-// Assumed to be used as below with fluid.onUncaughtException.addListener
-var outputTAPFailure = function (message) {
-    if (!fluid.tests.expectFailure) {
-        console.log("not ok -  " + message);
-    }
-};
-
-// Register listener to output TAP failure report
-if (shouldOutputTAP) {
-    fluid.onUncaughtException.addListener(outputTAPFailure, "outputTAPFailure",
-        fluid.handlerPriorities.uncaughtException.log);
-}
 
 fluid.loadTestingSupport();
 
@@ -48,6 +26,8 @@ var QUnit = fluid.registerNamespace("QUnit");
 var jqUnit = fluid.registerNamespace("jqUnit");
 
 fluid.registerNamespace("fluid.tests");
+
+fluid.registerNamespace("fluid.tests.tapOutput");
 
 fluid.loadInContext("../../tests/test-core/testTests/js/IoCTestingTests.js");
 
@@ -75,12 +55,41 @@ QUnit.testDone(function (data) {
     fluid.log(getTestMessage(data));
 });
 
-// Additional handler for accumulating TAP output
-if (shouldOutputTAP) {
+// Set boolean for the  presence of the --tap command line option to output a
+// TAP report for consumption by testem when used as a custom launcher
+fluid.tests.tapOutput.shouldOutputTAP = process.argv.findIndex(function (argument) {
+    return argument.indexOf("--tap") > -1;
+}) > -1;
+
+// For accumulating TAP messages for parsing by testem custom launcher
+var tapOutput = "";
+
+// Function to output a TAP  failure report
+// Assumed to be used with fluid.onUncaughtException.addListener
+fluid.tests.tapOutput.outputTAPFailure = function (message) {
+    if (!fluid.tests.expectFailure) {
+        console.log("not ok -  " + message);
+    }
+};
+
+if (fluid.tests.tapOutput.shouldOutputTAP) {
+    // Register listener to output TAP failure report
+    fluid.onUncaughtException.addListener(fluid.tests.tapOutput.outputTAPFailure, "outputTAPFailure",
+        fluid.handlerPriorities.uncaughtException.log);
+
+    // Additional handler for accumulating TAP output
     QUnit.testDone(function (data) {
         var tapResult = data.failed === 0 ? "ok" : "not ok";
         var tapMessage = tapResult + " " + getTestMessage(data);
         tapOutput = tapOutput + tapMessage + "\n";
+    });
+
+    // Additional handler for outputting TAP
+    QUnit.done(function () {
+        // Output the TAP header
+        console.log("1.." + expectedTestCases);
+        // Output the TAP report
+        console.log(tapOutput);
     });
 }
 
@@ -96,16 +105,6 @@ QUnit.done(function (data) {
         process.exitCode = 1;
     }
 });
-
-// Additional handler for outputting TAP
-if (shouldOutputTAP) {
-    QUnit.done(function () {
-        // Output the TAP header
-        console.log("1.." + expectedTestCases);
-        // Output the TAP report
-        console.log(tapOutput);
-    });
-}
 
 QUnit.log(function (details) {
     if (details.source) { // "white-box" inspection of qunit.js shows that it sets this field on error
@@ -180,8 +179,8 @@ fluid.tests.onUncaughtException = function () {
         fluid.invokeLater(function () {
             fluid.onUncaughtException.removeListener("log"); // restore the original listener
             // Reregister listener to output TAP failure report
-            if (shouldOutputTAP) {
-                fluid.onUncaughtException.addListener(outputTAPFailure, "outputTAPFailure",
+            if (fluid.tests.tapOutput.shouldOutputTAP) {
+                fluid.onUncaughtException.addListener(fluid.tests.tapOutput.outputTAPFailure, "outputTAPFailure",
                     fluid.handlerPriorities.uncaughtException.log);
             }
             console.log("Restarting jqUnit in nested handler");

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -55,7 +55,7 @@ var runTests = function () {
     fluid.setLogging(true);
 
     var getTestMessage = function (data) {
-        return "Test concluded - " + data.name + ": " + data.passed + " passed, " + data.failed + " failed";
+        return "Test concluded - " + data.name + ": " + data.passed + " assertion(s) passed, " + data.failed + " assertion(s) failed";
     };
 
     QUnit.testDone(function (data) {

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -49,6 +49,14 @@ QUnit.done(function (data) {
     fluid.log("Infusion node.js internal tests " +
         (expected === data.passed && data.failed === 0 ? "PASSED" : "FAILED") +
         " - " + data.passed + "/" + (expected + data.failed) + " tests passed");
+
+    // Set the process to return a non-0 exit code if any tests failed,
+    // or the number of expected tests is not the same as the number of passed
+    // tests; this allows basic usage in CI
+    if (data.failed > 0 || data.passed < expected) {
+        process.exitCode = 1;
+    }
+
 });
 
 QUnit.log(function (details) {

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -196,17 +196,17 @@ var runTests = function () {
     });
 
     QUnit.load();
-}
+};
 
 // Wrapper to ensure TAP report outputs failures if there's a failure in the fixtures
 if (shouldOutputTAP) {
     try {
         runTests();
-        }
+    }
     catch (e) {
         if (shouldOutputTAP) {
             console.log("1.." + expectedTestCases);
-            for(var i = 0; i < expectedTestCases; i++) {
+            for (var i = 0; i < expectedTestCases; i++) {
                 console.log("not ok - uncaught exception occured in test fixture " + e);
             }
         }

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -172,7 +172,9 @@ fluid.tests.onUncaughtException = function () {
         true, fluid.tests.expectFailure);
     fluid.onUncaughtException.removeListener("test-uncaught");
     fluid.onUncaughtException.removeListener("log");
-    fluid.onUncaughtException.removeListener("outputTAPFailure");
+    if (fluid.tests.tapOutput.shouldOutputTAP) {
+        fluid.onUncaughtException.removeListener("outputTAPFailure");
+    }
     fluid.tests.addLogListener(fluid.identity);
     fluid.tests.expectFailure = false;
     fluid.invokeLater(function () { // apply this later to avoid nesting uncaught exception handler
@@ -199,7 +201,9 @@ jqUnit.asyncTest("Test uncaught exception handler registration and deregistratio
     jqUnit.expect(2);
     fluid.onUncaughtException.addListener(fluid.tests.onUncaughtException, "test-uncaught");
     fluid.tests.addLogListener(fluid.tests.benignLogger);
-    fluid.onUncaughtException.removeListener("outputTAPFailure");
+    if (fluid.tests.tapOutput.shouldOutputTAP) {
+        fluid.onUncaughtException.removeListener("outputTAPFailure");
+    }
     fluid.tests.expectFailure = true;
     fluid.invokeLater(function () { // put this in a timeout to avoid bombing QUnit's exception handler
         "string".fail(); // provoke a global uncaught error

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -24,8 +24,8 @@ var shouldOutputTAP = process.argv.findIndex(function (argument) {
     return argument.indexOf("--tap") > -1;
 }) > -1;
 
-// Test fixtures here
-try {
+// Test runner function
+var runTests = function () {
     var fluid = require("../../src/module/fluid.js"),
         path = require("path");
 
@@ -74,7 +74,7 @@ try {
     QUnit.done(function (data) {
         fluid.log("Infusion node.js internal tests " +
             (expectedAsserts === data.passed && data.failed === 0 ? "PASSED" : "FAILED") +
-            " - " + data.passed + "/" + (expectedAsserts + data.failed) + " tests passed");
+            " - " + data.passed + "/" + (expectedAsserts + data.failed) + " assertions passed");
 
         // Set the process to return a non-0 exit code if any tests failed,
         // or the number of expected tests is not the same as the number of passed
@@ -198,13 +198,19 @@ try {
     QUnit.load();
 }
 
-catch (e) {
-    console.log(e);
-    // On an uncaught exception in the fixtures, dump a parseable TAP failure
-    if (shouldOutputTAP) {
-        console.log("1..10");
-        for(var i = 0; i < expectedTestCases; i++) {
-            console.log("not ok - uncaught exception occured in test fixture");
+// Wrapper to ensure TAP report outputs failures if there's a failure in the fixtures
+if (shouldOutputTAP) {
+    try {
+        runTests();
+        }
+    catch (e) {
+        if (shouldOutputTAP) {
+            console.log("1.." + expectedTestCases);
+            for(var i = 0; i < expectedTestCases; i++) {
+                console.log("not ok - uncaught exception occured in test fixture " + e);
+            }
         }
     }
+} else {
+    runTests();
 }

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -11,6 +11,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 /* eslint-env node */
 "use strict";
 
+
+var fluid = require("../../src/module/fluid.js"),
+    path = require("path");
+
 // For accumulating TAP messages for parsing by testem custom launcher
 var tapOutput = "";
 // Number of expected assertions
@@ -24,193 +28,191 @@ var shouldOutputTAP = process.argv.findIndex(function (argument) {
     return argument.indexOf("--tap") > -1;
 }) > -1;
 
-// Test runner function
-var runTests = function () {
-    var fluid = require("../../src/module/fluid.js"),
-        path = require("path");
-
-    fluid.loadTestingSupport();
-
-    var QUnit = fluid.registerNamespace("QUnit");
-    var jqUnit = fluid.registerNamespace("jqUnit");
-
-    fluid.registerNamespace("fluid.tests");
-
-    fluid.loadInContext("../../tests/test-core/testTests/js/IoCTestingTests.js");
-
-    var testModuleBase = __dirname + path.sep + "node_modules" + path.sep + "test-module";
-
-    fluid.module.preInspect(testModuleBase);
-
-    // We must store this NOW since it will be overwritten when the module is genuinely loaded - the test
-    // fixture will run long afterwards
-    var preInspected = fluid.module.modules["test-module"].baseDir;
-
-    jqUnit.test("Test early inspection of test module", function () {
-        jqUnit.assertEquals("Test that base directory of test module has been successfully pre-inspected", fluid.module.canonPath(testModuleBase), preInspected);
-    });
-
-    fluid.require("test-module", require, "test-module");
-
-    fluid.setLogging(true);
-
-    var getTestMessage = function (data) {
-        return "Test concluded - " + data.name + ": " + data.passed + " assertion(s) passed, " + data.failed + " assertion(s) failed";
-    };
-
-    QUnit.testDone(function (data) {
-        fluid.log(getTestMessage(data));
-    });
-
-    // Additional handler for accumulating TAP output
-    if (shouldOutputTAP) {
-        QUnit.testDone(function (data) {
-            var tapResult = data.failed === 0 ? "ok" : "not ok";
-            var tapMessage = tapResult + " " + getTestMessage(data);
-            tapOutput = tapOutput + tapMessage + "\n";
-        });
+// Function to output a TAP  failure report
+// Assumed to be used as below with fluid.onUncaughtException.addListener
+var outputTAPFailure = function (message) {
+    if (!fluid.tests.expectFailure) {
+        console.log("not ok -  " + message);
     }
-
-    QUnit.done(function (data) {
-        fluid.log("Infusion node.js internal tests " +
-            (expectedAsserts === data.passed && data.failed === 0 ? "PASSED" : "FAILED") +
-            " - " + data.passed + "/" + (expectedAsserts + data.failed) + " assertions passed");
-
-        // Set the process to return a non-0 exit code if any tests failed,
-        // or the number of expected tests is not the same as the number of passed
-        // tests; this allows basic usage in CI
-        if (data.failed > 0 || data.passed < expectedAsserts) {
-            process.exitCode = 1;
-        }
-    });
-
-    // Additional handler for outputting TAP
-    if (shouldOutputTAP) {
-        QUnit.done(function () {
-            // Output the TAP header
-            console.log("1.." + expectedTestCases);
-            // Output the TAP report
-            console.log(tapOutput);
-        });
-    }
-
-    QUnit.log(function (details) {
-        if (details.source) { // "white-box" inspection of qunit.js shows that it sets this field on error
-            fluid.log("Message: " + details.message + "\nSource: " + details.source);
-            if (details.expected !== undefined) {
-                console.log("Expected: ", JSON.stringify(details.expected, null, 4));
-                console.log("Actual: ", JSON.stringify(details.actual, null, 4));
-            }
-        }
-    });
-
-    fluid.test.runTests(["fluid.tests.myTestTree"]);
-
-    jqUnit.module("Non IoC tests");
-
-    jqUnit.test("Rendering truncation test", function () {
-        var rendered = fluid.renderLoggingArg(fluid);
-        jqUnit.assertTrue("Large object truncated", rendered.length < fluid.logObjectRenderChars + 100); // small allowance for extra diagnostic
-        console.log("Large log rendering object truncated to " + rendered.length + " chars");
-    });
-
-    jqUnit.test("Test fluid.require support", function () {
-        var testModule = fluid.registerNamespace("test-module");
-        jqUnit.assertEquals("Loaded module as Fluid namespace", "Export from test-module", testModule.value);
-        jqUnit.assertEquals("Loaded module as Fluid global entry", "Export from test-module", fluid.global["test-module"].value);
-    });
-
-    jqUnit.test("Test fluid.require diagnostics and FLUID-5906 loading", function () {
-        jqUnit.expect(1);
-        jqUnit.expectFrameworkDiagnostic("Module name for unloaded modules", function () {
-            fluid.require("%test-module3");
-        }, ["Module test-module3 has not been loaded and could not be loaded"]);
-        var testModule2 = fluid.require("%test-module2");
-        var rawTestModule2 = require("test-module2");
-        jqUnit.assertEquals("Same module resolvable via fluid.require and require ", rawTestModule2, testModule2);
-    });
-
-    jqUnit.test("Test propagation of standard globals", function () {
-        var expectedGlobals = ["console.log", "setTimeout", "clearTimeout", "setInterval", "clearInterval"];
-
-        fluid.each(expectedGlobals, function (oneGlobal) {
-            var type = typeof(fluid.get(fluid.global, oneGlobal));
-            jqUnit.assertEquals("Global " + oneGlobal + " has type function", "function", type);
-        });
-    });
-
-    jqUnit.test("Test module resolvePath", function () {
-        var resolved = fluid.module.resolvePath("%infusion/src/components/tableOfContents/html/TableOfContents.html");
-        var expected = fluid.module.canonPath(path.resolve(__dirname, "../../src/components/tableOfContents/html/TableOfContents.html"));
-        jqUnit.assertEquals("Resolved path into infusion module", expected, resolved);
-
-        var pkg = fluid.require("%test-module/package.json");
-        jqUnit.assertEquals("Loaded package.json via resolved path directly via fluid.require", "test-module", pkg.name);
-    });
-
-    fluid.tests.expectFailure = false;
-
-    fluid.tests.addLogListener = function (listener) {
-        fluid.onUncaughtException.addListener(listener, "log",
-            fluid.handlerPriorities.uncaughtException.log);
-    };
-
-    fluid.tests.onUncaughtException = function () {
-        jqUnit.assertEquals("Expected failure in uncaught exception handler",
-            true, fluid.tests.expectFailure);
-        fluid.onUncaughtException.removeListener("test-uncaught");
-        fluid.onUncaughtException.removeListener("log");
-        fluid.tests.addLogListener(fluid.identity);
-        fluid.tests.expectFailure = false;
-        fluid.invokeLater(function () { // apply this later to avoid nesting uncaught exception handler
-            fluid.invokeLater(function () {
-                fluid.onUncaughtException.removeListener("log"); // restore the original listener
-                console.log("Restarting jqUnit in nested handler");
-                jqUnit.start();
-            });
-            "string".fail(); // provoke a further global uncaught error - should be a no-op
-        });
-    };
-
-    fluid.tests.benignLogger = function () {
-        fluid.log("Expected global failure received in test case");
-        jqUnit.assert("Expected global failure");
-    };
-
-    jqUnit.asyncTest("Test uncaught exception handler registration and deregistration", function () {
-        jqUnit.expect(2);
-        fluid.onUncaughtException.addListener(fluid.tests.onUncaughtException, "test-uncaught");
-        fluid.tests.addLogListener(fluid.tests.benignLogger);
-        fluid.tests.expectFailure = true;
-        fluid.invokeLater(function () { // put this in a timeout to avoid bombing QUnit's exception handler
-            "string".fail(); // provoke a global uncaught error
-        });
-    });
-
-    jqUnit.test("FLUID-5807 noncorrupt framework stack traces", function () {
-        var error = new fluid.FluidError("thing");
-        jqUnit.assertTrue("Framework error is an error (from its own perspective)", error instanceof fluid.Error);
-        jqUnit.assertTrue("Framework error is an instance of itself", error instanceof fluid.FluidError);
-        var stack = error.stack.toString();
-        jqUnit.assertTrue("Our own filename must appear in the stack", stack.indexOf("basic-node-tests") !== -1);
-    });
-
-    QUnit.load();
 };
 
-// Wrapper to ensure TAP report outputs failures if there's a failure in the fixtures
+// Register listener to output TAP failure report
 if (shouldOutputTAP) {
-    try {
-        runTests();
+    fluid.onUncaughtException.addListener(outputTAPFailure, "outputTAPFailure",
+        fluid.handlerPriorities.uncaughtException.log);
+}
+
+fluid.loadTestingSupport();
+
+var QUnit = fluid.registerNamespace("QUnit");
+var jqUnit = fluid.registerNamespace("jqUnit");
+
+fluid.registerNamespace("fluid.tests");
+
+fluid.loadInContext("../../tests/test-core/testTests/js/IoCTestingTests.js");
+
+var testModuleBase = __dirname + path.sep + "node_modules" + path.sep + "test-module";
+
+fluid.module.preInspect(testModuleBase);
+
+// We must store this NOW since it will be overwritten when the module is genuinely loaded - the test
+// fixture will run long afterwards
+var preInspected = fluid.module.modules["test-module"].baseDir;
+
+jqUnit.test("Test early inspection of test module", function () {
+    jqUnit.assertEquals("Test that base directory of test module has been successfully pre-inspected", fluid.module.canonPath(testModuleBase), preInspected);
+});
+
+fluid.require("test-module", require, "test-module");
+
+fluid.setLogging(true);
+
+var getTestMessage = function (data) {
+    return "Test concluded - " + data.name + ": " + data.passed + " assertion(s) passed, " + data.failed + " assertion(s) failed";
+};
+
+QUnit.testDone(function (data) {
+    fluid.log(getTestMessage(data));
+});
+
+// Additional handler for accumulating TAP output
+if (shouldOutputTAP) {
+    QUnit.testDone(function (data) {
+        var tapResult = data.failed === 0 ? "ok" : "not ok";
+        var tapMessage = tapResult + " " + getTestMessage(data);
+        tapOutput = tapOutput + tapMessage + "\n";
+    });
+}
+
+QUnit.done(function (data) {
+    fluid.log("Infusion node.js internal tests " +
+        (expectedAsserts === data.passed && data.failed === 0 ? "PASSED" : "FAILED") +
+        " - " + data.passed + "/" + (expectedAsserts + data.failed) + " assertions passed");
+
+    // Set the process to return a non-0 exit code if any tests failed,
+    // or the number of expected tests is not the same as the number of passed
+    // tests; this allows basic usage in CI
+    if (data.failed > 0 || data.passed < expectedAsserts) {
+        process.exitCode = 1;
     }
-    catch (e) {
-        if (shouldOutputTAP) {
-            console.log("1.." + expectedTestCases);
-            for (var i = 0; i < expectedTestCases; i++) {
-                console.log("not ok - uncaught exception occured in test fixture " + e);
-            }
+});
+
+// Additional handler for outputting TAP
+if (shouldOutputTAP) {
+    QUnit.done(function () {
+        // Output the TAP header
+        console.log("1.." + expectedTestCases);
+        // Output the TAP report
+        console.log(tapOutput);
+    });
+}
+
+QUnit.log(function (details) {
+    if (details.source) { // "white-box" inspection of qunit.js shows that it sets this field on error
+        fluid.log("Message: " + details.message + "\nSource: " + details.source);
+        if (details.expected !== undefined) {
+            console.log("Expected: ", JSON.stringify(details.expected, null, 4));
+            console.log("Actual: ", JSON.stringify(details.actual, null, 4));
         }
     }
-} else {
-    runTests();
-}
+});
+
+fluid.test.runTests(["fluid.tests.myTestTree"]);
+
+jqUnit.module("Non IoC tests");
+
+jqUnit.test("Rendering truncation test", function () {
+    var rendered = fluid.renderLoggingArg(fluid);
+    jqUnit.assertTrue("Large object truncated", rendered.length < fluid.logObjectRenderChars + 100); // small allowance for extra diagnostic
+    console.log("Large log rendering object truncated to " + rendered.length + " chars");
+});
+
+jqUnit.test("Test fluid.require support", function () {
+    var testModule = fluid.registerNamespace("test-module");
+    jqUnit.assertEquals("Loaded module as Fluid namespace", "Export from test-module", testModule.value);
+    jqUnit.assertEquals("Loaded module as Fluid global entry", "Export from test-module", fluid.global["test-module"].value);
+});
+
+jqUnit.test("Test fluid.require diagnostics and FLUID-5906 loading", function () {
+    jqUnit.expect(1);
+    jqUnit.expectFrameworkDiagnostic("Module name for unloaded modules", function () {
+        fluid.require("%test-module3");
+    }, ["Module test-module3 has not been loaded and could not be loaded"]);
+    var testModule2 = fluid.require("%test-module2");
+    var rawTestModule2 = require("test-module2");
+    jqUnit.assertEquals("Same module resolvable via fluid.require and require ", rawTestModule2, testModule2);
+});
+
+jqUnit.test("Test propagation of standard globals", function () {
+    var expectedGlobals = ["console.log", "setTimeout", "clearTimeout", "setInterval", "clearInterval"];
+
+    fluid.each(expectedGlobals, function (oneGlobal) {
+        var type = typeof(fluid.get(fluid.global, oneGlobal));
+        jqUnit.assertEquals("Global " + oneGlobal + " has type function", "function", type);
+    });
+});
+
+jqUnit.test("Test module resolvePath", function () {
+    var resolved = fluid.module.resolvePath("%infusion/src/components/tableOfContents/html/TableOfContents.html");
+    var expected = fluid.module.canonPath(path.resolve(__dirname, "../../src/components/tableOfContents/html/TableOfContents.html"));
+    jqUnit.assertEquals("Resolved path into infusion module", expected, resolved);
+
+    var pkg = fluid.require("%test-module/package.json");
+    jqUnit.assertEquals("Loaded package.json via resolved path directly via fluid.require", "test-module", pkg.name);
+});
+
+fluid.tests.expectFailure = false;
+
+fluid.tests.addLogListener = function (listener) {
+    fluid.onUncaughtException.addListener(listener, "log",
+        fluid.handlerPriorities.uncaughtException.log);
+};
+
+fluid.tests.onUncaughtException = function () {
+    jqUnit.assertEquals("Expected failure in uncaught exception handler",
+        true, fluid.tests.expectFailure);
+    fluid.onUncaughtException.removeListener("test-uncaught");
+    fluid.onUncaughtException.removeListener("log");
+    fluid.onUncaughtException.removeListener("outputTAPFailure");
+    fluid.tests.addLogListener(fluid.identity);
+    fluid.tests.expectFailure = false;
+    fluid.invokeLater(function () { // apply this later to avoid nesting uncaught exception handler
+        fluid.invokeLater(function () {
+            fluid.onUncaughtException.removeListener("log"); // restore the original listener
+            // Reregister listener to output TAP failure report
+            if (shouldOutputTAP) {
+                fluid.onUncaughtException.addListener(outputTAPFailure, "outputTAPFailure",
+                    fluid.handlerPriorities.uncaughtException.log);
+            }
+            console.log("Restarting jqUnit in nested handler");
+            jqUnit.start();
+        });
+        "string".fail(); // provoke a further global uncaught error - should be a no-op
+    });
+};
+
+fluid.tests.benignLogger = function () {
+    fluid.log("Expected global failure received in test case");
+    jqUnit.assert("Expected global failure");
+};
+
+jqUnit.asyncTest("Test uncaught exception handler registration and deregistration", function () {
+    jqUnit.expect(2);
+    fluid.onUncaughtException.addListener(fluid.tests.onUncaughtException, "test-uncaught");
+    fluid.tests.addLogListener(fluid.tests.benignLogger);
+    fluid.onUncaughtException.removeListener("outputTAPFailure");
+    fluid.tests.expectFailure = true;
+    fluid.invokeLater(function () { // put this in a timeout to avoid bombing QUnit's exception handler
+        "string".fail(); // provoke a global uncaught error
+    });
+});
+
+jqUnit.test("FLUID-5807 noncorrupt framework stack traces", function () {
+    var error = new fluid.FluidError("thing");
+    jqUnit.assertTrue("Framework error is an error (from its own perspective)", error instanceof fluid.Error);
+    jqUnit.assertTrue("Framework error is an instance of itself", error instanceof fluid.FluidError);
+    var stack = error.stack.toString();
+    jqUnit.assertTrue("Our own filename must appear in the stack", stack.indexOf("basic-node-tests") !== -1);
+});
+
+QUnit.load();

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -39,8 +39,23 @@ fluid.require("test-module", require, "test-module");
 
 fluid.setLogging(true);
 
+// Set boolean for the  presence of the --tap command line option to output a
+// TAP report for consumption by testem when used as a custom launcher
+var shouldOutputTAP = process.argv.findIndex(function (argument) {
+    return argument.indexOf("--tap") > -1;
+}) > -1;
+
+// For accumulating TAP messages for parsing by testem custom launcher
+var tapOutput = "";
+
 QUnit.testDone(function (data) {
-    fluid.log("Test concluded - " + data.name + ": " + data.passed + " passed, " + data.failed + " failed");
+    var testMessage = "Test concluded - " + data.name + ": " + data.passed + " passed, " + data.failed + " failed";
+    fluid.log(testMessage);
+    if (shouldOutputTAP) {
+        var tapResult = data.failed === 0 ? "ok" : "not ok";
+        var tapMessage = tapResult + " " + testMessage;
+        tapOutput = tapOutput + tapMessage + "\n";
+    }
 });
 
 var expected = 20;
@@ -57,6 +72,10 @@ QUnit.done(function (data) {
         process.exitCode = 1;
     }
 
+    if (shouldOutputTAP) {
+        // Output the TAP result
+        console.log(tapOutput);
+    }
 });
 
 QUnit.log(function (details) {

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -11,33 +11,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 /* eslint-env node */
 "use strict";
 
-var fluid = require("../../src/module/fluid.js"),
-    path = require("path");
-
-fluid.loadTestingSupport();
-
-var QUnit = fluid.registerNamespace("QUnit");
-var jqUnit = fluid.registerNamespace("jqUnit");
-
-fluid.registerNamespace("fluid.tests");
-
-fluid.loadInContext("../../tests/test-core/testTests/js/IoCTestingTests.js");
-
-var testModuleBase = __dirname + path.sep + "node_modules" + path.sep + "test-module";
-
-fluid.module.preInspect(testModuleBase);
-
-// We must store this NOW since it will be overwritten when the module is genuinely loaded - the test
-// fixture will run long afterwards
-var preInspected = fluid.module.modules["test-module"].baseDir;
-
-jqUnit.test("Test early inspection of test module", function () {
-    jqUnit.assertEquals("Test that base directory of test module has been successfully pre-inspected", fluid.module.canonPath(testModuleBase), preInspected);
-});
-
-fluid.require("test-module", require, "test-module");
-
-fluid.setLogging(true);
+// For accumulating TAP messages for parsing by testem custom launcher
+var tapOutput = "";
+// Number of expected assertions
+var expectedAsserts = 20;
+// Number of expected test cases
+var expectedTestCases = 10;
 
 // Set boolean for the  presence of the --tap command line option to output a
 // TAP report for consumption by testem when used as a custom launcher
@@ -45,147 +24,187 @@ var shouldOutputTAP = process.argv.findIndex(function (argument) {
     return argument.indexOf("--tap") > -1;
 }) > -1;
 
-// For accumulating TAP messages for parsing by testem custom launcher
-var tapOutput = "";
+// Test fixtures here
+try {
+    var fluid = require("../../src/module/fluid.js"),
+        path = require("path");
 
-var getTestMessage = function (data) {
-    return "Test concluded - " + data.name + ": " + data.passed + " passed, " + data.failed + " failed";
-};
+    fluid.loadTestingSupport();
 
-QUnit.testDone(function (data) {
-    fluid.log(getTestMessage(data));
-});
+    var QUnit = fluid.registerNamespace("QUnit");
+    var jqUnit = fluid.registerNamespace("jqUnit");
 
-// Additional handler for accumulating TAP output
-if (shouldOutputTAP) {
+    fluid.registerNamespace("fluid.tests");
+
+    fluid.loadInContext("../../tests/test-core/testTests/js/IoCTestingTests.js");
+
+    var testModuleBase = __dirname + path.sep + "node_modules" + path.sep + "test-module";
+
+    fluid.module.preInspect(testModuleBase);
+
+    // We must store this NOW since it will be overwritten when the module is genuinely loaded - the test
+    // fixture will run long afterwards
+    var preInspected = fluid.module.modules["test-module"].baseDir;
+
+    jqUnit.test("Test early inspection of test module", function () {
+        jqUnit.assertEquals("Test that base directory of test module has been successfully pre-inspected", fluid.module.canonPath(testModuleBase), preInspected);
+    });
+
+    fluid.require("test-module", require, "test-module");
+
+    fluid.setLogging(true);
+
+    var getTestMessage = function (data) {
+        return "Test concluded - " + data.name + ": " + data.passed + " passed, " + data.failed + " failed";
+    };
+
     QUnit.testDone(function (data) {
-        var tapResult = data.failed === 0 ? "ok" : "not ok";
-        var tapMessage = tapResult + " " + getTestMessage(data);
-        tapOutput = tapOutput + tapMessage + "\n";
+        fluid.log(getTestMessage(data));
     });
-}
 
-var expected = 20;
-
-QUnit.done(function (data) {
-    fluid.log("Infusion node.js internal tests " +
-        (expected === data.passed && data.failed === 0 ? "PASSED" : "FAILED") +
-        " - " + data.passed + "/" + (expected + data.failed) + " tests passed");
-
-    // Set the process to return a non-0 exit code if any tests failed,
-    // or the number of expected tests is not the same as the number of passed
-    // tests; this allows basic usage in CI
-    if (data.failed > 0 || data.passed < expected) {
-        process.exitCode = 1;
+    // Additional handler for accumulating TAP output
+    if (shouldOutputTAP) {
+        QUnit.testDone(function (data) {
+            var tapResult = data.failed === 0 ? "ok" : "not ok";
+            var tapMessage = tapResult + " " + getTestMessage(data);
+            tapOutput = tapOutput + tapMessage + "\n";
+        });
     }
-});
 
-// Additional handler for outputting TAP
-if (shouldOutputTAP) {
-    QUnit.done(function () {
-        console.log(tapOutput);
+    QUnit.done(function (data) {
+        fluid.log("Infusion node.js internal tests " +
+            (expectedAsserts === data.passed && data.failed === 0 ? "PASSED" : "FAILED") +
+            " - " + data.passed + "/" + (expectedAsserts + data.failed) + " tests passed");
+
+        // Set the process to return a non-0 exit code if any tests failed,
+        // or the number of expected tests is not the same as the number of passed
+        // tests; this allows basic usage in CI
+        if (data.failed > 0 || data.passed < expectedAsserts) {
+            process.exitCode = 1;
+        }
     });
+
+    // Additional handler for outputting TAP
+    if (shouldOutputTAP) {
+        QUnit.done(function () {
+            // Output the TAP header
+            console.log("1.." + expectedTestCases);
+            // Output the TAP report
+            console.log(tapOutput);
+        });
+    }
+
+    QUnit.log(function (details) {
+        if (details.source) { // "white-box" inspection of qunit.js shows that it sets this field on error
+            fluid.log("Message: " + details.message + "\nSource: " + details.source);
+            if (details.expected !== undefined) {
+                console.log("Expected: ", JSON.stringify(details.expected, null, 4));
+                console.log("Actual: ", JSON.stringify(details.actual, null, 4));
+            }
+        }
+    });
+
+    fluid.test.runTests(["fluid.tests.myTestTree"]);
+
+    jqUnit.module("Non IoC tests");
+
+    jqUnit.test("Rendering truncation test", function () {
+        var rendered = fluid.renderLoggingArg(fluid);
+        jqUnit.assertTrue("Large object truncated", rendered.length < fluid.logObjectRenderChars + 100); // small allowance for extra diagnostic
+        console.log("Large log rendering object truncated to " + rendered.length + " chars");
+    });
+
+    jqUnit.test("Test fluid.require support", function () {
+        var testModule = fluid.registerNamespace("test-module");
+        jqUnit.assertEquals("Loaded module as Fluid namespace", "Export from test-module", testModule.value);
+        jqUnit.assertEquals("Loaded module as Fluid global entry", "Export from test-module", fluid.global["test-module"].value);
+    });
+
+    jqUnit.test("Test fluid.require diagnostics and FLUID-5906 loading", function () {
+        jqUnit.expect(1);
+        jqUnit.expectFrameworkDiagnostic("Module name for unloaded modules", function () {
+            fluid.require("%test-module3");
+        }, ["Module test-module3 has not been loaded and could not be loaded"]);
+        var testModule2 = fluid.require("%test-module2");
+        var rawTestModule2 = require("test-module2");
+        jqUnit.assertEquals("Same module resolvable via fluid.require and require ", rawTestModule2, testModule2);
+    });
+
+    jqUnit.test("Test propagation of standard globals", function () {
+        var expectedGlobals = ["console.log", "setTimeout", "clearTimeout", "setInterval", "clearInterval"];
+
+        fluid.each(expectedGlobals, function (oneGlobal) {
+            var type = typeof(fluid.get(fluid.global, oneGlobal));
+            jqUnit.assertEquals("Global " + oneGlobal + " has type function", "function", type);
+        });
+    });
+
+    jqUnit.test("Test module resolvePath", function () {
+        var resolved = fluid.module.resolvePath("%infusion/src/components/tableOfContents/html/TableOfContents.html");
+        var expected = fluid.module.canonPath(path.resolve(__dirname, "../../src/components/tableOfContents/html/TableOfContents.html"));
+        jqUnit.assertEquals("Resolved path into infusion module", expected, resolved);
+
+        var pkg = fluid.require("%test-module/package.json");
+        jqUnit.assertEquals("Loaded package.json via resolved path directly via fluid.require", "test-module", pkg.name);
+    });
+
+    fluid.tests.expectFailure = false;
+
+    fluid.tests.addLogListener = function (listener) {
+        fluid.onUncaughtException.addListener(listener, "log",
+            fluid.handlerPriorities.uncaughtException.log);
+    };
+
+    fluid.tests.onUncaughtException = function () {
+        jqUnit.assertEquals("Expected failure in uncaught exception handler",
+            true, fluid.tests.expectFailure);
+        fluid.onUncaughtException.removeListener("test-uncaught");
+        fluid.onUncaughtException.removeListener("log");
+        fluid.tests.addLogListener(fluid.identity);
+        fluid.tests.expectFailure = false;
+        fluid.invokeLater(function () { // apply this later to avoid nesting uncaught exception handler
+            fluid.invokeLater(function () {
+                fluid.onUncaughtException.removeListener("log"); // restore the original listener
+                console.log("Restarting jqUnit in nested handler");
+                jqUnit.start();
+            });
+            "string".fail(); // provoke a further global uncaught error - should be a no-op
+        });
+    };
+
+    fluid.tests.benignLogger = function () {
+        fluid.log("Expected global failure received in test case");
+        jqUnit.assert("Expected global failure");
+    };
+
+    jqUnit.asyncTest("Test uncaught exception handler registration and deregistration", function () {
+        jqUnit.expect(2);
+        fluid.onUncaughtException.addListener(fluid.tests.onUncaughtException, "test-uncaught");
+        fluid.tests.addLogListener(fluid.tests.benignLogger);
+        fluid.tests.expectFailure = true;
+        fluid.invokeLater(function () { // put this in a timeout to avoid bombing QUnit's exception handler
+            "string".fail(); // provoke a global uncaught error
+        });
+    });
+
+    jqUnit.test("FLUID-5807 noncorrupt framework stack traces", function () {
+        var error = new fluid.FluidError("thing");
+        jqUnit.assertTrue("Framework error is an error (from its own perspective)", error instanceof fluid.Error);
+        jqUnit.assertTrue("Framework error is an instance of itself", error instanceof fluid.FluidError);
+        var stack = error.stack.toString();
+        jqUnit.assertTrue("Our own filename must appear in the stack", stack.indexOf("basic-node-tests") !== -1);
+    });
+
+    QUnit.load();
 }
 
-QUnit.log(function (details) {
-    if (details.source) { // "white-box" inspection of qunit.js shows that it sets this field on error
-        fluid.log("Message: " + details.message + "\nSource: " + details.source);
-        if (details.expected !== undefined) {
-            console.log("Expected: ", JSON.stringify(details.expected, null, 4));
-            console.log("Actual: ", JSON.stringify(details.actual, null, 4));
+catch (e) {
+    console.log(e);
+    // On an uncaught exception in the fixtures, dump a parseable TAP failure
+    if (shouldOutputTAP) {
+        console.log("1..10");
+        for(var i = 0; i < expectedTestCases; i++) {
+            console.log("not ok - uncaught exception occured in test fixture");
         }
     }
-});
-
-fluid.test.runTests(["fluid.tests.myTestTree"]);
-
-jqUnit.module("Non IoC tests");
-
-jqUnit.test("Rendering truncation test", function () {
-    var rendered = fluid.renderLoggingArg(fluid);
-    jqUnit.assertTrue("Large object truncated", rendered.length < fluid.logObjectRenderChars + 100); // small allowance for extra diagnostic
-    console.log("Large log rendering object truncated to " + rendered.length + " chars");
-});
-
-jqUnit.test("Test fluid.require support", function () {
-    var testModule = fluid.registerNamespace("test-module");
-    jqUnit.assertEquals("Loaded module as Fluid namespace", "Export from test-module", testModule.value);
-    jqUnit.assertEquals("Loaded module as Fluid global entry", "Export from test-module", fluid.global["test-module"].value);
-});
-
-jqUnit.test("Test fluid.require diagnostics and FLUID-5906 loading", function () {
-    jqUnit.expect(1);
-    jqUnit.expectFrameworkDiagnostic("Module name for unloaded modules", function () {
-        fluid.require("%test-module3");
-    }, ["Module test-module3 has not been loaded and could not be loaded"]);
-    var testModule2 = fluid.require("%test-module2");
-    var rawTestModule2 = require("test-module2");
-    jqUnit.assertEquals("Same module resolvable via fluid.require and require ", rawTestModule2, testModule2);
-});
-
-jqUnit.test("Test propagation of standard globals", function () {
-    var expectedGlobals = ["console.log", "setTimeout", "clearTimeout", "setInterval", "clearInterval"];
-
-    fluid.each(expectedGlobals, function (oneGlobal) {
-        var type = typeof(fluid.get(fluid.global, oneGlobal));
-        jqUnit.assertEquals("Global " + oneGlobal + " has type function", "function", type);
-    });
-});
-
-jqUnit.test("Test module resolvePath", function () {
-    var resolved = fluid.module.resolvePath("%infusion/src/components/tableOfContents/html/TableOfContents.html");
-    var expected = fluid.module.canonPath(path.resolve(__dirname, "../../src/components/tableOfContents/html/TableOfContents.html"));
-    jqUnit.assertEquals("Resolved path into infusion module", expected, resolved);
-
-    var pkg = fluid.require("%test-module/package.json");
-    jqUnit.assertEquals("Loaded package.json via resolved path directly via fluid.require", "test-module", pkg.name);
-});
-
-fluid.tests.expectFailure = false;
-
-fluid.tests.addLogListener = function (listener) {
-    fluid.onUncaughtException.addListener(listener, "log",
-        fluid.handlerPriorities.uncaughtException.log);
-};
-
-fluid.tests.onUncaughtException = function () {
-    jqUnit.assertEquals("Expected failure in uncaught exception handler",
-        true, fluid.tests.expectFailure);
-    fluid.onUncaughtException.removeListener("test-uncaught");
-    fluid.onUncaughtException.removeListener("log");
-    fluid.tests.addLogListener(fluid.identity);
-    fluid.tests.expectFailure = false;
-    fluid.invokeLater(function () { // apply this later to avoid nesting uncaught exception handler
-        fluid.invokeLater(function () {
-            fluid.onUncaughtException.removeListener("log"); // restore the original listener
-            console.log("Restarting jqUnit in nested handler");
-            jqUnit.start();
-        });
-        "string".fail(); // provoke a further global uncaught error - should be a no-op
-    });
-};
-
-fluid.tests.benignLogger = function () {
-    fluid.log("Expected global failure received in test case");
-    jqUnit.assert("Expected global failure");
-};
-
-jqUnit.asyncTest("Test uncaught exception handler registration and deregistration", function () {
-    jqUnit.expect(2);
-    fluid.onUncaughtException.addListener(fluid.tests.onUncaughtException, "test-uncaught");
-    fluid.tests.addLogListener(fluid.tests.benignLogger);
-    fluid.tests.expectFailure = true;
-    fluid.invokeLater(function () { // put this in a timeout to avoid bombing QUnit's exception handler
-        "string".fail(); // provoke a global uncaught error
-    });
-});
-
-jqUnit.test("FLUID-5807 noncorrupt framework stack traces", function () {
-    var error = new fluid.FluidError("thing");
-    jqUnit.assertTrue("Framework error is an error (from its own perspective)", error instanceof fluid.Error);
-    jqUnit.assertTrue("Framework error is an instance of itself", error instanceof fluid.FluidError);
-    var stack = error.stack.toString();
-    jqUnit.assertTrue("Our own filename must appear in the stack", stack.indexOf("basic-node-tests") !== -1);
-});
-
-QUnit.load();
+}

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Lucendo Development Ltd.
+Copyright 2016 OCAD University
 
 Licensed under the Educational Community License (ECL), Version 2.0 or the New
 BSD license. You may not use this file except in compliance with one these
@@ -55,7 +56,7 @@ QUnit.testDone(function (data) {
     fluid.log(fluid.tests.getTestMessage(data));
 });
 
-var tapReporting = require('./tap-reporting');
+require("./tap-reporting");
 
 QUnit.done(function (data) {
     fluid.log("Infusion node.js internal tests " +

--- a/tests/node-tests/tap-reporting.js
+++ b/tests/node-tests/tap-reporting.js
@@ -1,0 +1,42 @@
+// Expected to be available as a result of fluid.loadTestingSupport();
+// in basic-node-tests.js
+var QUnit = fluid.registerNamespace("QUnit");
+var jqUnit = fluid.registerNamespace("jqUnit");
+
+// Set boolean for the  presence of the --tap command line option to output a
+// TAP report for consumption by testem when used as a custom launcher
+fluid.tests.tapOutput.shouldOutputTAP = process.argv.findIndex(function (argument) {
+    return argument.indexOf("--tap") > -1;
+}) > -1;
+
+// For accumulating TAP messages for parsing by testem custom launcher
+var tapOutput = "";
+
+// Function to output a TAP  failure report
+// Assumed to be used with fluid.onUncaughtException.addListener
+fluid.tests.tapOutput.outputTAPFailure = function (message) {
+    if (!fluid.tests.expectFailure) {
+        console.log("not ok -  " + message);
+    }
+};
+
+if (fluid.tests.tapOutput.shouldOutputTAP) {
+    // Register listener to output TAP failure report
+    fluid.onUncaughtException.addListener(fluid.tests.tapOutput.outputTAPFailure, "outputTAPFailure",
+        fluid.handlerPriorities.uncaughtException.log);
+
+    // Additional handler for accumulating TAP output
+    QUnit.testDone(function (data) {
+        var tapResult = data.failed === 0 ? "ok" : "not ok";
+        var tapMessage = tapResult + " " + fluid.tests.getTestMessage(data);
+        tapOutput = tapOutput + tapMessage + "\n";
+    });
+
+    // Additional handler for outputting TAP
+    QUnit.done(function () {
+        // Output the TAP header
+        console.log("1.." + fluid.tests.expectedTestCases);
+        // Output the TAP report
+        console.log(tapOutput);
+    });
+}

--- a/tests/node-tests/tap-reporting.js
+++ b/tests/node-tests/tap-reporting.js
@@ -1,7 +1,22 @@
+/*
+Copyright 2016 OCAD University
+
+Licensed under the Educational Community License (ECL), Version 2.0 or the New
+BSD license. You may not use this file except in compliance with one these
+Licenses.
+
+You may obtain a copy of the ECL 2.0 License and BSD License at
+https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
+*/
+
+/* eslint-env node */
+/* global fluid */
+
+"use strict";
+
 // Expected to be available as a result of fluid.loadTestingSupport();
 // in basic-node-tests.js
 var QUnit = fluid.registerNamespace("QUnit");
-var jqUnit = fluid.registerNamespace("jqUnit");
 
 // Set boolean for the  presence of the --tap command line option to output a
 // TAP report for consumption by testem when used as a custom launcher

--- a/tests/testem.json
+++ b/tests/testem.json
@@ -2,5 +2,10 @@
     "test_page": "tests/all-tests.html",
     "timeout": 300,
     "reporter": "tap",
-    "report_file": "report.tap"
+    "report_file": "report.tap",
+    "launchers": {
+        "Node Basic Packaging Tests": {
+            "command": "node tests/node-tests/basic-node-tests.js"
+        }
+    }
 }

--- a/tests/testem.json
+++ b/tests/testem.json
@@ -4,8 +4,9 @@
     "reporter": "tap",
     "report_file": "report.tap",
     "launchers": {
-        "Node Basic Packaging Tests": {
-            "command": "node tests/node-tests/basic-node-tests.js"
+        "Node Module Basic Packaging Tests": {
+            "command": "node tests/node-tests/basic-node-tests.js --tap",
+            "protocol": "tap"
         }
     }
 }


### PR DESCRIPTION
* Modifies the `testem.json` configuration to add a custom "Node Module Basic Packaging Tests" launcher to run `basic-node-tests.js` as part of the overall test run
* Modifies `basic-node-tests.js` to accept a command-line flag of `--tap`; if supplied, it will output a TAP-format report (see https://github.com/testem/testem#processes-with-tap-output) that can be consumed and reported by Testem
* Modifies `basic-node-tests.js` to exit with a non-zero exit code if any tests fail, to better support usage in CI

The node packaging tests will now be run as part of the `grunt tests` tasks in the VM, or locally with `testem ci --file tests/testem.json`

You can run the node packaging tests as part of Testem separately with this command: `testem ci --file tests/testem.json --launch "Node Module Basic Packaging Tests"` (assuming you have Testem installed)