### PR TITLE
FLUID-6383: exclude Headless Chrome from testem browsers used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
         "prepare": "npm run loadDependencies && npm run buildStylus",
         "prepublishOnly": "npm run buildDists",
         "pretest": "node node_modules/rimraf/bin.js reports/* coverage/*",
-        "test": "npm run test:browser && npm run test:node",
-        "test:browser": "node node_modules/testem/testem.js ci --file tests/testem.js",
+        "test": "cross-env HEADLESS=true npm run test:browser && npm run test:node",
+        "test:browser": "cross-env HEADLESS=true node node_modules/testem/testem.js ci --file tests/testem.js",
         "test:node": "node node_modules/nyc/bin/nyc.js node tests/node-tests/basic-node-tests.js",
-        "test:vagrant": "vagrant up && vagrant ssh -c 'cd /home/vagrant/sync/; DISPLAY=:0 npm test'",
-        "test:vagrantBrowser": "vagrant up && vagrant ssh -c 'cd /home/vagrant/sync/; DISPLAY=:0 npm run test:browser'",
+        "test:vagrant": "cross-env HEADLESS=true vagrant up && vagrant ssh -c 'cd /home/vagrant/sync/; DISPLAY=:0 npm test'",
+        "test:vagrantBrowser": "cross-env HEADLESS=true vagrant up && vagrant ssh -c 'cd /home/vagrant/sync/; DISPLAY=:0 npm run test:browser'",
         "test:vagrantNode": "vagrant up && vagrant ssh -c 'cd /home/vagrant/sync/; DISPLAY=:0 npm run test:node'",
         "posttest": "node node_modules/nyc/bin/nyc.js report -r text-summary -r html",
         "buildDists": "grunt buildDists",
@@ -40,6 +40,7 @@
         "fluid-resolve": "1.3.0"
     },
     "devDependencies": {
+        "cross-env": "5.2.0",
         "eslint-config-fluid": "1.3.0",
         "gpii-grunt-lint-all": "1.0.5",
         "gpii-testem": "2.1.7",

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -25,7 +25,7 @@ fluid.defaults("fluid.tests.testem", {
         tests:   "%infusion/tests"
     },
     testemOptions: {
-        skip: "PhantomJS,Opera,Safari",
+        skip: "PhantomJS,Opera,Safari,Headless Chrome",
         disable_watching: true,
         tap_quiet_logs: true
     }

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -25,7 +25,7 @@ fluid.defaults("fluid.tests.testem", {
         tests:   "%infusion/tests"
     },
     testemOptions: {
-        skip: "PhantomJS,Opera,Safari,Headless Chrome",
+        skip: "PhantomJS,Opera,Safari,Chrome",
         disable_watching: true,
         tap_quiet_logs: true
     }

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -27,7 +27,9 @@ fluid.defaults("fluid.tests.testem", {
     testemOptions: {
         skip: "PhantomJS,Opera,Safari,Chrome",
         disable_watching: true,
-        tap_quiet_logs: true
+        tap_quiet_logs: true,
+        // Set to headless browser mode without need to set environment variable in CLI
+        browser_args: "@expand:gpii.testem.constructBrowserArgs({that}.options.headlessBrowserArgs)"
     }
 });
 

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -27,9 +27,7 @@ fluid.defaults("fluid.tests.testem", {
     testemOptions: {
         skip: "PhantomJS,Opera,Safari,Chrome",
         disable_watching: true,
-        tap_quiet_logs: true,
-        // Set to headless browser mode without need to set environment variable in CLI
-        browser_args: "@expand:gpii.testem.constructBrowserArgs({that}.options.headlessBrowserArgs)"
+        tap_quiet_logs: true
     }
 });
 


### PR DESCRIPTION
This PR can be considered an "open for discussion" change, as is the issue described in JIRA: https://issues.fluidproject.org/browse/FLUID-6383 - see the JIRA issue for a fuller explanation.