### PR TITLE
FLUID-6027: Switching to fl-hidden-accessible from fl-uploader-hidden

### DIFF
--- a/src/components/uploader/html/Uploader.html
+++ b/src/components/uploader/html/Uploader.html
@@ -112,7 +112,7 @@
                                     x files were too y and were not added to the queue.
                                 </div>
                                 <button type="button" class="flc-uploader-errorPanel-section-removeButton fl-uploader-errorPanel-section-removeButton fl-force-right">
-                                     <span class="flc-uploader-erroredButton-text fl-uploader-hidden">Remove error</span>
+                                     <span class="flc-uploader-erroredButton-text fl-hidden-accessible">Remove error</span>
                                 </button>
                             </div>
 


### PR DESCRIPTION
Switched from fl-uploader-hidden to fl-hidden-accessible so that the label of the
button would not be removed from the accessibility tree

https://issues.fluidproject.org/browse/FLUID-6027