### PR TITLE
FLUID-6282 - Use Docker containers and headless browser for tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
   - name: "Build"
     command:
       - "docker build -t ${TMP_ID} --target builder ."
-      - "docker run --rm -ti -v ${TMP_ID}:/app ${TMP_ID} true"
+      - "docker run --rm -ti -v ${TMP_ID}:/app ${TMP_ID} true" # Copy folder contents into volume
     timeout_in_minutes: 15
     <<: *agent_tags
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@
 
 env:
   TMP_ID: "infusion-${BUILDKITE_BUILD_ID}" # Used to identify temporary containers, volumes and images
-  DOCKER_NODE_BROWSERS_IMAGE: "inclusivedesign/node-browsers@sha256:268540faab7274d29bbbf106573ec345eea49039088d696f1edcc4db9d7e09b6"
+  DOCKER_NODE_BROWSERS_IMAGE: "inclusivedesign/node-browsers@sha256:6ca7d333a361482a4fc4cb6d727d85094fa22d5ae01beb614ecb080c74b5ed32"
 
 # https://github.com/buildkite/feedback/issues/173
 agent_tags: &agent_tags

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,7 @@
 
 env:
   TMP_ID: "infusion-${BUILDKITE_BUILD_ID}" # Used to identify temporary containers, volumes and images
+  DOCKER_NODE_BROWSERS_IMAGE: "inclusivedesign/node-browsers@sha256:268540faab7274d29bbbf106573ec345eea49039088d696f1edcc4db9d7e09b6"
 
 # https://github.com/buildkite/feedback/issues/173
 agent_tags: &agent_tags
@@ -20,19 +21,19 @@ steps:
 
   - name: "Code Linter"
     command:
-      - "docker run --rm -ti -v ${TMP_ID}:/app -w /app inclusivedesign/node-browsers grunt lint"
+      - "docker run --rm -ti -v ${TMP_ID}:/app -w /app ${DOCKER_NODE_BROWSERS_IMAGE} grunt lint"
     timeout_in_minutes: 1
     <<: *agent_tags
 
   - name: "Node Tests"
     command:
-      - "docker run --rm -ti -v ${TMP_ID}:/app -w /app inclusivedesign/node-browsers npm run test:node"
+      - "docker run --rm -ti -v ${TMP_ID}:/app -w /app ${DOCKER_NODE_BROWSERS_IMAGE} npm run test:node"
     timeout_in_minutes: 5
     <<: *agent_tags
 
   - name: "Browser Tests"
     command:
-      - "docker run --rm -ti --cap-add=SYS_ADMIN -e HEADLESS=1 -v ${TMP_ID}:/app -w /app inclusivedesign/node-browsers npm run test:browser"
+      - "docker run --rm -ti --cap-add=SYS_ADMIN -e HEADLESS=1 -v ${TMP_ID}:/app -w /app ${DOCKER_NODE_BROWSERS_IMAGE} npm run test:browser"
     timeout_in_minutes: 15
     <<: *agent_tags
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,38 +2,46 @@
 # is configured using the Buildkite web UI and has a "Run this CI job" label. It is not included 
 # in this YAML configuration to prevent it from being accidentally removed as part of a PR change.
 
+env:
+  TMP_ID: "infusion-${BUILDKITE_BUILD_ID}" # Used to identify temporary containers, volumes and images
+
+# https://github.com/buildkite/feedback/issues/173
 agent_tags: &agent_tags
   agents:
     name: "${BUILDKITE_AGENT_META_DATA_NAME?}"
 
 steps:
   - name: "Build"
-    command: "DISPLAY=:0 vagrant up --provider virtualbox"
-    timeout_in_minutes: 20
-    <<: *agent_tags
-
-  # Wait and make sure the VM was successfully created before proceeding. Otherwise the remaining steps will not run.
-  - wait
-
-  - name: "Code Linter"
-    command: "vagrant ssh -c 'cd /home/vagrant/sync/; $(npm bin)/grunt lint'"
-    timeout_in_minutes: 2
-    <<: *agent_tags
-
-  - name: "Browser Tests"
-    command: "npm run test:vagrantBrowser"
+    command:
+      - "docker build -t ${TMP_ID} --target builder ."
+      - "docker run --rm -ti -v ${TMP_ID}:/app ${TMP_ID} true"
     timeout_in_minutes: 15
     <<: *agent_tags
 
+  - name: "Code Linter"
+    command:
+      - "docker run --rm -ti -v ${TMP_ID}:/app -w /app inclusivedesign/node-browsers grunt lint"
+    timeout_in_minutes: 1
+    <<: *agent_tags
+
   - name: "Node Tests"
-    command: "npm run test:vagrantNode"
+    command:
+      - "docker run --rm -ti -v ${TMP_ID}:/app -w /app inclusivedesign/node-browsers npm run test:node"
     timeout_in_minutes: 5
+    <<: *agent_tags
+
+  - name: "Browser Tests"
+    command:
+      - "docker run --rm -ti --cap-add=SYS_ADMIN -e HEADLESS=1 -v ${TMP_ID}:/app -w /app inclusivedesign/node-browsers npm run test:browser"
+    timeout_in_minutes: 15
     <<: *agent_tags
 
   - wait: ~
     continue_on_failure: true
 
   - name: "Cleanup"
-    command: "vagrant destroy -f"
+    command:
+      - "docker volume rm ${TMP_ID}"
+      - "docker image rm -f ${TMP_ID}"
     timeout_in_minutes: 5
     <<: *agent_tags

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.vagrant
+coverage
+node_modules
+reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:10-alpine AS builder
+
+# Add OS-level dependencies
+RUN apk add --no-cache python make git g++
+
+# Switch to regular user
+USER node
+
+# Install npm dependencies
+COPY --chown=node package.json /app/package.json
+WORKDIR /app
+RUN npm install
+
+# Build
+COPY --chown=node . /app
+RUN $(npm bin)/grunt
+
+# Annotate directory as a Docker volume (used by host, if desired) 
+VOLUME ["/app"]
+
+# Build final image to serve static assets (path: //infusion)
+FROM nginx:alpine
+WORKDIR /usr/share/nginx/html
+COPY --from=builder /app/products/*.zip .
+RUN unzip -o -d . infusion-*.zip

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "repository": "git://github.com/fluid-project/infusion.git",
     "main": "./src/module/fluid.js",
     "scripts": {
-        "prepublish": "npm run buildDists && npm run buildStylus",
+        "prepublishOnly": "npm run buildDists && npm run buildStylus",
         "pretest": "node node_modules/rimraf/bin.js reports/* coverage/*",
         "test": "npm run test:browser && npm run test:node",
         "test:browser": "node node_modules/testem/testem.js ci --file tests/testem.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "devDependencies": {
         "eslint-config-fluid": "1.2.0-dev.20180213T130610Z.40e6281",
         "fluid-grunt-eslint": "18.1.2",
-        "gpii-testem": "2.1.1-dev.20180320T102716Z.5caff1c",
+        "gpii-testem": "2.1.3",
         "grunt": "1.0.1",
         "grunt-contrib-clean": "1.1.0",
         "grunt-contrib-compress": "1.4.3",


### PR DESCRIPTION
This PR switches the CI pipeline from Vagrant to Docker containers and headless browsers.

The purpose of the Docker image is to provide a known environment for builds and to serve the static assets produced by the build.

The build target `builder` is the complete environment including node_modules and that's there tests are run. The final target is simply a Nginx image where the static assets are copied to (for usage in demos and whatnot -- it's not meant to be used as a base Docker image by downstream projects, they should include Infusion using the traditional methods described in the Infusion readme file).

This work relies on the new inclusivedesign/node-browsers image that contains Firefox, Chrome, Node.js and other test utilities like grunt-cli, istambul and testem.