### PR TITLE
FLUID-6228: Positioning radio button behind label.

### DIFF
--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -126,8 +126,8 @@
 
                 // position behind label
                 z-index: -2;
-                top: 50%;
-                left: 25%;
+                top: 1rem;
+                left: 1rem;
             }
             label {
                 margin-right: 5px;

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -117,6 +117,18 @@
         justify-content: center;
 
         .fl-choice {
+            input.fl-hidden-accessible {
+                // These overrides to the default behaviour of .fl-hidden-accessible are required to keep the
+                // radio button hidden from view, accessible and allow the input to be scrolled into view when tab
+                // focused. Using position fixed or absolute does not scroll the input into view when focused.
+                // See: FLUID-6228 ( https://issues.fluidproject.org/browse/FLUID-6228 )
+                position: relative;
+
+                // position behind label
+                z-index: -2;
+                top: 50%;
+                left: 25%;
+            }
             label {
                 margin-right: 5px;
                 border: 1px solid black;


### PR DESCRIPTION
This is to keep it hidden, but also allow it scroll into view when tab
focused.

https://issues.fluidproject.org/browse/FLUID-6228


*NOTE: For Firefox and IE 11 when tab focusing to the element, it will only show the smallest amount necessary. The other browsers do a better job of scrolling the entire widget into view.*