### PR TITLE
FLUID-6169: removed fluid.prefs.store as grade for temp and cookie store

### DIFF
--- a/src/framework/preferences/js/Store.js
+++ b/src/framework/preferences/js/Store.js
@@ -47,7 +47,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * @param {Object} options
      */
     fluid.defaults("fluid.prefs.cookieStore", {
-        gradeNames: ["fluid.prefs.store"],
+        gradeNames: ["fluid.prefs.dataSource"],
         cookie: {
             name: "fluid-ui-settings",
             path: "/",
@@ -134,7 +134,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * @param {Object} options
      */
     fluid.defaults("fluid.prefs.tempStore", {
-        gradeNames: ["fluid.prefs.store", "fluid.modelComponent"],
+        gradeNames: ["fluid.prefs.dataSource", "fluid.modelComponent"],
         invokers: {
             get: {
                 funcName: "fluid.identity",

--- a/tests/framework-tests/preferences/html/Store-test.html
+++ b/tests/framework-tests/preferences/html/Store-test.html
@@ -11,6 +11,8 @@
         <script type="text/javascript" src="../../../../src/framework/core/js/Fluid.js"></script>
         <script type="text/javascript" src="../../../../src/framework/core/js/FluidIoC.js"></script>
         <script type="text/javascript" src="../../../../src/framework/core/js/DataBinding.js"></script>
+        <script type="text/javascript" src="../../../../src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script type="text/javascript" src="../../../../src/framework/enhancement/js/ProgressiveEnhancement.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/Store.js"></script>
 
         <!--  These are the jqUnit test js files -->

--- a/tests/framework-tests/preferences/js/PageEnhancerTests.js
+++ b/tests/framework-tests/preferences/js/PageEnhancerTests.js
@@ -23,7 +23,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         components: {
             settingsStore: {
-                type: "fluid.prefs.tempStore"
+                type: "fluid.prefs.store",
+                options: {
+                    gradeNames: ["fluid.prefs.tempStore"]
+                }
             },
             pageEnhancer: {
                 type: "fluid.pageEnhancer",

--- a/tests/framework-tests/preferences/js/StoreTests.js
+++ b/tests/framework-tests/preferences/js/StoreTests.js
@@ -118,13 +118,16 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
             // Check that we get back the test settings correctly.
             var result = store.get();
+            jqUnit.assertDeepEq("The settings are saved to the model correctly.", testSettings, store.model);
             jqUnit.assertDeepEq("The settings are saved and retrieved correctly.", testSettings, result);
 
             // Change the results, save again. It should work again.
             var differentSettings = fluid.copy(testSettings);
             differentSettings.textSize = "32";
             store.set(differentSettings);
+            jqUnit.assertEquals("Changed settings are saved to model correctly.", "32", store.model.textSize);
             jqUnit.assertEquals("Changed settings are saved correctly.", "32", store.get().textSize);
+            jqUnit.assertEquals("Theme was saved to model correctly.", "bw", store.model.theme);
             jqUnit.assertEquals("Theme was saved correctly.", "bw", store.get().theme);
 
         });


### PR DESCRIPTION
All stores now derive fluid.prefs.dataSource. fluid.prefs.store defaults
to use the cookie store but can use other stores based on context.

https://issues.fluidproject.org/browse/FLUID-6169