### PR TITLE
FLUID-6188: Make sure that fluid.loadTestingSupport is idempotent.

### DIFF
--- a/src/module/fluid.js
+++ b/src/module/fluid.js
@@ -113,6 +113,15 @@ fluid.onUncaughtException.addListener(fluid.logUncaughtException, "log",
 fluid.onUncaughtException.addListener(function () {fluid.logActivity();}, "logActivity",
     fluid.handlerPriorities.uncaughtException.logActivity);
 
+
+// Make sure process exits with error (see FLUID-5920)
+fluid.handleUncaughtException = function () {
+    process.exit(1);
+};
+
+fluid.onUncaughtException.addListener(fluid.handleUncaughtException, "fail",
+    fluid.handlerPriorities.uncaughtException.fail);
+
 // Convert an argument intended for console.log in the node environment to a readable form (the
 // default action of util.inspect censors at depth 1)
 fluid.renderLoggingArg = function (arg) {
@@ -156,12 +165,19 @@ fluid.getCallerInfo = function (atDepth) {
 fluid.loadInContext = loadInContext;
 fluid.loadIncludes = loadIncludes;
 
+fluid.testingSupportLoaded = false;
+
 /**
  * Set up testing environment with jqUnit and IoC Test Utils in node.
- * This function will load everything necessary for running node jqUnit.
+ * This function will load the Infusion internal dependencies (QUnit, jqUnit and the IoC Testing Framework) necessary
+ * for running node-jqUnit - the node-jqunit module itself must still be loaded by the user via their own devDependencies.
  */
 fluid.loadTestingSupport = function () {
-    fluid.loadIncludes("devIncludes.json");
+    // Guard against multiple inclusion of QUnit - FLUID-6188
+    if (!fluid.testingSupportLoaded) {
+        fluid.loadIncludes("devIncludes.json");
+        fluid.testingSupportLoaded = true;
+    }
 };
 
 /** Implementation for FLUID-5822 to avoid requirement for dedupe-infusion **/

--- a/tests/node-tests/README.md
+++ b/tests/node-tests/README.md
@@ -18,6 +18,7 @@ The comprehensive test suite for Infusion should be run in the browser by loadin
 
 ## TAP output for Testem Integration
 
-The test can optionally output a TAP-formatted report in addition to its usual reporting, for integration with the Testem test runner (https://github.com/testem/testem#processes-with-tap-output) that runs the browser-based tests (see the main README.md for details)
+The test can optionally output a TAP-formatted report in addition to its usual reporting, for integration with the Testem test runner
+(https://github.com/testem/testem#processes-with-tap-output) that runs the browser-based tests (see the main README.md for details)
 
 This mode is invoked by executing `node basic-node-tests.js --tap`

--- a/tests/node-tests/basic-node-tests.js
+++ b/tests/node-tests/basic-node-tests.js
@@ -23,28 +23,12 @@ var jqUnit = fluid.registerNamespace("jqUnit");
 
 fluid.registerNamespace("fluid.tests");
 
-fluid.registerNamespace("fluid.tests.tapOutput");
-
 // Number of expected assertions
-fluid.tests.expectedAsserts = 20;
-// Number of expected test cases
-fluid.tests.expectedTestCases = 10;
+fluid.tests.expectedAsserts = 21;
+// Number of expected test cases - used in tap-reporting.js
+fluid.tests.expectedTestCases = 11;
 
-fluid.loadInContext("../../tests/test-core/testTests/js/IoCTestingTests.js");
-
-var testModuleBase = __dirname + path.sep + "node_modules" + path.sep + "test-module" + path.sep;
-
-fluid.module.preInspect(testModuleBase);
-
-// We must store this NOW since it will be overwritten when the module is genuinely loaded - the test
-// fixture will run long afterwards
-var preInspected = fluid.module.modules["test-module"].baseDir;
-
-jqUnit.test("Test early inspection of test module", function () {
-    jqUnit.assertEquals("Test that base directory of test module has been successfully pre-inspected", fluid.module.canonPath(testModuleBase), preInspected);
-});
-
-fluid.require("test-module", require, "test-module");
+require("./tap-reporting");
 
 fluid.setLogging(true);
 
@@ -55,8 +39,6 @@ fluid.tests.getTestMessage = function (data) {
 QUnit.testDone(function (data) {
     fluid.log(fluid.tests.getTestMessage(data));
 });
-
-require("./tap-reporting");
 
 QUnit.done(function (data) {
     fluid.log("Infusion node.js internal tests " +
@@ -80,6 +62,55 @@ QUnit.log(function (details) {
         }
     }
 });
+
+fluid.tests.expectFailure = false;
+
+fluid.tests.addLogListener = function (listener) {
+    fluid.onUncaughtException.addListener(listener, "log",
+        fluid.handlerPriorities.uncaughtException.log);
+};
+
+fluid.onUncaughtException.addListener(function () {
+    if (fluid.tests.expectFailure) {
+        fluid.tests.expectFailure = false;
+    } else {
+        process.exit(1);
+    }
+}, "fail", fluid.handlerPriorities.uncaughtException.fail);
+
+/****
+ * TEST FIXTURES BEGIN HERE
+ ****/
+
+var testModuleBase = __dirname + path.sep + "node_modules" + path.sep + "test-module" + path.sep;
+
+fluid.module.preInspect(testModuleBase);
+
+// We must store this NOW since it will be overwritten when the module is genuinely loaded - the test
+// fixture will run long afterwards
+var preInspected = fluid.module.modules["test-module"].baseDir;
+
+jqUnit.test("Test early inspection of test module", function () {
+    jqUnit.assertEquals("Test that base directory of test module has been successfully pre-inspected", fluid.module.canonPath(testModuleBase), preInspected);
+});
+
+fluid.require("test-module", require, "test-module");
+
+// test FLUID-6188 idempotency of fluid.loadTestingSupport();
+
+var oldQUnit = QUnit;
+fluid.loadTestingSupport();
+QUnit = fluid.registerNamespace("QUnit");
+
+jqUnit.test("FLUID-6188 test: fluid.loadTestingSupport is idempotent and will only create one QUnit object", function () {
+    if (oldQUnit !== QUnit) {
+    // We don't use jqUnit here since in this case the QUnit configuration is unusably hosed
+        fluid.fail("FLUID-6188 test failed: Failure of idempotency of fluid.loadTestingSupport");
+    }
+    jqUnit.assert("fluid.loadTestingSupport is idempotent");
+});
+
+fluid.loadInContext("../../tests/test-core/testTests/js/IoCTestingTests.js");
 
 fluid.test.runTests(["fluid.tests.myTestTree"]);
 
@@ -125,54 +156,32 @@ jqUnit.test("Test module resolvePath", function () {
     jqUnit.assertEquals("Loaded package.json via resolved path directly via fluid.require", "test-module", pkg.name);
 });
 
-fluid.tests.expectFailure = false;
-
-fluid.tests.addLogListener = function (listener) {
-    fluid.onUncaughtException.addListener(listener, "log",
-        fluid.handlerPriorities.uncaughtException.log);
-};
-
-fluid.tests.onUncaughtException = function () {
-    jqUnit.assertEquals("Expected failure in uncaught exception handler",
-        true, fluid.tests.expectFailure);
-    fluid.onUncaughtException.removeListener("test-uncaught");
-    fluid.onUncaughtException.removeListener("log");
-    if (fluid.tests.tapOutput.shouldOutputTAP) {
-        fluid.onUncaughtException.removeListener("outputTAPFailure");
-    }
-    fluid.tests.addLogListener(fluid.identity);
-    fluid.tests.expectFailure = false;
-    fluid.invokeLater(function () { // apply this later to avoid nesting uncaught exception handler
-        fluid.invokeLater(function () {
-            fluid.onUncaughtException.removeListener("log"); // restore the original listener
-            // Reregister listener to output TAP failure report
-            if (fluid.tests.tapOutput.shouldOutputTAP) {
-                fluid.onUncaughtException.addListener(fluid.tests.tapOutput.outputTAPFailure, "outputTAPFailure",
-                    fluid.handlerPriorities.uncaughtException.log);
-            }
-            console.log("Restarting jqUnit in nested handler");
-            jqUnit.start();
-        });
-        "string".fail(); // provoke a further global uncaught error - should be a no-op
-    });
-};
 
 fluid.tests.benignLogger = function () {
     fluid.log("Expected global failure received in test case");
     jqUnit.assert("Expected global failure");
 };
 
+fluid.tests.onUncaughtException = function () {
+    jqUnit.assertEquals("Expected failure in uncaught exception handler",
+        true, fluid.tests.expectFailure);
+    fluid.onUncaughtException.removeListener("test-uncaught"); // remove ourselves - registered by the test below
+    fluid.onUncaughtException.removeListener("log"); // remove "benignLogger" and restore the original listener
+    fluid.invokeLater(function () { // apply this later to avoid nesting uncaught exception handler
+        console.log("Restarting jqUnit in nested handler");
+        jqUnit.start();
+    });
+};
+
 jqUnit.asyncTest("Test uncaught exception handler registration and deregistration", function () {
     jqUnit.expect(2);
     fluid.onUncaughtException.addListener(fluid.tests.onUncaughtException, "test-uncaught");
     fluid.tests.addLogListener(fluid.tests.benignLogger);
-    if (fluid.tests.tapOutput.shouldOutputTAP) {
-        fluid.onUncaughtException.removeListener("outputTAPFailure");
-    }
     fluid.tests.expectFailure = true;
     fluid.invokeLater(function () { // put this in a timeout to avoid bombing QUnit's exception handler
         "string".fail(); // provoke a global uncaught error
     });
+
 });
 
 jqUnit.test("FLUID-5807 noncorrupt framework stack traces", function () {

--- a/tests/node-tests/tap-reporting.js
+++ b/tests/node-tests/tap-reporting.js
@@ -18,6 +18,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 // in basic-node-tests.js
 var QUnit = fluid.registerNamespace("QUnit");
 
+fluid.registerNamespace("fluid.tests.tapOutput");
+
 // Set boolean for the  presence of the --tap command line option to output a
 // TAP report for consumption by testem when used as a custom launcher
 fluid.tests.tapOutput.shouldOutputTAP = process.argv.findIndex(function (argument) {


### PR DESCRIPTION
 Also fix for FLUID-5920 to ensure that default global uncaught exception handler causes system exit with failure. General tidying and reorganisation of basic node tests and their entanglement with TAP reporting