### PR TITLE
FLUID-6277 - Cleanup code coverage reports

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
   - name: "Build"
     command:
       - "DISPLAY=:0 vagrant up --provider virtualbox"
-      - "vagrant ssh -c 'cd /home/vagrant/sync/; $(npm bin)/npm run pretest'"
+      - "vagrant ssh -c 'cd /home/vagrant/sync/; npm run pretest'"
     timeout_in_minutes: 20
     <<: *agent_queue
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,8 @@ steps:
     continue_on_failure: true
 
   - name: "Cleanup"
-    command: "vagrant destroy -f"
+    command:
+      - "vagrant destroy -f"
+      - "rm -rf ./reports ./coverage" # FLUID-6277
     timeout_in_minutes: 5
     <<: *agent_queue

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,9 @@ agent_queue: &agent_queue
 
 steps:
   - name: "Build"
-    command: "DISPLAY=:0 vagrant up --provider virtualbox"
+    command:
+      - "DISPLAY=:0 vagrant up --provider virtualbox"
+      - "vagrant ssh -c 'cd /home/vagrant/sync/; $(npm bin)/npm run pretest'"
     timeout_in_minutes: 20
     <<: *agent_queue
 
@@ -37,8 +39,6 @@ steps:
     continue_on_failure: true
 
   - name: "Cleanup"
-    command:
-      - "vagrant destroy -f"
-      - "rm -rf ./reports ./coverage" # FLUID-6277
+    command: "vagrant destroy -f"
     timeout_in_minutes: 5
     <<: *agent_queue


### PR DESCRIPTION
Just a cleanup step to cleanup the code coverage reports directories so they don't start to buildup  over time (causing memory issues).

We could simply delete the build directory and do a clean `git clone` every time, but this would be too slow (and increase the chances of issues in GitHub causing builds to break).