### PR TITLE
FLUID-6053: reduce fixed width of sliders slightly to deal with issue…

### DIFF
--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -184,7 +184,7 @@
     }
 
     .fl-slider-horz {
-        width: 9em;
+        width: 8.8em;
     }
 
     .fl-slider-input {


### PR DESCRIPTION
This shaves 0.2em off the fixed width of the sliders so that the textfield doesn't linebreak when using the `Enlarge buttons, menus, text-fields, and other inputs` UIO option.

@jobara, the issue we found with the jQuery slider not respecting the "enlarge inputs" option has been added to an existing JIRA at https://issues.fluidproject.org/browse/FLUID-4606