### PR TITLE
NOJIRA - Fix BUILDKITE_AGENT_NAME variable

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@
 
 agent_tags: &agent_tags
   agents:
-    name: "${BUILDKITE_AGENT_META_DATA_NAME?}"
+    name: "${BUILDKITE_AGENT_NAME?}"
 
 steps:
   - name: "Build"


### PR DESCRIPTION
BUILDKITE_AGENT_META_DATA_NAME has been deprecated and removed from buildkite-agent 3.3