### PR TITLE
FLUID-6357: Moving aria-expanded to the button instead of the panel.

### DIFF
--- a/src/components/slidingPanel/js/SlidingPanel.js
+++ b/src/components/slidingPanel/js/SlidingPanel.js
@@ -164,8 +164,10 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     };
 
     fluid.slidingPanel.setAriaStates = function (that, isShowing) {
-        that.locate("toggleButton").attr("aria-pressed", isShowing);
-        that.locate("panel").attr("aria-expanded", isShowing);
+        that.locate("toggleButton").attr({
+            "aria-pressed": isShowing,
+            "aria-expanded": isShowing
+        });
     };
 
 })(jQuery, fluid_3_0_0);

--- a/tests/component-tests/slidingPanel/js/SlidingPanelTests.js
+++ b/tests/component-tests/slidingPanel/js/SlidingPanelTests.js
@@ -45,9 +45,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             jqUnit.assertEquals("Show/hide button has the button role", "button", button.attr("role"));
             jqUnit.assertEquals("Show/hide button has correct aria-pressed", state, button.attr("aria-pressed"));
             jqUnit.assertEquals("Show/hide button has correct aria-controls", panel.attr("id"), button.attr("aria-controls"));
+            jqUnit.assertEquals("Show/hide button has correct aria-expanded", state, button.attr("aria-expanded"));
             jqUnit.assertEquals("Panel has the group role", "group", panel.attr("role"));
             jqUnit.assertEquals("Panel has the correct aria-label", that.options.strings.panelLabel, panel.attr("aria-label"));
-            jqUnit.assertEquals("Panel has correct aria-expanded", state, panel.attr("aria-expanded"));
         };
 
         jqUnit.test("Test Init", function () {

--- a/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorResponsiveTests.js
+++ b/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorResponsiveTests.js
@@ -127,18 +127,17 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var attrState = state ? "true" : "false";
         fluid.tests.prefs.responsive.assertAriaForButton(button, buttonName, controlsId);
         jqUnit.assertEquals(buttonName + " button has correct aria-pressed", attrState, button.attr("aria-pressed"));
+        jqUnit.assertEquals(buttonName + " button has correct aria-expanded", attrState, button.attr("aria-expanded"));
     };
 
     fluid.tests.prefs.responsive.assertAria = function (that, state) {
         var toggleButton = that.locate("toggleButton");
         var panel = that.locate("panel");
         var panelId = panel.attr("id");
-        var attrState = state ? "true" : "false";
 
         fluid.tests.prefs.responsive.assertAriaForToggleButton(toggleButton, "Hide/show", panelId, state);
         jqUnit.assertEquals("Panel has the group role", "group", panel.attr("role"));
         jqUnit.assertEquals("Panel has the correct aria-label", that.options.strings.panelLabel, panel.attr("aria-label"));
-        jqUnit.assertEquals("Panel has correct aria-expanded", attrState, panel.attr("aria-expanded"));
     };
 
     fluid.tests.prefs.responsive.assertResetButton = function (separatedPanel, state) {

--- a/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
+++ b/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
@@ -106,6 +106,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     fluid.tests.prefs.assertAriaForToggleButton = function (button, buttonName, controlsId, state) {
         fluid.tests.prefs.assertAriaForButton(button, buttonName, controlsId);
         jqUnit.assertEquals(buttonName + " button has correct aria-pressed", state, button.attr("aria-pressed"));
+        jqUnit.assertEquals(buttonName + " button has correct aria-expanded", state, button.attr("aria-expanded"));
     };
 
     fluid.tests.prefs.assertAria = function (that, state) {
@@ -116,7 +117,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         fluid.tests.prefs.assertAriaForToggleButton(toggleButton, "Hide/show", panelId, state);
         jqUnit.assertEquals("Panel has the group role", "group", panel.attr("role"));
         jqUnit.assertEquals("Panel has the correct aria-label", that.options.strings.panelLabel, panel.attr("aria-label"));
-        jqUnit.assertEquals("Panel has correct aria-expanded", state, panel.attr("aria-expanded"));
     };
 
     fluid.tests.prefs.testSeparatedPanel = function (separatedPanel) {


### PR DESCRIPTION
This is to conform with the aria spec. See: 
https://www.w3.org/WAI/GL/wiki/Using_aria-expanded_to_indicate_the_state_of_a_collapsible_element

https://issues.fluidproject.org/browse/FLUID-6357