### PR TITLE
FLUID-6338: Moving buildStylus from postInstall to prepare.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -455,7 +455,8 @@ module.exports = function (grunt) {
             "distributions" + ( target ? ":" + target : "" ),
             "cleanForDist",
             "verifyDistJS",
-            "verifyDistCSS"
+            "verifyDistCSS",
+            "buildStylus" // put back stylus files needed for development
         ];
         grunt.task.run(tasks);
     });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "repository": "git://github.com/fluid-project/infusion.git",
     "main": "./src/module/fluid.js",
     "scripts": {
-        "postinstall": "npm run buildStylus",
+        "prepare": "npm run buildStylus",
         "prepublishOnly": "npm run buildDists",
         "pretest": "node node_modules/rimraf/bin.js reports/* coverage/*",
         "test": "npm run test:browser && npm run test:node",

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -6,8 +6,6 @@ nodejs_app_name: infusion
 
 nodejs_branch: lts
 
-nodejs_npm_version: 3.10.10
-
 nodejs_app_npm_packages:
   - testem
   - istanbul


### PR DESCRIPTION
This should prevent it from trying to run buildStylus when installed as 
a dependency of another package.

Should also using Infusion as a dependency in another project using 3.0.0-dev.20180913T134630Z.1dc9abaf4.FLUID-6338

https://issues.fluidproject.org/browse/FLUID-6338