### PR TITLE
Add SKIP_NODE_MODULES_BIND_MOUNT env var to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,11 +30,16 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "#{app_directory}"
 
   # Mounts node_modules in /var/tmp to work around issues in the VirtualBox shared folders
-  config.vm.provision "shell", run: "always", inline: <<-SHELL
-    sudo mkdir -p /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
-    sudo chown vagrant:vagrant -R /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
-    sudo mount -o bind /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
-  SHELL
+  #
+  # Set SKIP_NODE_MODULES_BIND_MOUNT to "1" to skip this and have the directory shared
+  # between host and VM
+  if ENV["SKIP_NODE_MODULES_BIND_MOUNT"] != "1"
+    config.vm.provision "shell", run: "always", inline: <<-SHELL
+      sudo mkdir -p /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
+      sudo chown vagrant:vagrant -R /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
+      sudo mount -o bind /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
+    SHELL
+  end
 
   # List additional directories to sync to the VM in your "Vagrantfile.local" file
   # using the following format:


### PR DESCRIPTION
In certain situations, it's perfectly fine to have the node_modules shared between host and a vagrant box:

* When host/VM architecture are the same
* When all work happens inside the VM

That is the situation in CI Linux build nodes.

This has the advantage that certain operations like publishing the build artifacts can happen outside the VM (as they need access to credentials that would be hard to import into the VM) without having to run `npm install` a second time.

This PR adds an environment variable that allow CI (and Linux users) to avoid the bind mount during the `vagrant up` phase by specifying SKIP_NODE_MODULES_BIND_MOUNT=1.