### PR TITLE
Add CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-
-## What Is Infusion? ##
+# Infusion #
 
 [![Build status](https://badge.buildkite.com/5c8634255695aaaeda0e48799272f9f0e758e6512829737c94.svg?branch=master)](https://buildkite.com/fluid-project/fluid-infusion)
+
+## What Is Infusion? ##
 
 Infusion is a different kind of JavaScript framework. Our approach is to leave you in control—it's your interface,
 using your markup, your way. Infusion is accessible and very, very configurable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 ## What Is Infusion? ##
 
+[![Build status](https://badge.buildkite.com/5c8634255695aaaeda0e48799272f9f0e758e6512829737c94.svg?branch=master)](https://buildkite.com/fluid-project/fluid-infusion)
+
 Infusion is a different kind of JavaScript framework. Our approach is to leave you in control—it's your interface,
 using your markup, your way. Infusion is accessible and very, very configurable.
 


### PR DESCRIPTION
It seems like good marketing to have a status badge for CI builds (limited to the master branch only, so broken PRs don't have an impact).

It's below the first header because [markdownlint](https://github.com/markdownlint/markdownlint) complains if I put it up top ([MD041](https://github.com/markdownlint/markdownlint/blob/1571bedb7e84be6420c8b2d47461c0bfcc1bea27/lib/mdl/rules.rb#L612) rule).