### PR TITLE
FLUID-6032: Fixing progress label

### DIFF
--- a/demos/progress/js/progressDemo.js
+++ b/demos/progress/js/progressDemo.js
@@ -84,7 +84,7 @@ var demo = demo || {};
         strings: {
             confirmStatus: "Confirm and submit your order.",
             orderSubmitted: "Order Submitted. Demo finished.",
-            percentCompleted: "%percent% Complete",
+            percentCompleted: "%percentComplete% Complete",
             progressTitle: "Checking inventory, please wait."
         },
         events: {
@@ -157,7 +157,7 @@ var demo = demo || {};
                     modelListeners: {
                         "percent": {
                             func: "{progress}.update",
-                            args: ["{change}.value"],
+                            args: ["{change}.value", "{shoppingDemo}.options.strings.percentCompleted"],
                             excludeSource: "init"
                         }
                     }

--- a/src/components/progress/js/Progress.js
+++ b/src/components/progress/js/Progress.js
@@ -132,8 +132,9 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
             fluid.progress.updateWidth(that, pixels);
         }
 
-        if (labelText !== null) {
-            fluid.progress.updateText(that.label, labelText);
+        if (fluid.isValue(labelText)) {
+            var text = fluid.stringTemplate(labelText, {percentComplete: percent});
+            fluid.progress.updateText(that.label, text);
         }
 
         // update ARIA

--- a/tests/component-tests/progress/js/ProgressTests.js
+++ b/tests/component-tests/progress/js/ProgressTests.js
@@ -166,6 +166,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             progressBar.update(null, "");
             jqUnit.assertTrue("After updating text with an empty string, the label should be empty",
                  progressBar.label.text() === "");
+            // 4.8
+            // update with string template
+            progressBar.update(10, "%percentComplete% Complete");
+            jqUnit.assertTrue("After updating text with an string template, the label should include the rendered temlpate",
+                 progressBar.label.text() === "10% Complete");
         });
 
         jqUnit.module("Progress Tests (No animation)");


### PR DESCRIPTION
- Added the progress label text update back to the demo
- Updated the progress component to optionally interpolate the percentage into a string template

https://issues.fluidproject.org/browse/FLUID-6032