### PR TITLE
FLUID-6029: Rectify spelling error of the word "itself" 

### DIFF
--- a/tests/manual-tests/components/inlineEdit/rich/index.html
+++ b/tests/manual-tests/components/inlineEdit/rich/index.html
@@ -47,7 +47,7 @@
                 <h2>Description</h2>
                 <p>
                     Below are three examples of rich text inline edit. Two using TinyMCE, and one using CK Editor 3.
-                    Apart from being a demostration of the rich text inline edit itslef, this also demostrates that
+                    Apart from being a demostration of the rich text inline edit itself, this also demostrates that
                     mulitple instances can be run on the same page.
                 </p>
                 <p class="instructions-note">


### PR DESCRIPTION
Rectify spelling error of the word "itself" from "itslef" in the description section of rich inline edit page.