### PR TITLE
FLUID-6309 - Use npm prepublishOnly instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "repository": "git://github.com/fluid-project/infusion.git",
     "main": "./src/module/fluid.js",
     "scripts": {
-        "prepublish": "npm run buildDists && npm run buildStylus",
+        "prepublishOnly": "npm run buildDists && npm run buildStylus",
         "pretest": "node node_modules/rimraf/bin.js reports/* coverage/*",
         "test": "npm run test:browser && npm run test:node",
         "test:browser": "node node_modules/testem/testem.js ci --file tests/testem.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "repository": "git://github.com/fluid-project/infusion.git",
     "main": "./src/module/fluid.js",
     "scripts": {
-	"postinstall": "npm run buildStylus",
+        "postinstall": "npm run buildStylus",
         "prepublishOnly": "npm run buildDists",
         "pretest": "node node_modules/rimraf/bin.js reports/* coverage/*",
         "test": "npm run test:browser && npm run test:node",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "repository": "git://github.com/fluid-project/infusion.git",
     "main": "./src/module/fluid.js",
     "scripts": {
-        "prepublishOnly": "npm run buildDists && npm run buildStylus",
+	"postinstall": "npm run buildStylus",
+        "prepublishOnly": "npm run buildDists",
         "pretest": "node node_modules/rimraf/bin.js reports/* coverage/*",
         "test": "npm run test:browser && npm run test:node",
         "test:browser": "node node_modules/testem/testem.js ci --file tests/testem.js",

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -14,7 +14,6 @@ nodejs_app_npm_packages:
 
 nodejs_app_commands:
   - npm install
-  - grunt
 
 nodejs_app_install_dir: /home/vagrant/sync
 


### PR DESCRIPTION
This effectively ensures that "grunt BuildDist && grunt BuildStylus" only run during "npm publish" and not at "npm install" time.