### PR TITLE
FLUID-5534: Adding arrows to indicate additional content

### DIFF
--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -133,7 +133,7 @@
                 margin-right: 0;
             }
             .fl-preview-A {
-                font-size: 1.75em;
+                font-size: 1.7em;
             }
 
             // Pseudo content to prevent AT from reading display 'a'

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -192,7 +192,7 @@
     }
 
     // Font Icons
-    .fl-icon-indicator, .fl-icon-crossout, .fl-icon-big-a, .fl-icon-small-a, .fl-icon-line-space-expanded, .fl-icon-line-space-condensed,
+    .fl-icon-right, .fl-icon-left, .fl-icon-indicator, .fl-icon-crossout, .fl-icon-big-a, .fl-icon-small-a, .fl-icon-line-space-expanded, .fl-icon-line-space-condensed,
     .fl-icon-contrast, .fl-icon-undo, .fl-icon-line-space, .fl-icon-inputs, .fl-icon-simplify, .fl-icon-font, .fl-icon-size, .fl-icon-text-to-speech, .fl-icon-toc {
         font-family: 'InfusionIcons' !important;
         speak: none;
@@ -250,6 +250,12 @@
     }
 
     // header icons
+    .fl-icon-right:before {
+        content: "\e001";
+    }
+    .fl-icon-left:before {
+        content: "\e002";
+    }
     .fl-icon-contrast:before {
         content: "\e005";
     }

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -121,16 +121,19 @@
                 margin-right: 5px;
                 border: 1px solid black;
                 border-radius: 5px;
-                height: 3em;
-                width: 3em;
+                height: 2.5em;
+                width: 2.5em;
                 text-align: center;
                 vertical-align: middle;
                 display: inline-block;
-                line-height: 3em !important;
+                line-height: 2.2em !important;
                 padding: 2px;
             }
+            &:last-child label {
+                margin-right: 0;
+            }
             .fl-preview-A {
-                font-size: 2em;
+                font-size: 1.75em;
             }
 
             // Pseudo content to prevent AT from reading display 'a'
@@ -142,6 +145,7 @@
                 outline: 2px solid black;
             }
         }
+
     }
 
     // Stepper
@@ -236,7 +240,7 @@
 
         .fl-prefsEditor-contrast-defaultThemeLabel .fl-crossout {
             font-family: 'InfusionIcons' !important;
-            margin-top: -1.75em;
+            margin-top: -1.25em;
             font-size: 1.85em;
         }
 

--- a/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
+++ b/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
@@ -72,7 +72,9 @@ html {
                 justify-content: space-between;
                 align-items: center;
                 width: 100%;
+                min-height: 3.6rem;
                 text-transform: lowercase;
+                white-space: nowrap;
 
                 [class*='fl-icon-'] {
                     display: none;
@@ -94,18 +96,19 @@ html {
                     font-variant: normal;
                     text-transform: none;
                     -webkit-font-smoothing: antialiased;
-                    margin: -0.4rem 1rem 0rem 1rem;
-                    font-size: 4rem;
+                    font-size: 3rem;
                 }
 
                 // Single Left-Pointing Angle Quotation Mark
                 &:before {
                     content: "\2039";
+                    margin-left: 1rem;
                 }
 
                 // Single Right-Pointing Angle Quotation Mark
                 &:after {
                     content: "\203a";
+                    margin-right: 1rem;
                 }
             }
 
@@ -174,6 +177,7 @@ html {
                     box-shadow: 0px 6px 7px -6px rgba(0,0,0,0.3);
                     font-size: 1.2rem;
                     height: 3rem;
+                    white-space: normal;
 
                     [class*='fl-icon-'] {
                         display: inline;

--- a/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
+++ b/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
@@ -68,7 +68,9 @@ html {
             padding: 16px 0.5rem;
 
             h2 {
-                text-align: center;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
                 width: 100%;
                 text-transform: lowercase;
 
@@ -80,7 +82,41 @@ html {
                     padding-top: 0.2rem;
                     font-size: 1.3em;
                     font-weight: 600;
+                    text-align: center;
                 }
+
+                // The same as Font Icons style declaration from PrefsEditor.styl
+                // Declared separately so that additional markup would not have to
+                // be added to the panels and the heading text itself would have the
+                // propper font family applied.
+                &:before, &:after {
+                    font-family: 'InfusionIcons' !important;
+                    speak: none;
+                    font-style: normal;
+                    font-weight: normal;
+                    font-variant: normal;
+                    text-transform: none;
+                    -webkit-font-smoothing: antialiased;
+                    margin: 0.2em 0.3em 0 0;
+                    font-size: 1.5em;
+                }
+
+                // same as fl-icon-left
+                &:before {
+                    content: "\e002";
+                }
+
+                // same as fl-icon-right
+                &:after {
+                    content: "\e001";
+                }
+            }
+
+            // hide left arrow from first panel
+            // hide right arrow from last panel
+            &:first-of-type h2:before,
+            &:last-of-type h2:after {
+                visibility: hidden;
             }
 
             // visually hide descriptions in mobile view.
@@ -135,8 +171,7 @@ html {
                 min-width: 25rem;
 
                 h2 {
-                    display: flex;
-                    align-items: center;
+                    justify-content: flex-start;
                     margin: 0 0 1.8rem 0;
                     border-bottom: solid #ccc 1px;
                     box-shadow: 0px 6px 7px -6px rgba(0,0,0,0.3);
@@ -145,6 +180,10 @@ html {
 
                     [class*='fl-icon-'] {
                         display: inline;
+                    }
+
+                    &:before, &:after {
+                        content: none;
                     }
                 }
 

--- a/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
+++ b/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
@@ -85,30 +85,27 @@ html {
                     text-align: center;
                 }
 
-                // The same as Font Icons style declaration from PrefsEditor.styl
-                // Declared separately so that additional markup would not have to
-                // be added to the panels and the heading text itself would have the
-                // propper font family applied.
+                // for right and left arrows
                 &:before, &:after {
-                    font-family: 'InfusionIcons' !important;
+                    font-family: "Times New Roman", Georgia, Times, serif !important;
                     speak: none;
                     font-style: normal;
                     font-weight: normal;
                     font-variant: normal;
                     text-transform: none;
                     -webkit-font-smoothing: antialiased;
-                    margin: 0.2em 0.3em 0 0;
-                    font-size: 1.5em;
+                    margin: -0.4rem 1rem 0rem 1rem;
+                    font-size: 4rem;
                 }
 
-                // same as fl-icon-left
+                // Single Left-Pointing Angle Quotation Mark
                 &:before {
-                    content: "\e002";
+                    content: "\2039";
                 }
 
-                // same as fl-icon-right
+                // Single Right-Pointing Angle Quotation Mark
                 &:after {
-                    content: "\e001";
+                    content: "\203a";
                 }
             }
 

--- a/src/framework/preferences/messages/contrast.json
+++ b/src/framework/preferences/messages/contrast.json
@@ -5,6 +5,6 @@
     "contrast-by": "Black on yellow",
     "contrast-yb": "Yellow on black",
     "contrast-lgdg": "Low contrast",
-    "contrastLabel": "colour and contrast",
+    "contrastLabel": "Contrast",
     "contrastDescr": "Change text and background colours"
 }


### PR DESCRIPTION
This is an interim solution, as the arrows are not interactive and can not
be used to scroll the panels. Rather in this implementation they are just
used to indicate that there is additional content that can be manually scrolled to.

https://issues.fluidproject.org/browse/FLUID-5534

NOTE: There is a bug in IE 11 where the headers between panels do not line up. ( see: [FLUID-6154](https://issues.fluidproject.org/browse/FLUID-6154) )