### PR TITLE
FLUID-6025: Removing delete instructions from the row labels

### DIFF
--- a/src/components/uploader/js/FileQueueView.js
+++ b/src/components/uploader/js/FileQueueView.js
@@ -170,7 +170,7 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         row.prop("id", file.id);
         row.addClass(that.options.styles.ready);
         fluid.uploader.fileQueueView.bindRowHandlers(that, row);
-        fluid.updateAriaLabel(row, fileName + " " + fileSize + " " + that.options.strings.status.remove);
+        fluid.updateAriaLabel(row, fileName + " " + fileSize);
         return row;
     };
 


### PR DESCRIPTION
The aria-label had include the remove information that was only relevant before
the file was uploaded. This has been removed. The state of the file row is still
updated in the title attribute, which contains the removal instructions before uploading
and says "file uploaded" after.

https://issues.fluidproject.org/browse/FLUID-6025