### PR TITLE
FLUID-6011: Using IDs instead of empty links for ToC

### DIFF
--- a/src/components/tableOfContents/js/TableOfContents.js
+++ b/src/components/tableOfContents/js/TableOfContents.js
@@ -20,25 +20,12 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     *******/
     fluid.registerNamespace("fluid.tableOfContents");
 
-
-    fluid.tableOfContents.insertAnchor = function (name, element, anchorClass) {
-       // In order to resolve FLUID-4453, we need to make sure that the owner document is correctly
-       // taken from the target element (the preview may be in an iframe)
-        var anchor = $("<a></a>", element.ownerDocument);
-        anchor.prop({
-            "class": anchorClass,
-            name: name,
-            id: name
-        });
-        anchor.insertBefore(element);
-    };
-
-    fluid.tableOfContents.headingTextToAnchorInfo = function (heading, guidFunc) {
-        var guid = guidFunc();
+    fluid.tableOfContents.headingTextToAnchorInfo = function (heading) {
+        var id = fluid.allocateSimpleId(heading);
 
         var anchorInfo = {
-            id: guid,
-            url: "#" + guid
+            id: id,
+            url: "#" + id
         };
 
         return anchorInfo;
@@ -57,13 +44,8 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
     fluid.tableOfContents.refreshView = function (that) {
         var headings = that.locateHeadings();
 
-        // remove existing toc anchors from the the DOM, before adding any new ones.
-        that.locate("tocAnchors").remove();
-
         that.anchorInfo = fluid.transform(headings, function (heading) {
-            var info = that.headingTextToAnchorInfo(heading);
-            that.insertAnchor(info.id, heading, that.options.anchorClass);
-            return info;
+            return that.headingTextToAnchorInfo(heading);
         });
 
         var headingsModel = that.modelBuilder.assembleModel(headings, that.anchorInfo);
@@ -98,12 +80,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         },
         model: [],
         invokers: {
-            headingTextToAnchorInfo: {
-                funcName: "fluid.tableOfContents.headingTextToAnchorInfo",
-                args: ["{arguments}.0", "{that}.generateGUID"]
-            },
-            insertAnchor: "fluid.tableOfContents.insertAnchor",
-            generateGUID: "fluid.allocateGuid",
+            headingTextToAnchorInfo: "fluid.tableOfContents.headingTextToAnchorInfo",
             locateHeadings: {
                 funcName: "fluid.tableOfContents.locateHeadings",
                 args: ["{that}"]
@@ -127,13 +104,11 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         },
         selectors: {
             headings: ":header:visible",
-            tocContainer: ".flc-toc-tocContainer",
-            tocAnchors: ".flc-toc-anchors"
+            tocContainer: ".flc-toc-tocContainer"
         },
         ignoreForToC: {
             tocContainer: "{that}.options.selectors.tocContainer"
         },
-        anchorClass: "flc-toc-anchors",
         events: {
             onRefresh: null,
             afterRender: null,

--- a/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
+++ b/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
@@ -260,13 +260,22 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return set;
     };
 
-    var renderTOCTest = function (that, testHeadings, anchorInfo) {
-        var tocLinks = locateSet(that, ["link1", "link2", "link3", "link4", "link5", "link6"]);
-        jqUnit.assertEquals("The toc header is rendered correctly", that.options.strings.tocHeader, that.locate("tocHeader").text());
+    /**
+     * @param {fluid.tableOfContents.levels} levels - An instance of fluid.tableOfContents.levels component
+     * @param {Object} testHeadings - expected heading info data
+     * @param {Object} anchorInfo - optional. An array of anchor info objects
+     *                              these should include at least the url like {url: "#url"}.
+     *                              Typically this will come from the "anchorInfo" member of a
+     *                              fluid.tableOfContents component.
+     *
+     */
+    var renderTOCTest = function (levels, testHeadings, anchorInfo) {
+        var tocLinks = locateSet(levels, ["link1", "link2", "link3", "link4", "link5", "link6"]);
+        jqUnit.assertEquals("The toc header is rendered correctly", levels.options.strings.tocHeader, levels.locate("tocHeader").text());
         jqUnit.assertEquals("The correct number of links are rendered", testHeadings.headingInfo.length, tocLinks.length);
         // #FLUID-4352: check if <ul> exists when there is no tocLinks
         if (tocLinks.length === 0) {
-            jqUnit.assertEquals("<ul> should not be defined when no headers are found", 0, $("ul", that.locate("flc-toc-tocContainer")).length);
+            jqUnit.assertEquals("<ul> should not be defined when no headers are found", 0, $("ul", levels.locate("flc-toc-tocContainer")).length);
         }
         fluid.each(tocLinks, function (elm, idx) {
             var hInfo = testHeadings.headingInfo[idx];
@@ -277,7 +286,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             // To address IE7 problem, http://bugs.jquery.com/ticket/7117
             // To fix, strip it URI if the windows.location is in href. Otherwise, do nothing.
             var eleHref = elm.attr("href").replace($(location).attr("href"), "");
-            jqUnit.assertEquals("ToC anchor set correctly", eleHref, headingURL);
+            jqUnit.assertEquals("ToC anchor set correctly", headingURL, eleHref);
         });
     };
 

--- a/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
+++ b/tests/component-tests/tableOfContents/js/TableOfContentsTests.js
@@ -276,7 +276,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             // To address IE7 problem, http://bugs.jquery.com/ticket/7117
             // To fix, strip it URI if the windows.location is in href. Otherwise, do nothing.
             var eleHref = elm.attr("href").replace($(location).attr("href"), "");
-            jqUnit.assertTrue("ToC anchor set correctly", hInfo.url ? eleHref === hInfo.url : eleHref.indexOf(fluid.fluidInstance) === 1);
+            jqUnit.assertTrue("ToC anchor set correctly", hInfo.url ? eleHref === hInfo.url : eleHref.indexOf("fluid-id-" + fluid.fluidInstance) === 1);
         });
     };
 
@@ -428,17 +428,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.module("Table of Contents Tests");
         // fluid tableOfContents" tests
 
-        jqUnit.test("insertAnchor", function () {
-            var tocTestAnchorName = "tocTestAnchor";
-            var tocInsertAnchorElement = $("#tocInsertAnchor");
-            fluid.tableOfContents.insertAnchor(tocTestAnchorName, tocInsertAnchorElement);
-            // check if the anchor is inserted before the element, in that case, index 0 should be the anchor
-            // the first-child test below assumes that there is only 2 element in the wrapper, including the inserted anchor element.
-            var tocInsertAnchorWrapperFirstChild = $("#tocInsertAnchorWrapper :first-child");
-            jqUnit.assertEquals("ToC insert anchor correctly: id", tocTestAnchorName, tocInsertAnchorWrapperFirstChild.prop("id"));
-            jqUnit.assertEquals("ToC insert anchor correctly: name", tocTestAnchorName, tocInsertAnchorWrapperFirstChild.attr("name"));
-        });
-
         jqUnit.test("public function: headingTextToAnchorInfo", function () {
             // set up and init the ToC component
             var toc = renderTOCComponent();
@@ -482,16 +471,15 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 headingInfo : []
             };
             var headings = $("#flc-toc").children(":header");
-            var serializeHeading = function (level, text) {
-                // macro to serialize heading elements, level, text
-                return {"level": level, "text": text};
-            };
-            headings.each(function (headingsIndex) {
-                var currLink = headings.eq(headingsIndex);
-                testHeadings.headingInfo.push(serializeHeading(
-                    currLink.prop("tagName").substr(currLink.prop("tagName").length - 1),
-                    currLink.text()
-                ));
+
+            fluid.each(headings, function (heading) {
+                heading = $(heading);
+                var headingID = heading.attr("id");
+                testHeadings.headingInfo.push({
+                    level: heading.prop("tagName").substr(heading.prop("tagName").length - 1),
+                    text: heading.text(),
+                    url: headingID ? "#" + headingID : undefined
+                });
             });
             renderTOCComponent("#flc-toc", {
                 listeners: {
@@ -573,9 +561,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                                 jqUnit.assert("The onRefresh event should have fired");
                                 renderTOCTest(levels, testHeadingRefreshed);
                                 renderTOCAnchorTest();
-                                var numHeadings = testHeadingRefreshed.headingInfo.length;
-
-                                jqUnit.assertEquals("The correct number of anchors should be present", numHeadings, that.locate("tocAnchors").length);
                                 jqUnit.start();
                             }, "inTestCase", "last");
 
@@ -630,9 +615,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                         listener: function (that, levels) {
                             renderTOCTest(levels, testHeadings);
                             renderTOCAnchorTest();
-                            var numHeadings = testHeadings.headingInfo.length;
-
-                            jqUnit.assertEquals("The correct number of anchors should be present", numHeadings, that.locate("tocAnchors").length);
                             jqUnit.start();
                         },
                         args: ["{that}", "{that}.levels"]


### PR DESCRIPTION
The ToC now points at the ID of a header item instead of creating an empty anchor to point at. 

https://issues.fluidproject.org/browse/FLUID-6011
