### PR TITLE
FLUID-6183: Added height variable to recalculate panel height.

### DIFF
--- a/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
+++ b/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
@@ -292,6 +292,9 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         }, "collapseFrame");
         separatedPanel.slidingPanel.events.afterPanelShow.addListener(function () {
             separatedPanel.iframeRenderer.iframe.show();
+
+            // FLUID-6183: Required for bug in MS EDGE that clips off the bottom of adjusters
+            var height = separatedPanel.iframeRenderer.iframe.height();
             separatedPanel.locate("reset").show();
         }, "openPanel");
         separatedPanel.slidingPanel.events.onPanelHide.addListener(function () {

--- a/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
+++ b/src/framework/preferences/js/SeparatedPanelPrefsEditor.js
@@ -294,7 +294,8 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             separatedPanel.iframeRenderer.iframe.show();
 
             // FLUID-6183: Required for bug in MS EDGE that clips off the bottom of adjusters
-            var height = separatedPanel.iframeRenderer.iframe.height();
+            // The height needs to be recalculated in order for the panel to show up completely
+            separatedPanel.iframeRenderer.iframe.height();
             separatedPanel.locate("reset").show();
         }, "openPanel");
         separatedPanel.slidingPanel.events.onPanelHide.addListener(function () {


### PR DESCRIPTION
MS Edge cuts off the bottom of the adjusters so the height needed to be recalculated in order to show the entire UIO panel.