### PR TITLE
FLUID-6086: Fixing stdio option to allow stdout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,10 +26,10 @@ var execSync = require("child_process").execSync;
  */
 var getFromExec = function (command, options) {
     var result = options.defaultValue;
-    var stdio = options.verbose ? "pipe" : "ignore";
+    var stderr = options.verbose ? "pipe" : "ignore";
 
     try {
-        result = execSync(command, {stdio: stdio });
+        result = execSync(command, {stdio: ["pipe", "pipe", stderr]});
     } catch (e) {
         if (options.verbose) {
             console.log("Error executing command: " + command);


### PR DESCRIPTION
The verbose setting now only affects stderr, as the stdout needs to be returned by the function

https://issues.fluidproject.org/browse/FLUID-6086