### PR TITLE
FLUID-6269 - Make Ansible error output more readable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     sudo dnf -y upgrade firefox google-chrome-stable
     sudo ansible-galaxy install -fr /home/vagrant/sync/provisioning/requirements.yml
-    sudo PYTHONUNBUFFERED=1 ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure"
+    sudo PYTHONUNBUFFERED=1 ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure"
   SHELL
 
   # Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string


### PR DESCRIPTION
Use the "debug" callback plugin instead of the default. Despite its name, the output should be easier.

Example of hard to read output: https://buildkite.com/fluid-project/fluid-infusion/builds/166#52fa9dbc-db86-4f10-8191-ebabf5a3b522/18-235

Example of easy to ready output (notice the failed task preserves the command's output):

```
    default: TASK [nodejs : Clone application repository] ***********************************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Make sure the application install directory exists and is owned by the appropriate user] ***
    default: ok: [localhost]
    default: 
    default: TASK [nodejs : Run application related commands as the application user] *******
    default: failed: [localhost] (item=npm install) => {
    default:     "changed": true, 
    default:     "cmd": [
    default:         "npm", 
    default:         "install"
    default:     ], 
    default:     "delta": "0:01:39.278170", 
    default:     "end": "2018-04-03 17:31:46.337372", 
    default:     "item": "npm install", 
    default:     "rc": 1, 
    default:     "start": "2018-04-03 17:30:07.059202"
    default: }
    default: 
    default: STDOUT:
    default: 
    default: 
    default: > infusion@3.0.0 prepublish /home/vagrant/sync
    default: > npm run buildDists && npm run buildStylus && exit 1
    default: 
    default: 
    default: > infusion@3.0.0 buildDists /home/vagrant/sync
    default: > grunt buildDists
    default: 
    default: Running "buildDists" task
    default: 
    default: Running "clean:build" (clean) task
    default: >> 1 path cleaned.
```