### PR TITLE
NOJIRA: Removes block step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,4 @@
 steps:
-  # The CI job will be paused for third-party PR branches. It can be resumed from the Buildkite dashboard.
-  - block: "Run this CI job"
-    # Buildkite uses an "account:branch" naming pattern for third-party branches.
-    branches: "*:*"
-
   - name: "Create VM"
     command: "DISPLAY=:0 vagrant up --provider virtualbox && npm install"
     timeout_in_minutes: 15
@@ -22,4 +17,3 @@ steps:
 
   - name: "Destroy VM"
     command: "vagrant destroy -f"
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+# A block step is introduced in all pull request branches before any of the steps listed below. It 
+# is configured using the Buildkite web UI and has a "Run this CI job" label. It is not included 
+# in this YAML configuration to prevent it from being accidentally removed as part of a PR change.
 steps:
   - name: "Create VM"
     command: "DISPLAY=:0 vagrant up --provider virtualbox && npm install"

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.buildkite
 .settings
 .gitignore
 .npmignore


### PR DESCRIPTION
The block step has been added to the Infusion pipeline using the Buildkite web UI. This ensures it can't be removed by accident in a PR.