### PR TITLE
NOJIRA: Adds more timeouts to CI stages

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,19 +4,23 @@
 steps:
   - name: "Create VM"
     command: "DISPLAY=:0 vagrant up --provider virtualbox && npm install"
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
 
   # Wait and make sure the VM was successfully created before proceeding. Otherwise the remaining steps will not run.
   - wait
 
   - name: "Install dependencies"
     command: "vagrant ssh -c 'cd /home/vagrant/sync; npm install'"
+    timeout_in_minutes: 20
 
   - name: "Build Infusion"
     command: "vagrant ssh -c 'cd /home/vagrant/sync; grunt clean stylus modulefiles:all pathMap:all copy:all copy:necessities uglify:all concat:all compress:all'"
+    timeout_in_minutes: 20
 
   - name: "Run tests"
     command: "npm run test:vagrant"
+    timeout_in_minutes: 20
 
   - name: "Destroy VM"
     command: "vagrant destroy -f"
+    timeout_in_minutes: 5


### PR DESCRIPTION
These timeouts take into account how long Infusion CI jobs currently take. They should avoid scenarios like the one experienced today where [stalled tests prevented other jobs from running](https://buildkite.com/fluid-project/fluid-infusion/builds/121). 