### PR TITLE
FLUID-6305: fixes / test coverage for locale bug in fluid.fetchResources

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ All of these libraries are already bundled within the Infusion image.
 ## How Do I Run Tests? ##
 
 There are two options available for running tests. The first option involves using the browsers installed on your
-compute.  The second uses browsers available in a VM.
+computer.  The second uses browsers available in a VM.
 
 ### Run Tests On Your Computer ###
 

--- a/src/framework/core/js/FluidRequests.js
+++ b/src/framework/core/js/FluidRequests.js
@@ -67,12 +67,16 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             if (resourceSpec.url && !resourceSpec.href) {
                 resourceSpec.href = resourceSpec.url;
             }
+
+            // If options.defaultLocale is set, it will replace any
+            // defaultLocale set on an individual resourceSpec
             if (that.options.defaultLocale) {
                 resourceSpec.defaultLocale = that.options.defaultLocale;
-                if (resourceSpec.locale === undefined) {
-                    resourceSpec.locale = that.options.defaultLocale;
-                }
             }
+            if (!resourceSpec.locale) {
+                resourceSpec.locale = resourceSpec.defaultLocale;
+            }
+
         });
         if (that.options.amalgamateClasses) {
             fluid.fetchResources.amalgamateClasses(resourceSpecs, that.options.amalgamateClasses, that.operate);

--- a/tests/framework-tests/core/data/testTemplate3.html
+++ b/tests/framework-tests/core/data/testTemplate3.html
@@ -1,0 +1,1 @@
+<div>Test Template 3</div>

--- a/tests/framework-tests/core/data/testTemplate3_en.html
+++ b/tests/framework-tests/core/data/testTemplate3_en.html
@@ -1,0 +1,1 @@
+<div>Test Template 3 Localised</div>

--- a/tests/framework-tests/core/data/testTemplate4.html
+++ b/tests/framework-tests/core/data/testTemplate4.html
@@ -1,0 +1,1 @@
+<div>Test Template 4</div>

--- a/tests/framework-tests/core/data/testTemplate4_en.html
+++ b/tests/framework-tests/core/data/testTemplate4_en.html
@@ -1,0 +1,1 @@
+<div>Test Template 4 Localised</div>

--- a/tests/framework-tests/core/js/ResourceLoaderTests.js
+++ b/tests/framework-tests/core/js/ResourceLoaderTests.js
@@ -20,12 +20,15 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     fluid.defaults("fluid.tests.resourceLoader", {
         gradeNames: ["fluid.resourceLoader"],
+        defaultLocale: "en",
         terms: {
             prefix: "../data"
         },
         resources: {
             template1: "%prefix/testTemplate1.html",
-            template2: "../data/testTemplate2.html"
+            template2: "../data/testTemplate2.html",
+            template3: "%prefix/testTemplate3.html",
+            template4: "../data/testTemplate4.html"
         },
         listeners: {
             onResourcesLoaded: "fluid.tests.resourceLoader.testTemplateLoader"
@@ -43,11 +46,17 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.assertTrue("\"forceCache\" option for the template2 has been set", resources.template2.forceCache);
         jqUnit.assertEquals("The content of the template2 has been loaded correctly", "<div>Test Template 2</div>", $.trim(resources.template2.resourceText));
 
+        // The localised template with a templating path of prefixTerm + name
+        jqUnit.assertEquals("The content of the template3 has been loaded correctly", "<div>Test Template 3 Localised</div>", $.trim(resources.template3.resourceText));
+
+        // The localised template with a full path
+        jqUnit.assertEquals("The content of the template4 has been loaded correctly", "<div>Test Template 4 Localised</div>", $.trim(resources.template4.resourceText));
+
         jqUnit.start();
     };
 
     jqUnit.asyncTest("Test Resource Loader", function () {
-        jqUnit.expect(6);
+        jqUnit.expect(8);
         fluid.tests.resourceLoader();
     });
 


### PR DESCRIPTION
This PR (based on investigation by @BlueSlug and myself) fixes a bug in `fluid.fetchResources` that emerged in working on adding several translated message bundles for UIO (https://issues.fluidproject.org/browse/FLUID-6299), and adds test coverage for confirming it fixed in the tests for both `fluid.fetchResources` and `fluid.resourceLoader`.

The underlying bug is described in https://issues.fluidproject.org/browse/FLUID-6305 and its impact on `fluid.resourceLoader` in https://issues.fluidproject.org/browse/FLUID-6306

Tagging @amb26 for review per recent email exchange.