### PR TITLE
FLUID-6171: adding IoC resoltion to fluid.renderer.selection.inputs

### DIFF
--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -712,6 +712,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         stringArrayIndex: {
             theme: [] // must be supplied by the integrator
         },
+        selectID: "{that}.id", // used for the name attribute to group the selection options
         listeners: {
             "afterRender.style": "{that}.style"
         },
@@ -734,7 +735,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 rowID: "themeRow",
                 labelID: "themeLabel",
                 inputID: "themeInput",
-                selectID: "theme-radio",
+                selectID: "{that}.options.selectID",
                 tree: {
                     optionnames: "${{that}.msgLookup.theme}",
                     optionlist: "${{that}.options.controlValues.theme}",

--- a/src/framework/renderer/js/RendererUtilities.js
+++ b/src/framework/renderer/js/RendererUtilities.js
@@ -307,17 +307,17 @@ fluid_3_0_0 = fluid_3_0_0 || {};
     fluid.renderer.selection.inputs = function (options, container, key, config) {
         fluid.expect("Selection to inputs expander", options, ["selectID", "inputID", "labelID", "rowID"]);
         var selection = config.expander(options.tree);
-        var selectID = config.expandLight(options.selectID);
+        var expandedOpts = config.expandLight(options);
         var rows = fluid.transform(selection.optionlist.value, function (option, index) {
             var togo = {};
-            var element =  {parentRelativeID: "..::" + selectID, choiceindex: index};
-            togo[options.inputID] = element;
-            togo[options.labelID] = fluid.copy(element);
+            var element =  {parentRelativeID: "..::" + expandedOpts.selectID, choiceindex: index};
+            togo[expandedOpts.inputID] = element;
+            togo[expandedOpts.labelID] = fluid.copy(element);
             return togo;
         });
         var togo = {}; // TODO: JICO needs to support "quoted literal key initialisers" :P
-        togo[selectID] = selection;
-        togo[options.rowID] = {children: rows};
+        togo[expandedOpts.selectID] = selection;
+        togo[expandedOpts.rowID] = {children: rows};
         togo = config.expander(togo);
         return togo;
     };

--- a/src/framework/renderer/js/RendererUtilities.js
+++ b/src/framework/renderer/js/RendererUtilities.js
@@ -307,7 +307,10 @@ fluid_3_0_0 = fluid_3_0_0 || {};
     fluid.renderer.selection.inputs = function (options, container, key, config) {
         fluid.expect("Selection to inputs expander", options, ["selectID", "inputID", "labelID", "rowID"]);
         var selection = config.expander(options.tree);
-        var expandedOpts = config.expandLight(options);
+        // Remove the tree from option expansion as this is handled above, and
+        // the tree may have strings with similar syntax to IoC references.
+        var optsToExpand = fluid.censorKeys(options, ["tree"]);
+        var expandedOpts = config.expandLight(optsToExpand);
         var rows = fluid.transform(selection.optionlist.value, function (option, index) {
             var togo = {};
             var element =  {parentRelativeID: "..::" + expandedOpts.selectID, choiceindex: index};

--- a/src/framework/renderer/js/RendererUtilities.js
+++ b/src/framework/renderer/js/RendererUtilities.js
@@ -307,15 +307,16 @@ fluid_3_0_0 = fluid_3_0_0 || {};
     fluid.renderer.selection.inputs = function (options, container, key, config) {
         fluid.expect("Selection to inputs expander", options, ["selectID", "inputID", "labelID", "rowID"]);
         var selection = config.expander(options.tree);
+        var selectID = config.expandLight(options.selectID);
         var rows = fluid.transform(selection.optionlist.value, function (option, index) {
             var togo = {};
-            var element =  {parentRelativeID: "..::" + options.selectID, choiceindex: index};
+            var element =  {parentRelativeID: "..::" + selectID, choiceindex: index};
             togo[options.inputID] = element;
             togo[options.labelID] = fluid.copy(element);
             return togo;
         });
         var togo = {}; // TODO: JICO needs to support "quoted literal key initialisers" :P
-        togo[options.selectID] = selection;
+        togo[selectID] = selection;
         togo[options.rowID] = {children: rows};
         togo = config.expander(togo);
         return togo;

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -1210,8 +1210,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             inputValue = input.value;
             label = labels.eq(index);
             jqUnit.assertTrue("The contrast label has appropriate css applied", label.hasClass(that.options.classnameMap.theme[inputValue]));
-
             jqUnit.assertEquals("The aria-label is " + that.options.messageBase.contrast[index], that.options.messageBase.contrast[index], label.attr("aria-label"));
+            jqUnit.assertEquals("The input has the correct name attribute", that.id, $(input).attr("name"));
         });
 
         jqUnit.assertTrue("The default contrast label has the default label css applied", labels.eq(0).hasClass(that.options.styles.defaultThemeLabel));
@@ -1233,7 +1233,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         modules: [{
             name: "Test the contrast settings panel",
             tests: [{
-                expect: 18,
+                expect: 24,
                 name: "Test the rendering of the contrast panel",
                 sequence: [{
                     listener: "fluid.tests.contrastPanel.testDefault",
@@ -1284,7 +1284,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         modules: [{
             name: "Test the contrast settings panel with controlValues replaced",
             tests: [{
-                expect: 12,
+                expect: 15,
                 name: "Test the rendering of the contrast panel",
                 sequence: [{
                     listener: "fluid.tests.contrastPanel.testDefault",

--- a/tests/framework-tests/renderer/html/RendererUtilities-test.html
+++ b/tests/framework-tests/renderer/html/RendererUtilities-test.html
@@ -75,6 +75,13 @@
             </table>
         </div>
 
+        <div class="fluid-6171-IoC-resolution">
+            <div class="flc-test-row">
+                <input type="radio" class="flc-test-input" name="theme" id="default" value="default" />
+                <label for="default" class="flc-test-label"></label>
+            </div>
+        </div>
+
         <div class="renderer-component-test-repeat">
             <ul>
                 <li class="csc-tabs-tab">

--- a/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
+++ b/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
@@ -1015,14 +1015,19 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     input: ".flc-test-input"
                 },
                 selectionID: "",
+                selectorMap: {
+                    rowID: "row",
+                    labelID: "label",
+                    inputID: "input"
+                },
                 repeatingSelectors: ["row"],
                 renderOnInit: true,
                 protoTree: {
                     expander: {
                         type: "fluid.renderer.selection.inputs",
-                        rowID: "row",
-                        labelID: "label",
-                        inputID: "input",
+                        rowID: "{that}.options.selectorMap.rowID",
+                        labelID: "{that}.options.selectorMap.labelID",
+                        inputID: "{that}.options.selectorMap.inputID",
                         selectID: "{that}.options.selectionID",
                         tree: {
                             optionnames: "${{that}.options.strings.theme}",

--- a/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
+++ b/tests/framework-tests/renderer/js/RendererUtilitiesTests.js
@@ -997,6 +997,64 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
         });
 
+        jqUnit.asyncTest("FLUID-6171 test: IoC resolution in inputs expander", function () {
+            fluid.defaults("fluid.tets.fluid_6171.inputRenderer", {
+                gradeNames: ["fluid.rendererComponent"],
+                controlValues: {
+                    theme: ["a", "b"]
+                },
+                strings: {
+                    theme: ["A", "B"]
+                },
+                model: {
+                    value: "a"
+                },
+                selectors: {
+                    row: ".flc-test-row",
+                    label: ".flc-test-label",
+                    input: ".flc-test-input"
+                },
+                selectionID: "",
+                repeatingSelectors: ["row"],
+                renderOnInit: true,
+                protoTree: {
+                    expander: {
+                        type: "fluid.renderer.selection.inputs",
+                        rowID: "row",
+                        labelID: "label",
+                        inputID: "input",
+                        selectID: "{that}.options.selectionID",
+                        tree: {
+                            optionnames: "${{that}.options.strings.theme}",
+                            optionlist: "${{that}.options.controlValues.theme}",
+                            selection: "${value}"
+                        }
+                    }
+                }
+            });
+
+            var selectionID = "fluid-6171";
+            fluid.tets.fluid_6171.inputRenderer(".fluid-6171-IoC-resolution", {
+                selectionID: selectionID,
+                listeners: {
+                    "afterRender.assert": {
+                        listener: function (that) {
+                            that.locate("input").each(function (idx, elm) {
+                                elm = $(elm);
+                                jqUnit.assertEquals("The group name for the radio button at index " + idx + " should be set correctly", selectionID, elm.attr("name"));
+                            });
+                        },
+                        args: ["{that}"],
+                        priority: "last:testing"
+                    },
+                    "afterRender.start": {
+                        listener: "jqUnit.start",
+                        priority: "after:assert"
+                    }
+                }
+            });
+        });
+
         function deleteComponentTypes(tree) {
             return fluid.transform(tree, function (el) {
                 if (fluid.isPrimitive(el)) {


### PR DESCRIPTION
The renderer expander will now also resolve IoC references for the
selectID. rowID, labelID, and inputID all point at values in the
selectors block and do not resolve IoC references.

https://issues.fluidproject.org/browse/FLUID-6171