### PR TITLE
FLUID-4016: Investigate and possibly remove "stylisticOffset" from reorderer options

### DIFF
--- a/src/components/reorderer/js/Reorderer.js
+++ b/src/components/reorderer/js/Reorderer.js
@@ -190,8 +190,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             movables:    ".flc-reorderer-movable",
             selectables: ".flc-reorderer-movable",
             dropTargets: ".flc-reorderer-movable",
-            grabHandle: "",
-            stylisticOffset: ""
+            grabHandle: ""
         },
         avatarCreator: fluid.reorderer.defaultAvatarCreator,
         keysets: fluid.reorderer.defaultKeysets,
@@ -677,7 +676,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         dom.refresh("movables");
         dom.refresh("selectables");
         dom.refresh("grabHandle", dom.fastLocate("movables"));
-        dom.refresh("stylisticOffset", dom.fastLocate("movables"));
         dom.refresh("dropTargets");
         if (selectableContext) { // if it didn't exist on dispatch, it must be up to date now
             selectableContext.selectables = dom.fastLocate("selectables");


### PR DESCRIPTION
Removed the Stylistic Offset selectable; Tested on Google Chrome 64, Firefox 58 on Windows 10; did not cause any issues to the Reorderer demo.
Please Review :)