### PR TITLE
FLUID-6103: address Chrome-on-Windows pause/resume failures introduced by Chrome regression

### DIFF
--- a/src/framework/enhancement/js/ContextAwareness.js
+++ b/src/framework/enhancement/js/ContextAwareness.js
@@ -212,9 +212,18 @@ var fluid_2_0_0 = fluid_2_0_0 || {};
         return typeof(navigator) !== "undefined" && navigator.platform ? navigator.platform : undefined;
     };
 
+    // Context awareness for the reported user agent name
+
+    fluid.contextAware.browser.getUserAgent = function () {
+        return typeof(navigator) !== "undefined" && navigator.userAgent ? navigator.userAgent : undefined;
+    };
+
     fluid.contextAware.makeChecks({
         "fluid.browser.platformName": {
             funcName: "fluid.contextAware.browser.getPlatformName"
+        },
+        "fluid.browser.userAgent": {
+            funcName: "fluid.contextAware.browser.getUserAgent"
         }
     });
 

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -269,7 +269,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     // https://bugs.chromium.org/p/chromium/issues/detail?id=679043
 
     fluid.tests.textToSpeech.isPauseResumeSupporting = function () {
-      return !fluid.tests.textToSpeech.isChromeOnWindows() && !fluid.test.conditionalTestUtils.isBrowserOnLinux();
+        return !fluid.tests.textToSpeech.isChromeOnWindows() && !fluid.test.conditionalTestUtils.isBrowserOnLinux();
     };
 
     // Makes check Chrome on Windows due to TTS pause/resume bug

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -269,12 +269,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     // https://bugs.chromium.org/p/chromium/issues/detail?id=679043
 
     fluid.tests.textToSpeech.isPauseResumeSupporting = function () {
-        return !fluid.tests.textToSpeech.isChromeOnWindows() || !fluid.test.conditionalTestUtils.isBrowserOnLinux;
+      return !fluid.tests.textToSpeech.isChromeOnWindows() && !fluid.test.conditionalTestUtils.isBrowserOnLinux();
     };
 
     // Makes check Chrome on Windows due to TTS pause/resume bug
     fluid.contextAware.makeChecks({
-        "fluid.tests.textToSpeech.isPauseResumeSupporting": "fluid.tests.textToSpeech.isPauseResumeSupporting"
+        "fluid.tests.textToSpeech.supportsPauseResume": "fluid.tests.textToSpeech.isPauseResumeSupporting"
     });
 
     fluid.defaults("fluid.tests.textToSpeech.contextAwareTestRunner", {
@@ -283,9 +283,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             supportsPauseResume: {
                 checks: {
                     supportsPauseResume: {
-                        contextValue: "{fluid.tests.textToSpeech.isPauseResumeSupporting}",
+                        contextValue: "{fluid.tests.textToSpeech.supportsPauseResume}",
                         equals: true,
-                        gradeNames: ["fluid.tests.textToSpeech.supportsPauseResume"]
+                        gradeNames: ["fluid.tests.textToSpeech.contextAwareTestRunner.supportsPauseResume"]
                     }
                 }
             }
@@ -295,7 +295,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         }
     });
 
-    fluid.defaults("fluid.tests.textToSpeech.supportsPauseResume", {
+    fluid.defaults("fluid.tests.textToSpeech.contextAwareTestRunner.supportsPauseResume", {
         tests: {
             supportsPauseResume: "fluid.tests.textToSpeech.supportsPauseResumeTests"
         }

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -258,14 +258,33 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
            fluid.test.conditionalTestUtils.bypassTest, "Browser appears to support TTS", "Browser does not appear to support TTS");
     };
 
+    fluid.tests.textToSpeech.isChromeOnWindows = function () {
+        return fluid.contextAware.getCheckValue(fluid.rootComponent, "{fluid.browser.isChrome}") && fluid.contextAware.getCheckValue(fluid.rootComponent, "{fluid.browser.platform.isWindows}");
+    };
+
+    // The following environments are currently consider to not support
+    // pause and resume:
+    // Linux (any browser)
+    // Chrome on Windows due to this bug:
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=679043
+
+    fluid.tests.textToSpeech.isPauseResumeSupporting = function () {
+        return !fluid.tests.textToSpeech.isChromeOnWindows() || !fluid.test.conditionalTestUtils.isBrowserOnLinux;
+    };
+
+    // Makes check Chrome on Windows due to TTS pause/resume bug
+    fluid.contextAware.makeChecks({
+        "fluid.tests.textToSpeech.isPauseResumeSupporting": "fluid.tests.textToSpeech.isPauseResumeSupporting"
+    });
+
     fluid.defaults("fluid.tests.textToSpeech.contextAwareTestRunner", {
         gradeNames: ["fluid.test.conditionalTestUtils.contextAwareTestRunner"],
         contextAwareness: {
             supportsPauseResume: {
                 checks: {
                     supportsPauseResume: {
-                        contextValue: "{fluid.browser.platform.isLinux}",
-                        equals: false,
+                        contextValue: "{fluid.tests.textToSpeech.isPauseResumeSupporting}",
+                        equals: true,
                         gradeNames: ["fluid.tests.textToSpeech.supportsPauseResume"]
                     }
                 }

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -91,14 +91,36 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     // Functions for browser platform reporting for makeChecks
+
+    // Given the lack of standards around navigator.platform, this is based on
+    // web developer "folk knowledge" as embodied in posts like
+    // http://stackoverflow.com/questions/19877924/what-is-the-list-of-possible-values-for-navigator-platform-as-of-today
+    //
+    // These checks should not be relied upon outside of a controlled testing
+    // context, when we need to skip certain tests based on bugs or partial
+    // implementation on a particular browser/platform combination
+
+    // Linux platforms identify themselves with a full "Linux" string plus
+    // a platform architecture string, as the following partial list:
+    // - Linux x86_64
+    // - Linux aarch64
     fluid.test.conditionalTestUtils.isBrowserOnLinux = function () {
         return fluid.test.conditionalTestUtils.contextValueContains("Linux", "{fluid.browser.platformName}");
     };
 
+    // Macintosh platforms identify themselves with a "Mac" string concatenated
+    // with a platform architecture string, such as:
+    // - MacIntel
+    // - MacPPC
     fluid.test.conditionalTestUtils.isBrowserOnMac = function () {
         return fluid.test.conditionalTestUtils.contextValueContains("Mac", "{fluid.browser.platformName}");
     };
 
+    // Windows platforms identify themselves with a "Win" string concatenated
+    // with a platform architecture string, such as:
+    // - Win32
+    // - Win16
+    // - WinCE
     fluid.test.conditionalTestUtils.isBrowserOnWindows = function () {
         return fluid.test.conditionalTestUtils.contextValueContains("Win", "{fluid.browser.platformName}");
     };
@@ -115,7 +137,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     // Edge reports Chrome in its userAgent string, so we have to additionally check for
     // the Edge string
     fluid.test.conditionalTestUtils.isChromeBrowser = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Chrome", "{fluid.browser.userAgent}") && !fluid.test.conditionalTestUtils.contextValueContains("Edge", "{fluid.browser.userAgent}");;
+        return fluid.test.conditionalTestUtils.contextValueContains("Chrome", "{fluid.browser.userAgent}") && !fluid.test.conditionalTestUtils.contextValueContains("Edge", "{fluid.browser.userAgent}");
     };
 
     // We have to check that the userAgent string contains Safari, but does not

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -103,10 +103,34 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.browser.platformName}");
     };
 
+    // Makes checks for browser platform
     fluid.contextAware.makeChecks({
         "fluid.browser.platform.isLinux": "fluid.test.conditionalTestUtils.isBrowserOnLinux",
         "fluid.browser.platform.isMac": "fluid.test.conditionalTestUtils.isBrowserOnMac",
         "fluid.browser.platform.isWindows": "fluid.test.conditionalTestUtils.isBrowserOnWindows"
+    });
+
+    // Functions for web browser name reporting for makeChecks
+
+    fluid.test.conditionalTestUtils.isChromeBrowser = function () {
+        return fluid.test.conditionalTestUtils.contextValueContains("Chrome", "{fluid.browser.userAgent}");
+    };
+
+    // We have to check that the userAgent string contains Safari, but does not
+    // contain Chrome, because Chrome on Mac includes the string "Safari"
+    fluid.test.conditionalTestUtils.isSafariBrowser = function () {
+        return fluid.test.conditionalTestUtils.contextValueContains("Safari", "{fluid.browser.userAgent}") && !fluid.test.conditionalTestUtils.contextValueContains("Chrome", "{fluid.browser.userAgent}");
+    };
+
+    fluid.test.conditionalTestUtils.isFirefoxBrowser = function () {
+        return fluid.test.conditionalTestUtils.contextValueContains("Firefox", "{fluid.browser.userAgent}");
+    };
+
+    // Makes checks for browser name
+    fluid.contextAware.makeChecks({
+        "fluid.browser.isChrome": "fluid.test.conditionalTestUtils.isChromeBrowser",
+        "fluid.browser.isSafari": "fluid.test.conditionalTestUtils.isSafariBrowser",
+        "fluid.browser.isFirefox": "fluid.test.conditionalTestUtils.isFirefoxBrowser"
     });
 
 })();

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -100,7 +100,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     fluid.test.conditionalTestUtils.isBrowserOnWindows = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Windows", "{fluid.browser.platformName}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Win", "{fluid.browser.platformName}");
     };
 
     // Makes checks for browser platform

--- a/tests/test-core/utils/js/ConditionalTestUtils.js
+++ b/tests/test-core/utils/js/ConditionalTestUtils.js
@@ -112,8 +112,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     // Functions for web browser name reporting for makeChecks
 
+    // Edge reports Chrome in its userAgent string, so we have to additionally check for
+    // the Edge string
     fluid.test.conditionalTestUtils.isChromeBrowser = function () {
-        return fluid.test.conditionalTestUtils.contextValueContains("Chrome", "{fluid.browser.userAgent}");
+        return fluid.test.conditionalTestUtils.contextValueContains("Chrome", "{fluid.browser.userAgent}") && !fluid.test.conditionalTestUtils.contextValueContains("Edge", "{fluid.browser.userAgent}");;
     };
 
     // We have to check that the userAgent string contains Safari, but does not
@@ -126,11 +128,16 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         return fluid.test.conditionalTestUtils.contextValueContains("Firefox", "{fluid.browser.userAgent}");
     };
 
+    fluid.test.conditionalTestUtils.isEdgeBrowser = function () {
+        return fluid.test.conditionalTestUtils.contextValueContains("Edge", "{fluid.browser.userAgent}");
+    };
+
     // Makes checks for browser name
     fluid.contextAware.makeChecks({
         "fluid.browser.isChrome": "fluid.test.conditionalTestUtils.isChromeBrowser",
         "fluid.browser.isSafari": "fluid.test.conditionalTestUtils.isSafariBrowser",
-        "fluid.browser.isFirefox": "fluid.test.conditionalTestUtils.isFirefoxBrowser"
+        "fluid.browser.isFirefox": "fluid.test.conditionalTestUtils.isFirefoxBrowser",
+        "fluid.browser.isEdge": "fluid.test.conditionalTestUtils.isEdgeBrowser"
     });
 
 })();


### PR DESCRIPTION
This issue is described at https://issues.fluidproject.org/browse/FLUID-6103, and a bug has been filed with (and acknowledged by) the Chromium team around the non-firing of the `textToSpeech.onpause` and `textToSpeech.onresume` events in the current version of Chrome on Windows: https://bugs.chromium.org/p/chromium/issues/detail?id=679043

Making PR for review purposes and discussion of how to best address the immediate issue (a browser bug in Chrome is causing test failure).