### PR TITLE
FLUID-6165: Adding a replace merge policy for controlValues

### DIFF
--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -771,6 +771,10 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "controlValues.textFont": "enum"
             }
         },
+        mergePolicy: {
+            "controlValues.textFont": "replace",
+            "stringArrayIndex.textFont": "replace"
+        },
         selectors: {
             textFont: ".flc-prefsEditor-text-font",
             label: ".flc-prefsEditor-text-font-label",
@@ -879,6 +883,10 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "model.value": "default",
                 "controlValues.theme": "enum"
             }
+        },
+        mergePolicy: {
+            "controlValues.theme": "replace",
+            "stringArrayIndex.theme": "replace"
         },
         listeners: {
             "afterRender.style": "{that}.style"

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -1090,6 +1090,59 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         }]
     });
 
+    fluid.defaults("fluid.tests.prefs.panel.textFont.override", {
+        gradeNames: ["fluid.tests.prefs.panel.textFont"],
+        stringArrayIndex: {
+            textFont: ["textFont-default", "textFont-verdana"]
+        },
+        controlValues: {
+            textFont: ["default", "verdana"]
+        }
+    });
+
+    fluid.defaults("fluid.tests.textFontPanelOverride", {
+        gradeNames: ["fluid.test.testEnvironment"],
+        components: {
+            textFont: {
+                type: "fluid.tests.prefs.panel.textFont.override",
+                container: ".flc-textFont",
+                createOnEvent: "{textFontTester}.events.onTestCaseStart"
+            },
+            textFontTester: {
+                type: "fluid.tests.textFontOverrideTester"
+            }
+        }
+    });
+
+    fluid.defaults("fluid.tests.textFontOverrideTester", {
+        gradeNames: ["fluid.test.testCaseHolder"],
+        testOptions: {
+            expectedNumOfOptions: 2,
+            defaultValue: "default",
+            newValue: "verdana"
+        },
+        modules: [{
+            name: "Test the text font settings panel with controlValues replaced",
+            tests: [{
+                expect: 6,
+                name: "Test the rendering of the text font panel",
+                sequence: [{
+                    listener: "fluid.tests.textFontPanel.testDefault",
+                    args: ["{textFont}", "{that}.options.testOptions.expectedNumOfOptions", "{that}.options.testOptions.defaultValue"],
+                    event: "{textFontPanelOverride textFont}.events.afterRender"
+                }, {
+                    func: "fluid.changeElementValue",
+                    args: ["{textFont}.dom.textFont", "{that}.options.testOptions.newValue"]
+                }, {
+                    listener: "fluid.tests.panels.utils.checkModel",
+                    args: ["value", "{textFont}.model", "{that}.options.testOptions.newValue"],
+                    spec: {path: "value", priority: "last"},
+                    changeEvent: "{textFont}.applier.modelChanged"
+                }]
+            }]
+        }]
+    });
+
     /*******************************************************************************
      * Contrast
      *******************************************************************************/
@@ -1187,6 +1240,57 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     args: ["{contrast}", "{that}.options.testOptions.expectedNumOfOptions", "{that}.options.testOptions.defaultValue"],
                     spec: {priority: "last"},
                     event: "{contrastPanel contrast}.events.afterRender"
+                }, {
+                    func: "fluid.tests.contrastPanel.changeChecked",
+                    args: ["{contrast}.dom.themeInput", "{that}.options.testOptions.newValue"]
+                }, {
+                    listener: "fluid.tests.panels.utils.checkModel",
+                    args: ["value", "{contrast}.model", "{that}.options.testOptions.newValue"],
+                    spec: {path: "value", priority: "last"},
+                    changeEvent: "{contrast}.applier.modelChanged"
+                }]
+            }]
+        }]
+    });
+
+    fluid.defaults("fluid.tests.prefs.panel.contrast.override", {
+        gradeNames: ["fluid.tests.prefs.panel.contrast"],
+        controlValues:{
+            theme: ["default", "bw", "yb"]
+        }
+    });
+
+    fluid.defaults("fluid.tests.contrastPanelOverride", {
+        gradeNames: ["fluid.test.testEnvironment"],
+        components: {
+            contrast: {
+                type: "fluid.tests.prefs.panel.contrast.override",
+                container: ".flc-contrast",
+                createOnEvent: "{contrastTester}.events.onTestCaseStart"
+            },
+            contrastTester: {
+                type: "fluid.tests.contrastOverrideTester"
+            }
+        }
+    });
+
+    fluid.defaults("fluid.tests.contrastOverrideTester", {
+        gradeNames: ["fluid.test.testCaseHolder"],
+        testOptions: {
+            expectedNumOfOptions: 3,
+            defaultValue: "default",
+            newValue: "yb"
+        },
+        modules: [{
+            name: "Test the contrast settings panel with controlValues replaced",
+            tests: [{
+                expect: 12,
+                name: "Test the rendering of the contrast panel",
+                sequence: [{
+                    listener: "fluid.tests.contrastPanel.testDefault",
+                    args: ["{contrast}", "{that}.options.testOptions.expectedNumOfOptions", "{that}.options.testOptions.defaultValue"],
+                    spec: {priority: "last"},
+                    event: "{contrastPanelOverride contrast}.events.afterRender"
                 }, {
                     func: "fluid.tests.contrastPanel.changeChecked",
                     args: ["{contrast}.dom.themeInput", "{that}.options.testOptions.newValue"]
@@ -1487,7 +1591,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     $(document).ready(function () {
         fluid.test.runTests([
             "fluid.tests.textFontPanel",
+            "fluid.tests.textFontPanelOverride",
             "fluid.tests.contrastPanel",
+            "fluid.tests.contrastPanelOverride",
             "fluid.tests.textSizePanel",
             "fluid.tests.lineSpacePanel",
             "fluid.tests.layoutPanel",


### PR DESCRIPTION
The textFont and contrast panels will replace the arrays that are used
to control their rendering.

https://issues.fluidproject.org/browse/FLUID-6165