### PR TITLE
INFRA-162 - Specify tags to target h-0005

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,19 @@
 # A block step is introduced in all pull request branches before any of the steps listed below. It 
 # is configured using the Buildkite web UI and has a "Run this CI job" label. It is not included 
 # in this YAML configuration to prevent it from being accidentally removed as part of a PR change.
+
+agent_queue: &agent_queue
+  agents:
+    env: dev
+    type: physical
+    hypervisor: virtualbox
+    vagrant: true
+
 steps:
   - name: "Build"
     command: "DISPLAY=:0 vagrant up --provider virtualbox"
     timeout_in_minutes: 20
+    <<: *agent_queue
 
   # Wait and make sure the VM was successfully created before proceeding. Otherwise the remaining steps will not run.
   - wait
@@ -12,14 +21,17 @@ steps:
   - name: "Code Linter"
     command: "vagrant ssh -c 'cd /home/vagrant/sync/; $(npm bin)/grunt lint'"
     timeout_in_minutes: 2
+    <<: *agent_queue
 
   - name: "Browser Tests"
     command: "npm run test:vagrantBrowser"
     timeout_in_minutes: 15
+    <<: *agent_queue
 
   - name: "Node Tests"
     command: "npm run test:vagrantNode"
     timeout_in_minutes: 5
+    <<: *agent_queue
 
   - wait: ~
     continue_on_failure: true
@@ -27,3 +39,4 @@ steps:
   - name: "Cleanup"
     command: "vagrant destroy -f"
     timeout_in_minutes: 5
+    <<: *agent_queue


### PR DESCRIPTION
Right now, Buildkite will distribute builds to any agent that is only.

This definition is needed to it targets agents that can properly run the Vagrant-based steps.

Since it's still not possible to define the agent at the pipeline level, each step must define the tags independently. To keep it DRY, it uses YAML anchors.