### PR TITLE
FLUID-5994: fix HTML validator issues in keyboard A11Y demo components

### DIFF
--- a/demos/inlineEdit/json/config.json
+++ b/demos/inlineEdit/json/config.json
@@ -10,6 +10,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/inlineEdit",
         "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/InlineEditAPI.html",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Simple Text Inline Edit feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Simple%20Tex%20Inline%20Edit%20feedback"
     }
 }

--- a/demos/keyboard-a11y/js/keyboardDemo.js
+++ b/demos/keyboard-a11y/js/keyboardDemo.js
@@ -188,7 +188,7 @@ var demo = demo || {};
                 "this": "{that}.dom.thumbSelector",
                 "method": "attr",
                 "args": [{
-                    "role": "listitem",
+                    "role": "option",
                     "aria-controls": "image-preview",
                     "aria-selected": false
                 }]

--- a/demos/keyboard-a11y/json/config.json
+++ b/demos/keyboard-a11y/json/config.json
@@ -12,6 +12,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/keyboard-a11y",
         "apiLink": "http://wiki.fluidproject.org/display/docs/Keyboard+Accessibility+Plugin+API",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Keyboard Accessibility Plugin feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Keyboard%20Accessibility%20Plugin%20feedback"
     }
 }

--- a/demos/overviewPanel/index.html
+++ b/demos/overviewPanel/index.html
@@ -45,7 +45,7 @@
                     titleLink: "http://fluidproject.org/infusion.html",
                     demoCodeLink: "https://github.com/fluid-project/infusion/tree/master/demos/overviewPanel",
                     infusionCodeLink: "https://github.com/fluid-project/infusion",
-                    feedbackLink: "mailto:infusion-users@fluidproject.org?subject=Overview Panel feedback"
+                    feedbackLink: "mailto:infusion-users@fluidproject.org?subject=Overview%20Panel%20feedback"
                 }
             });
         </script>

--- a/demos/pager/json/config.json
+++ b/demos/pager/json/config.json
@@ -10,6 +10,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/pager",
         "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/PagerAPI.html",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Pager feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Pager%20feedback"
     }
 }

--- a/demos/prefsFramework/json/config.json
+++ b/demos/prefsFramework/json/config.json
@@ -11,6 +11,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/prefsFramework",
         "apiLink": "http://docs.fluidproject.org/infusion/development/PreferencesFramework.html",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Preferences Framework feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Preferences%20Framework%20feedback"
     }
 }

--- a/demos/progress/json/config.json
+++ b/demos/progress/json/config.json
@@ -10,6 +10,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/progress",
         "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/ProgressAPI.html",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Progress feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Progress%20feedback"
     }
 }

--- a/demos/renderer/json/config.json
+++ b/demos/renderer/json/config.json
@@ -10,6 +10,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/renderer",
         "apiLink": "http://docs.fluidproject.org/infusion/development/Renderer.html",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Renderer feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Renderer%20feedback"
     }
 }

--- a/demos/reorderer/gridReorderer/json/config.json
+++ b/demos/reorderer/gridReorderer/json/config.json
@@ -10,6 +10,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/gridReorderer",
         "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/GridReordererAPI.html",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Grid Reorderer feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Grid%20Reorderer%20feedback"
     }
 }

--- a/demos/reorderer/imageReorderer/json/config.json
+++ b/demos/reorderer/imageReorderer/json/config.json
@@ -11,6 +11,6 @@
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/imageReorderer",
         "apiLink": "http://docs.fluidproject.org/infusion/development/ImageReordererAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Image+Reorderer+Design+Overview",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Image Reorderer feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Image%20Reorderer%20feedback"
     }
 }

--- a/demos/reorderer/layoutReorderer/json/config.json
+++ b/demos/reorderer/layoutReorderer/json/config.json
@@ -11,6 +11,6 @@
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/layoutReorderer",
         "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/LayoutReordererAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Layout+Reorderer+Design+Overview",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Layout Reorderer feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Layout%20Reorderer%20feedback"
     }
 }

--- a/demos/reorderer/listReorderer/json/config.json
+++ b/demos/reorderer/listReorderer/json/config.json
@@ -11,6 +11,6 @@
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/reorderer/listReorderer",
         "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/ListReordererAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/List+Reorderer+Design+Overview",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=List Reorderer feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=List%20Reorderer%20feedback"
     }
 }

--- a/demos/tableOfContents/json/config.json
+++ b/demos/tableOfContents/json/config.json
@@ -10,6 +10,6 @@
     "links": {
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/tableOfContents",
         "apiLink": "http://docs.fluidproject.org/infusion/development/to-do/TableOfContentsAPI.html",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Table of Contents feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Table%20of%20Contents%20feedback"
     }
 }

--- a/demos/uiOptions/json/config.json
+++ b/demos/uiOptions/json/config.json
@@ -10,6 +10,6 @@
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/uiOptions",
         "apiLink": "http://docs.fluidproject.org/infusion/development/UserInterfaceOptionsAPI.html",
         "designLink": "http://wiki.fluidproject.org/pages/viewpage.action?pageId=29959408",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=UI Options feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=UI%20Options%20feedback"
     }
 }

--- a/demos/uploader/json/config.json
+++ b/demos/uploader/json/config.json
@@ -10,6 +10,6 @@
         "demoCodeLink": "https://github.com/fluid-project/infusion/tree/master/demos/uploader",
         "apiLink": "http://docs.fluidproject.org/infusion/development/UploaderAPI.html",
         "designLink": "http://wiki.fluidproject.org/display/Infusion13/Uploader+Design+Overview",
-        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Uploader feedback"
+        "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=Uploader%20feedback"
     }
 }


### PR DESCRIPTION
This turned out to be a fairly simple fix related to updating the `aria-role` attributes and space-encoding the mailto URL.

JIRA reporting it https://issues.fluidproject.org/browse/FLUID-5994

Tagging @jobara 

I'm fixing a few of the other issues with the injected markup under this heading as well, such as space-encoding all the `mailto` URLs.