### PR TITLE
FLUID-6017 + FLUID-6018: style native HTML sliders with CSS, make them responsive to prefs framework enactors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -243,6 +243,14 @@ module.exports = function (grunt) {
                 }]
             }
         },
+        // grunt-contrib-watch task to watch and rebuild stylus files
+        // automatically when doing stylus development
+        watch: {
+            buildStylus: {
+                files: "src/**/css/stylus/*.styl",
+                tasks: "buildStylus"
+            }
+        },
         shell: {
             runTests: {
                 command: "vagrant ssh -c 'cd /home/vagrant/sync/; DISPLAY=:0 testem ci --file tests/testem.json'"
@@ -280,6 +288,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-modulefiles");
     grunt.loadNpmTasks("grunt-contrib-stylus");
     grunt.loadNpmTasks("grunt-shell");
+    grunt.loadNpmTasks("grunt-contrib-watch");
 
     // Custom tasks:
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -247,7 +247,7 @@ module.exports = function (grunt) {
         // automatically when doing stylus development
         watch: {
             buildStylus: {
-                files: "src/**/css/stylus/*.styl",
+                files: ["src/**/css/stylus/*.styl", "src/**/css/stylus/utils/*.styl"],
                 tasks: "buildStylus"
             }
         },

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ CSS files for the Preferences Framework have been re-written in Stylus. Only Sty
 
 For developing the Preferences Framework, run the following from the project root to compile Stylus files to CSS:
 
-    `grunt buildStylus`
+    grunt buildStylus
 
 A `watch` task using [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) is also supplied to ease Stylus development. This task launches a process that watches all Stylus files in the `src` directory and recompiles them when they are changed. This task can be run using the following command:
 
-    `grunt watch:buildStylus`
+    grunt watch:buildStylus

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ All of these libraries are already bundled within the Infusion image.
 
 Infusion is in the process of switching to use [Stylus](http://learnboost.github.io/stylus/) for CSS pre-processing.
 CSS files for the Preferences Framework have been re-written in Stylus. Only Stylus files are pushed into the github repository.
+
 For developing the Preferences Framework, run the following from the project root to compile Stylus files to CSS:
 
-    grunt buildStylus
+    `grunt buildStylus`
+
+A `watch` task using [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) is also supplied to ease Stylus development. This task launches a process that watches all Stylus files in the `src` directory and recompiles them when they are changed. This task can be run using the following command:
+
+    `grunt watch:buildStylus`

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "grunt-contrib-concat": "1.0.1",
         "grunt-contrib-compress": "1.3.0",
         "grunt-contrib-stylus": "1.2.0",
+        "grunt-contrib-watch": "1.0.0",
         "grunt-modulefiles": "0.3.1",
         "lodash": "4.13.1",
         "eslint-config-fluid": "1.0.0",

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -124,7 +124,7 @@
             left:0;
             margin-top: -0.4em;
             margin-left: -0.4em;
-            slider-thumb-common()
+            slider-thumb-common();
 
             &:active {
                 outline: none;
@@ -139,15 +139,15 @@
         // Native slider thumb appearance
         &::-webkit-slider-thumb {
             -webkit-appearance: none;
-            slider-thumb-common()
+            slider-thumb-common();
         }
 
         &::-moz-range-thumb {
-            slider-thumb-common()
+            slider-thumb-common();
         }
 
         &::-ms-thumb {
-            slider-thumb-common()
+            slider-thumb-common();
         }
         // Native slider track appearance
         // We hide any inherent track styling and let the styles
@@ -155,15 +155,15 @@
         // from native widget styling
 
         &::-webkit-slider-runnable-track {
-            slider-native-track-common()
+            slider-native-track-common();
         }
 
         &::-moz-range-track {
-            slider-native-track-common()
+            slider-native-track-common();
         }
 
         &::-ms-track {
-            slider-native-track-common()
+            slider-native-track-common();
             color: transparent;
         }
 

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -152,7 +152,7 @@
         slider-native-track-common()
     }
 
-    .fl-prefsEditor input[type=range].fl-slider::-ms-track {
+    input[type=range].fl-slider::-ms-track {
         slider-native-track-common()
     }
 

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -9,6 +9,21 @@
          url('../fonts/InfusionIcons-PrefsEditor.eot');
 }
 
+// Mixin for common styles of the "thumb" (slider control)
+// used by both the jQuery and native HTML sliders
+slider-thumb-common()
+    height: 1.5em;
+    width: 1.5em;
+    background-color: #fff;
+    border: 1px solid #b3b3b3;
+    border-radius: 2em;
+    box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
+    background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+    background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+    background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+    background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+    background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+
 .fl-prefsEditor {
     font-family: "Myriad Pro", Helvetica, Arial, sans-serif;
 
@@ -108,15 +123,9 @@
             display:block;
             top:0;
             left:0;
-            height: 1.5em;
-            width: 1.5em;
             margin-top: -0.4em;
             margin-left: -0.4em;
-            background-color: #fff;
-            border: 1px solid #b3b3b3;
-            border-radius: 2em;
-            box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
-            background-image: linear-gradient(right top, rgb(255,255,255) 46%, rgb(233,234,234) 73%);
+            slider-thumb-common()
 
             &:active {
                 outline: none;
@@ -132,45 +141,15 @@
 
     input[type=range].fl-slider::-webkit-slider-thumb {
         -webkit-appearance: none;
-        height: 1.5em;
-        width: 1.5em;
-        background-color: #fff;
-        border: 1px solid #b3b3b3;
-        border-radius: 2em;
-        box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
-        background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        slider-thumb-common()
     }
 
     input[type=range].fl-slider::-moz-range-thumb {
-        height: 1.5em;
-        width: 1.5em;
-        background-color: #fff;
-        border: 1px solid #b3b3b3;
-        border-radius: 2em;
-        box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
-        background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        slider-thumb-common()
     }
 
     .fl-prefsEditor input[type=range].fl-slider::-mms-thumb {
-        height: 1.5em;
-        width: 1.5em;
-        background-color: #fff;
-        border: 1px solid #b3b3b3;
-        border-radius: 2em;
-        box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
-        background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-        background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        slider-thumb-common()
     }
 
     .fl-slider-horz {

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -145,18 +145,15 @@
     // from native widget styling
 
     input[type=range].fl-slider::-webkit-slider-runnable-track {
-        background: transparent;
-        border: 0px;
+        slider-native-track-common()
     }
 
     input[type=range].fl-slider::-moz-range-track {
-        background: transparent;
-        border: 0px;
+        slider-native-track-common()
     }
 
     .fl-prefsEditor input[type=range].fl-slider::-ms-track {
-        background: transparent;
-        border: 0px;
+        slider-native-track-common()
     }
 
     .fl-slider-horz {

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -136,7 +136,7 @@
 
     input[type=range].fl-slider {
         -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
-        // Native slider thumb appearance    
+        // Native slider thumb appearance
         &::-webkit-slider-thumb {
             -webkit-appearance: none;
             slider-thumb-common()
@@ -165,6 +165,19 @@
         &::-ms-track {
             slider-native-track-common()
         }
+
+        &::-ms-fill-lower {
+            background: none;
+            background-color: transparent;
+            border: 0;
+        }
+
+        &::-ms-fill-upper {
+            background: none;
+            background-color: transparent;
+            border: 0;
+        }
+
     }
 
     .fl-slider-horz {

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -139,6 +139,8 @@ slider-thumb-common()
         -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
     }
 
+    // Native slider thumb appearance
+
     input[type=range].fl-slider::-webkit-slider-thumb {
         -webkit-appearance: none;
         slider-thumb-common()
@@ -148,8 +150,26 @@ slider-thumb-common()
         slider-thumb-common()
     }
 
-    .fl-prefsEditor input[type=range].fl-slider::-mms-thumb {
+    .fl-prefsEditor input[type=range].fl-slider::-ms-thumb {
         slider-thumb-common()
+    }
+
+    // Native slider track appearance
+    // We hide any inherent track styling
+
+    input[type=range].fl-slider::-webkit-slider-runnable-track {
+        background: transparent;
+        border: 0px;
+    }
+
+    input[type=range].fl-slider::-moz-range-track {
+        background: transparent;
+        border: 0px;
+    }
+
+    .fl-prefsEditor input[type=range].fl-slider::-ms-track {
+        background: transparent;
+        border: 0px;
     }
 
     .fl-slider-horz {

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -133,6 +133,8 @@
     }
 
     // Native slider appearance
+    // based on techniques described at https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/
+    // and http://brennaobrien.com/blog/2014/05/style-input-type-range-in-every-browser.html
 
     input[type=range].fl-slider {
         -webkit-appearance: none; /* Hides the slider so that custom slider can be made */

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -155,7 +155,9 @@ slider-thumb-common()
     }
 
     // Native slider track appearance
-    // We hide any inherent track styling
+    // We hide any inherent track styling and let the styles
+    // set with the fl-slider class be used without interference
+    // from native widget styling
 
     input[type=range].fl-slider::-webkit-slider-runnable-track {
         background: transparent;

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -122,38 +122,35 @@
 
     input[type=range].fl-slider {
         -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
-    }
+        // Native slider thumb appearance    
+        &::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            slider-thumb-common()
+        }
 
-    // Native slider thumb appearance
+        &::-moz-range-thumb {
+            slider-thumb-common()
+        }
 
-    input[type=range].fl-slider::-webkit-slider-thumb {
-        -webkit-appearance: none;
-        slider-thumb-common()
-    }
+        &::-ms-thumb {
+            slider-thumb-common()
+        }
+        // Native slider track appearance
+        // We hide any inherent track styling and let the styles
+        // set with the fl-slider class be used without interference
+        // from native widget styling
 
-    input[type=range].fl-slider::-moz-range-thumb {
-        slider-thumb-common()
-    }
+        &::-webkit-slider-runnable-track {
+            slider-native-track-common()
+        }
 
-    .fl-prefsEditor input[type=range].fl-slider::-ms-thumb {
-        slider-thumb-common()
-    }
+        &::-moz-range-track {
+            slider-native-track-common()
+        }
 
-    // Native slider track appearance
-    // We hide any inherent track styling and let the styles
-    // set with the fl-slider class be used without interference
-    // from native widget styling
-
-    input[type=range].fl-slider::-webkit-slider-runnable-track {
-        slider-native-track-common()
-    }
-
-    input[type=range].fl-slider::-moz-range-track {
-        slider-native-track-common()
-    }
-
-    input[type=range].fl-slider::-ms-track {
-        slider-native-track-common()
+        &::-ms-track {
+            slider-native-track-common()
+        }
     }
 
     .fl-slider-horz {

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -123,6 +123,56 @@
             }
         }
     }
+
+    // Native slider appearance
+
+    input[type=range].fl-slider {
+        -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
+    }
+
+    input[type=range].fl-slider::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        height: 1.5em;
+        width: 1.5em;
+        background-color: #fff;
+        border: 1px solid #b3b3b3;
+        border-radius: 2em;
+        box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
+        background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+    }
+
+    input[type=range].fl-slider::-moz-range-thumb {
+        height: 1.5em;
+        width: 1.5em;
+        background-color: #fff;
+        border: 1px solid #b3b3b3;
+        border-radius: 2em;
+        box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
+        background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+    }
+
+    .fl-prefsEditor input[type=range].fl-slider::-mms-thumb {
+        height: 1.5em;
+        width: 1.5em;
+        background-color: #fff;
+        border: 1px solid #b3b3b3;
+        border-radius: 2em;
+        box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
+        background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
+        background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+    }
+
     .fl-slider-horz {
         width: 9em;
     }

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -9,17 +9,6 @@
          url('../fonts/InfusionIcons-PrefsEditor.eot');
 }
 
-// Mixin for common styles of the "thumb" (slider control)
-// used by both the jQuery and native HTML sliders
-slider-thumb-common()
-    height: 1.5em;
-    width: 1.5em;
-    background-color: #fff;
-    border: 1px solid #b3b3b3;
-    border-radius: 2em;
-    box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
-    background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
-
 .fl-prefsEditor {
     font-family: "Myriad Pro", Helvetica, Arial, sans-serif;
 

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -18,10 +18,6 @@ slider-thumb-common()
     border: 1px solid #b3b3b3;
     border-radius: 2em;
     box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
-    background-image: -webkit-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-    background-image: -moz-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-    background-image: -o-linear-gradient(right top, #fff 46%, #e9eaea 73%);
-    background-image: -ms-linear-gradient(right top, #fff 46%, #e9eaea 73%);
     background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
 
 .fl-prefsEditor {

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -164,6 +164,7 @@
 
         &::-ms-track {
             slider-native-track-common()
+            color: transparent;
         }
 
         &::-ms-fill-lower {

--- a/src/framework/preferences/css/stylus/utils/Helpers.styl
+++ b/src/framework/preferences/css/stylus/utils/Helpers.styl
@@ -21,3 +21,16 @@ linear-gradient() {
         s('linear-gradient(%s)', content);
     }
 }
+
+
+// Mixin for common styles of the "thumb" (slider control)
+// used by both the jQuery and native HTML sliders
+slider-thumb-common() {
+    height: 1.5em;
+    width: 1.5em;
+    background-color: #fff;
+    border: 1px solid #b3b3b3;
+    border-radius: 2em;
+    box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
+    background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
+}

--- a/src/framework/preferences/css/stylus/utils/Helpers.styl
+++ b/src/framework/preferences/css/stylus/utils/Helpers.styl
@@ -34,3 +34,10 @@ slider-thumb-common() {
     box-shadow: 4px 2px 3px rgba(0,0,0,0.3);
     background-image: linear-gradient(right top, #fff 46%, #e9eaea 73%);
 }
+
+// Mixin for common styles of the "track" on the native HTML sliders
+
+slider-native-track-common() {
+    background: transparent;
+    border: 0px;
+}

--- a/src/framework/preferences/css/stylus/utils/Themes.styl
+++ b/src/framework/preferences/css/stylus/utils/Themes.styl
@@ -53,18 +53,11 @@ build-themes-prefsEditor(contrastThemes) {
                     background: none;
                     background-color: fColor;
                 }
-
-                input[type=range].fl-slider::-webkit-slider-thumb {
-                    slider-thumb-common-contrastTheme()
-                }
-
-                input[type=range].fl-slider::-moz-range-thumb {
-                    slider-thumb-common-contrastTheme()
-                }
-
-                input[type=range].fl-slider::-mms-thumb {
-                    slider-thumb-common-contrastTheme()
-                }
+                    &::-webkit-slider-thumb,
+                    &::-moz-range-thumb,
+                    &::-mms-thumb {
+                        slider-thumb-common-contrastTheme()
+                    }
 
                 // ON/OFF switch
                 .fl-prefsEditor-switch,

--- a/src/framework/preferences/css/stylus/utils/Themes.styl
+++ b/src/framework/preferences/css/stylus/utils/Themes.styl
@@ -45,7 +45,7 @@ build-themes-prefsEditor(contrastThemes) {
 
                     a, a:hover,
                     .fl-slider-handle, .fl-slider-handle:hover {
-                        slider-thumb-common-contrastTheme()
+                        slider-thumb-common-contrastTheme();
                     }
                 }
 
@@ -53,13 +53,13 @@ build-themes-prefsEditor(contrastThemes) {
                     background: none;
                     background-color: fColor;
                     &::-webkit-slider-thumb {
-                        slider-thumb-common-contrastTheme()
+                        slider-thumb-common-contrastTheme();
                     }
                     &::-moz-range-thumb {
-                        slider-thumb-common-contrastTheme()
+                        slider-thumb-common-contrastTheme();
                     }
                     &::-ms-thumb {
-                        slider-thumb-common-contrastTheme()
+                        slider-thumb-common-contrastTheme();
                     }
                 }
 

--- a/src/framework/preferences/css/stylus/utils/Themes.styl
+++ b/src/framework/preferences/css/stylus/utils/Themes.styl
@@ -27,6 +27,7 @@ themes = {
 slider-thumb-common-contrastTheme() {
     background: none;
     background-color: fColor;
+    box-shadow: none !important;
 }
 
 build-themes-prefsEditor(contrastThemes) {

--- a/src/framework/preferences/css/stylus/utils/Themes.styl
+++ b/src/framework/preferences/css/stylus/utils/Themes.styl
@@ -24,10 +24,16 @@ themes = {
     }
 }
 
+slider-thumb-common-contrastTheme()
+    background: none;
+    background-color: fColor;
+
 build-themes-prefsEditor(contrastThemes) {
+
     for themeName in contrastThemes {
         fColor = contrastThemes[themeName].foregroundColor;
         bColor = contrastThemes[themeName].backgroundColor;
+
 
         {themeName} {
             .fl-prefsEditor {
@@ -38,10 +44,25 @@ build-themes-prefsEditor(contrastThemes) {
 
                     a, a:hover,
                     .fl-slider-handle, .fl-slider-handle:hover {
-                        border:1px solid fColor;
-                        background-color: bColor;
-                        background-image: none;
+                        slider-thumb-common-contrastTheme()
                     }
+                }
+
+                input[type=range].fl-slider {
+                    background: none;
+                    background-color: fColor;
+                }
+
+                input[type=range].fl-slider::-webkit-slider-thumb {
+                    slider-thumb-common-contrastTheme()
+                }
+
+                input[type=range].fl-slider::-moz-range-thumb {
+                    slider-thumb-common-contrastTheme()
+                }
+
+                .fl-prefsEditor input[type=range].fl-slider::-mms-thumb {
+                    slider-thumb-common-contrastTheme()
                 }
 
                 // ON/OFF switch

--- a/src/framework/preferences/css/stylus/utils/Themes.styl
+++ b/src/framework/preferences/css/stylus/utils/Themes.styl
@@ -24,9 +24,10 @@ themes = {
     }
 }
 
-slider-thumb-common-contrastTheme()
+slider-thumb-common-contrastTheme() {
     background: none;
     background-color: fColor;
+}
 
 build-themes-prefsEditor(contrastThemes) {
 
@@ -61,7 +62,7 @@ build-themes-prefsEditor(contrastThemes) {
                     slider-thumb-common-contrastTheme()
                 }
 
-                .fl-prefsEditor input[type=range].fl-slider::-mms-thumb {
+                input[type=range].fl-slider::-mms-thumb {
                     slider-thumb-common-contrastTheme()
                 }
 

--- a/src/framework/preferences/css/stylus/utils/Themes.styl
+++ b/src/framework/preferences/css/stylus/utils/Themes.styl
@@ -52,12 +52,16 @@ build-themes-prefsEditor(contrastThemes) {
                 input[type=range].fl-slider {
                     background: none;
                     background-color: fColor;
-                }
-                    &::-webkit-slider-thumb,
-                    &::-moz-range-thumb,
+                    &::-webkit-slider-thumb {
+                        slider-thumb-common-contrastTheme()
+                    }
+                    &::-moz-range-thumb {
+                        slider-thumb-common-contrastTheme()
+                    }
                     &::-mms-thumb {
                         slider-thumb-common-contrastTheme()
                     }
+                }
 
                 // ON/OFF switch
                 .fl-prefsEditor-switch,


### PR DESCRIPTION
This addresses both https://issues.fluidproject.org/browse/FLUID-6017 and https://issues.fluidproject.org/browse/FLUID-6018 by styling the native sliders with CSS, using the techniques described at https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/

Additionally, since it's rather painful to run `grunt buildStylus` each time when doing Stylus development, I've added a `grunt watch:buildStylus` task using `grunt-contrib-watch` that automatically recompiles Stylus -> CSS as changes are made. I ended up doing this as a local customization at first and then concluded it might be generally useful for the project.

Needs to be tested with IE and Edge, will do so when in the office later this morning. Opening PR now for review of the basic approach.

Tagging @jobara 