### PR TITLE
FLUID-6279: improving handling of "normal" initial line-height.

### DIFF
--- a/src/framework/preferences/js/Enactors.js
+++ b/src/framework/preferences/js/Enactors.js
@@ -286,7 +286,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         invokers: {
             set: {
                 funcName: "fluid.prefs.enactor.lineSpace.set",
-                args: ["{arguments}.0", "{that}", "{that}.getLineHeightMultiplier"]
+                args: ["{that}", "{arguments}.0"]
             },
             getLineHeight: {
                 funcName: "fluid.prefs.enactor.lineSpace.getLineHeight",
@@ -327,21 +327,22 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             return Number(lineHeight);
         }
 
-        return Math.round(parseFloat(lineHeight) / fontSize * 100) / 100;
+        return fluid.roundToDecimal(parseFloat(lineHeight) / fontSize, 2);
     };
 
-    fluid.prefs.enactor.lineSpace.set = function (times, that, getLineHeightMultiplierFunc) {
+    fluid.prefs.enactor.lineSpace.set = function (that, times) {
         // Calculating the initial size here rather than using a members expand because the "line-height"
-        // cannot be detected on hidden containers such as separated paenl iframe.
+        // cannot be detected on hidden containers such as separated panel iframe.
         if (!that.initialSize) {
-            that.initialSize = getLineHeightMultiplierFunc();
+            that.initialSize = that.getLineHeight();
+            that.lineHeightMultiplier = that.getLineHeightMultiplier();
         }
 
         // that.initialSize === 0 when the browser returned "lineHeight" css value is undefined,
         // which occurs when firefox detects "line-height" value on a hidden container.
         // @ See getLineHeightMultiplier() & http://issues.fluidproject.org/browse/FLUID-4500
-        if (that.initialSize) {
-            var targetLineSpace = times * that.initialSize;
+        if (that.lineHeightMultiplier) {
+            var targetLineSpace = that.initialSize === "normal" && times === 1 ? that.initialSize : times * that.lineHeightMultiplier;
             that.container.css("line-height", targetLineSpace);
         }
     };

--- a/tests/framework-tests/preferences/html/Enactors-test.html
+++ b/tests/framework-tests/preferences/html/Enactors-test.html
@@ -77,8 +77,11 @@
         </div>
 
         <div class="flc-lineSpace-parent" style="font-size: 24px">
-            <div class="flc-lineSpace" style="line-height: 12px; font-size: 6px">
-            </div>
+            <div class="flc-lineSpace-getTests" style="line-height: 12px; font-size: 6px;"></div>
+            <div class="flc-lineSpace" style="line-height: normal;"></div>
+            <div class="flc-lineSpace-length" style="line-height: 12px;"></div>
+            <div class="flc-lineSpace-number" style="line-height: 1.5;"></div>
+            <div class="flc-lineSpace-percentage" style="line-height: 50%;"></div>
         </div>
 
         <div class="flc-tableOfContents">


### PR DESCRIPTION
When a browser returns "normal" as the initial line-height, the enactor will set the line-height back to "normal" when no line-height multiplier needs to be set. That is, when there are no preferences for line-height to apply.

https://issues.fluidproject.org/browse/FLUID-6279