### PR TITLE
FLUID-6278: Passes along the lang code for each block of text being synthesized

### DIFF
--- a/demos/orator/index.html
+++ b/demos/orator/index.html
@@ -47,9 +47,9 @@
     <section class="fl-demo-container">
         <div class="flc-orator fl-demo-content">
             <article class="flc-orator-content">
-                <h1>Diverse <span lang="en-US">Participation</span> and Perspectives</h1>
+                <h1>Diverse Participation and Perspectives</h1>
 
-                <p lang="en">
+                <p>
                     In keeping with the edict “nothing about us without us”, this principle is about inviting a diversity of people with a broad range of needs, preferences, interests and skills into the design process, and in so doing, weakening the distinction between user and designer. Considering inclusion in all aspects and at all stages of the design process requires that our communication methods, group processes and daily interactions are inclusive. This helps to ensure that the products and services that are created will be more inclusive.
                 </p>
 

--- a/demos/orator/index.html
+++ b/demos/orator/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-CA">
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -47,9 +47,9 @@
     <section class="fl-demo-container">
         <div class="flc-orator fl-demo-content">
             <article class="flc-orator-content">
-                <h1>Diverse Participation and Perspectives</h1>
+                <h1>Diverse <span lang="en-US">Participation</span> and Perspectives</h1>
 
-                <p>
+                <p lang="en">
                     In keeping with the edict “nothing about us without us”, this principle is about inviting a diversity of people with a broad range of needs, preferences, interests and skills into the design process, and in so doing, weakening the distinction between user and designer. Considering inclusion in all aspects and at all stages of the design process requires that our communication methods, group processes and daily interactions are inclusive. This helps to ensure that the products and services that are created will be more inclusive.
                 </p>
 

--- a/demos/prefsFramework/index.html
+++ b/demos/prefsFramework/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">

--- a/src/components/orator/css/Orator.css
+++ b/src/components/orator/css/Orator.css
@@ -151,7 +151,7 @@
     color: #000000;
     background-color: #EED400;
     /* Used to make the background appear larger so that it stands out in a block of text */
-    outline: 0.2rem solid #EED400;
+    padding: 0.2rem 0;
 }
 
 

--- a/src/components/orator/js/Orator.js
+++ b/src/components/orator/js/Orator.js
@@ -266,7 +266,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             utteranceOnPause: null,
             utteranceOnResume: null,
             utteranceOnStart: null,
-            onStop: "{fluid.textToSpeech}.events.onStop"
+            onStop: null
         },
         utteranceEventMap: {
             onboundary: "utteranceOnBoundary",
@@ -663,11 +663,13 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             that.resetParseQueue();
             that.parser.parse(elm[0]);
 
-            fluid.each(that.parseQueue, function (parsedBlock, index) {
+            var queueSpeechPromises = fluid.transform(that.parseQueue, function (parsedBlock, index) {
                 var interrupt = !index; // only interrupt on the first string
                 var text = that.parsedToString(parsedBlock);
-                that.queueSpeech(text, {lang: parsedBlock[0].lang, interrupt: interrupt});
+                return that.queueSpeech(text, {lang: parsedBlock[0].lang, interrupt: interrupt});
             });
+
+            fluid.promise.sequence(queueSpeechPromises).then(that.events.onStop.fire);
         }
     };
 

--- a/src/components/orator/js/Orator.js
+++ b/src/components/orator/js/Orator.js
@@ -384,7 +384,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             "utteranceOnEnd.resetParseIndex": {
                 changePath: "",
                 value: {
-                    parseIndex: null,
+                    parseIndex: null
                 },
                 source: "utteranceOnEnd"
             },
@@ -608,7 +608,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                     lastQueue.push(lastParsed);
                     that.applier.change("", {
                         parseQueueCount: that.parseQueue.length,
-                        parseItemCount: that.model.parseItemCount + 1,
+                        parseItemCount: that.model.parseItemCount + 1
                     }, "ADD", "addToParseQueue");
                     parsed.blockIndex += word.length;
                 }

--- a/src/components/orator/js/Orator.js
+++ b/src/components/orator/js/Orator.js
@@ -199,7 +199,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * This is not bound declaratively to ensure that the correct arguments are passed along to the `that.toggle`
      * method.
      *
-     * @param {fluid.orator.controller} that
+     * @param {fluid.orator.controller} that - an instance of the component
      */
     fluid.orator.controller.bindClick = function (that) {
         that.locate("playToggle").click(function () {
@@ -213,7 +213,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * that this method will be used in conjunction with a click handler. In that case, it's most likely that the state
      * will be toggling the existing model value.
      *
-     * @param {fluid.orator.controller} that
+     * @param {fluid.orator.controller} that - an instance of the component
      * @param {String|Array} path - the path, into the model, for the value to toggle
      * @param {Boolean} state - (optional) explicit state to set the model value to
      */
@@ -230,7 +230,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * False - play style removed
      *       - aria-label set to the `play` string
      *
-     * @param {fluid.orator.controller} that
+     * @param {fluid.orator.controller} that - an instance of the component
      * @param {Boolean} state - the state to set the controller to
      */
     fluid.orator.controller.setToggleView = function (that, state) {
@@ -429,11 +429,9 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * Updates the `ttsBoundary` and `parseQueueIndex` model paths based on the provided boundary. Attempts to determine
      * if the supplied boundary is derived from the current queue or if the parseQueueIndex needs to be incremented.
      *
-     * @param  {fluid.orator.domReader} that
+     * @param  {fluid.orator.domReader} that - an instance of the component
      * @param  {Integer} boundary - the incoming boundary, typically from a {SpeechSynthesisUtterance} boundary event.
      *                              This indicates the starting index of the word being Synthesized.
-     * @return {Undefined} - Nothing is ever returned, but a `return;` statement is used to short ciruit the function
-     *                       when the component is paused.
      */
     fluid.orator.domReader.setCurrentBoundary = function (that, boundary) {
         // It is possible that the pause event triggers before all of the boundary events have been received.
@@ -501,13 +499,11 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * initial text; which then proceeds through the transform chain to arrive at the final text.
      * To change the speech function (e.g for testing) the `onQueueSpeech.queueSpeech` listener can be overridden.
      *
-     * @param {fluid.orator.domReader} that
+     * @param {fluid.orator.domReader} that - an instance of the component
      * @param {String} text - The text to be synthesized
-     * @param {Boolean} interrupt - Used to indicate if this text should be queued or replace existing utterances.
-     *                              This will be passed along to the listeners in the options; `options.interrupt`.
      * @param {Object} options - (optional) options to configure the utterance with. This will also be interpolated with
-     *                           the interrupt parameter and event mappings. See: `fluid.textToSpeech.queueSpeech` in
-     *                           TextToSpeech.js for an example of utterance options for that speech function.
+     *                           the event mappings. See: `fluid.textToSpeech.queueSpeech` in TextToSpeech.js for an
+     *                           example of utterance options for that speech function.
      *
      * @return {Promise} - A promise for the final resolved text
      */
@@ -557,7 +553,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * Retrieves the active parseQueue array to be used when updating from the latest parsed text node. Will increment
      * the parseQueue with a new empty array if one doesn't already exist or if the language has changed.
      *
-     * @param {fluid.orator.domReader} that
+     * @param {fluid.orator.domReader} that - an instance of the component
      * @param {String} lang - a valid BCP 47 language code.
      *
      * @return {Array} - the parseQueue array to update with the latest parsed text node.
@@ -581,7 +577,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * previous {DomWordMap} in the parseQueue. For example: when the syllabification separator tag is inserted
      * between words.
      *
-     * @param {fluid.orator.domReader} that
+     * @param {fluid.orator.domReader} that - an instance of the component
      * @param {TextNodeData} textNodeData - the parsed information of text node. Typically from `fluid.textNodeParser`
      */
     fluid.orator.domReader.addToParseQueue = function (that, textNodeData) {
@@ -624,7 +620,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     /**
      * Reset the parseQueue and related model values
      *
-     * @param {fluid.orator.domReader} that
+     * @param {fluid.orator.domReader} that - an instance of the component
      */
     fluid.orator.domReader.resetParseQueue = function (that) {
         that.parseQueue = [];
@@ -658,7 +654,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * voicing engine. The parsed data points are added to the component's `parseQueue`. Once all of the text has been
      * synthesized, the `onStop` event is fired.
      *
-     * @param {fluid.orator.domReader} that
+     * @param {fluid.orator.domReader} that - an instance of the component
      * @param {String|jQuery|DomElement} elm - The DOM node to read
      */
     fluid.orator.domReader.readFromDOM = function (that, elm) {
@@ -682,7 +678,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     /**
      * Returns the index of the closest data point from the parseQueue based on the boundary provided.
      *
-     * @param {fluid.orator.domReader} that
+     * @param {fluid.orator.domReader} that - an instance of the component
      * @param {Integer} boundary - The boundary value used to compare against the blockIndex of the parsed data points.
      *                             If the boundary is undefined or out of bounds, `undefined` will be returned.
      * @param {Integer} parseQueueIndex - The index of into the parseQueue to determine which queue to use for
@@ -794,7 +790,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * Highlights text from the `parseQueue`. Highlights are performed by wrapping the appropriate text in the markup
      * specified at `that.options.markup.highlight`.
      *
-     * @param {fluid.orator.domReader} that
+     * @param {fluid.orator.domReader} that - an instance of the component
      */
     fluid.orator.domReader.highlight = function (that) {
         that.removeHighlight();
@@ -978,9 +974,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     /**
      * Retrieves the text from the current selection
      *
-     * @param {fluid.orator.selectionReader} that
-     *
-     * @return {String} - the text from the current selection
+     * @param {fluid.orator.selectionReader} that - an instance of the component
      */
     fluid.orator.selectionReader.getSelection = function (that) {
         that.selection = window.getSelection();

--- a/src/components/textToSpeech/js/MockTTS.js
+++ b/src/components/textToSpeech/js/MockTTS.js
@@ -76,13 +76,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             },
             // override the speak invoker to return the utterance component instead of the SpeechSynthesisUtterance instance
             speak: {
-                func: "{that}.invokeSpeechSynthesisFunc",
-                args: ["speak", {
-                    expander: {
-                        "this": "{that}.queue",
-                        method: "pop"
-                    }
-                }]
+                funcName: "fluid.mock.textToSpeech.speakOverride",
+                args: ["{that}"]
             }
         },
         distributeOptions: {
@@ -91,6 +86,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             namespace: "utteranceMock"
         }
     });
+
+    fluid.mock.textToSpeech.speakOverride = function (that) {
+        var utterance = that.queue[that.queue.length - 1];
+        that.invokeSpeechSynthesisFunc("speak", utterance);
+    };
 
     fluid.mock.textToSpeech.invokeStub = function (that, method, args) {
         args = fluid.makeArray(args);

--- a/src/components/textToSpeech/js/MockTTS.js
+++ b/src/components/textToSpeech/js/MockTTS.js
@@ -77,7 +77,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             // override the speak invoker to return the utterance component instead of the SpeechSynthesisUtterance instance
             speak: {
                 func: "{that}.invokeSpeechSynthesisFunc",
-                args: ["speak", "{that}.queue.0"]
+                args: ["speak", {
+                    expander: {
+                        "this": "{that}.queue",
+                        method: "pop"
+                    }
+                }]
             }
         },
         distributeOptions: {

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -146,7 +146,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                         "onCreate.queue": {
                             "this": "{fluid.textToSpeech}.queue",
                             method: "push",
-                            args: ["{that}.utterance"]
+                            args: ["{that}"]
                         },
                         "onCreate.speak": {
                             listener: "{textToSpeech}.speak",

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -325,7 +325,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * Assembles the utterance options and fires onSpeechQueued which will kick off the creation of an utterance
      * component. If "interrupt" is true, this utterance will replace any existing ones.
      *
-     * @param {Component} that - an instance of `fluid.textToSpeech`
+     * @param {fluid.textToSpeech} that
      * @param {String} text - the text to be synthesized
      * @param {Boolean} interrupt - used to indicate if this text should be queued or replace existing utterances
      * @param {UtteranceOpts} options - options to configure the {SpeechSynthesisUtterance} with. It is merged on top of
@@ -350,6 +350,29 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         return promise;
     };
 
+    /**
+     * Options to configure the SpeechSynthesis Utterance with.
+     * See: https://w3c.github.io/speech-api/speechapi.html#utterance-attributes
+     *
+     * @typedef {Object} Speech
+     * @property {String} text - the text to Synthesize
+     * @property {UtteranceOpts} options - options to configure the {SpeechSynthesisUtterance} with. It is merged on top
+     *                                     of the `utteranceOpts` from the component's model.
+     */
+
+    /**
+     * Queues a {Speech[]}, calling `that.queueSpeech` for each. This is useful for sets of text that should be
+     * synthesized with differing {UtteranceOpts}, but still treated as an atomic unit. For example, if a set of text
+     * includes words from different languages.
+     *
+     * @param  {fluid.textToSpeech} that
+     * @param  {Speech[]} speeches - the set of text to queue as a unit
+     * @param  {Boolean} interrupt - used to indicate if the related text should be queued or replace existing
+     *                               utterances
+     *
+     * @return {Promise} - returns a promise that is resolved/rejected after all of the speeches have finish or any
+     *                     have been rejected.
+     */
     fluid.textToSpeech.queueSpeechSequence = function (that, speeches, interrupt) {
         var sequence = fluid.transform(speeches, function (speech, index) {
             var toInterrupt = interrupt && !index; // only interrupt on the first string
@@ -363,7 +386,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * is required because if the SpeechSynthesis is cancelled remaining {SpeechSynthesisUtterance} are ignored and do
      * not fire their `onend` event.
      *
-     * @param  {Component} that - an instance of `fluid.textToSpeech`
+     * @param  {fluid.textToSpeech} that
      */
     fluid.textToSpeech.cancel = function (that) {
         // Safari does not fire the onend event from an utterance when the speech synthesis is cancelled.
@@ -441,7 +464,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * event provided in the utteranceEventMap, any corresponding event binding passed in directly through the
      * utteranceOpts will be rebound as component event listeners with the "external" namespace.
      *
-     * @param {Component} that - an instance of `fluid.textToSpeech.utterance`
+     * @param {fluid.textToSpeech.utterance} that
      * @param {Object} utteranceEventMap - a mapping from {SpeechSynthesisUtterance} events to component events.
      * @param {UtteranceOpts} utteranceOpts - options to configure the {SpeechSynthesisUtterance} with.
      *

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -61,42 +61,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         return !!(window && window.speechSynthesis);
     };
 
-    /**
-     * Ensures that TTS is supported in the browser, including cases where the
-     * feature is detected, but where the underlying audio engine is missing.
-     * For example in VMs on SauceLabs, the behaviour for browsers which report that the speechSynthesis
-     * API is implemented is for the `onstart` event of an utterance to never fire. If we don't receive this
-     * event within a timeout, this API's behaviour is to return a promise which rejects.
-     *
-     * @param {Number} delay - A time in milliseconds to wait for the speechSynthesis to fire its onStart event
-     * by default it is 5000ms (5s). This is crux of the test, as it needs time to attempt to run the speechSynthesis.
-     * @return {fluid.promise} - A promise which will resolve if the TTS is supported (the onstart event is fired within the delay period)
-     * or be rejected otherwise.
-     */
-    fluid.textToSpeech.checkTTSSupport = function (delay) {
-        var promise = fluid.promise();
-        if (fluid.textToSpeech.isSupported()) {
-            // MS Edge speech synthesizer won't speak if the text string is blank,
-            // so this must contain actual text
-            var toSpeak = new SpeechSynthesisUtterance("short"); // short text to attempt to speak
-            toSpeak.volume = 0; // mutes the Speech Synthesizer
-            // Same timeout as the timeout in the IoC testing framework
-            var timeout = setTimeout(function () {
-                fluid.textToSpeech.invokeSpeechSynthesisFunc("cancel");
-                promise.reject();
-            }, delay || 5000);
-            toSpeak.onend = function () {
-                clearTimeout(timeout);
-                fluid.textToSpeech.invokeSpeechSynthesisFunc("cancel");
-                promise.resolve();
-            };
-            fluid.textToSpeech.invokeSpeechSynthesisFunc("speak", toSpeak);
-        } else {
-            fluid.invokeLater(promise.reject);
-        }
-        return promise;
-    };
-
     /*********************************************************************************************
      * fluid.textToSpeech component
      *********************************************************************************************/

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -295,7 +295,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * Assembles the utterance options and fires onSpeechQueued which will kick off the creation of an utterance
      * component. If "interrupt" is true, this utterance will replace any existing ones.
      *
-     * @param {fluid.textToSpeech} that
+     * @param {fluid.textToSpeech} that - an instance of the component
      * @param {String} text - the text to be synthesized
      * @param {Boolean} interrupt - used to indicate if this text should be queued or replace existing utterances
      * @param {UtteranceOpts} options - options to configure the {SpeechSynthesisUtterance} with. It is merged on top of
@@ -335,7 +335,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * synthesized with differing {UtteranceOpts}, but still treated as an atomic unit. For example, if a set of text
      * includes words from different languages.
      *
-     * @param  {fluid.textToSpeech} that
+     * @param  {fluid.textToSpeech} that - an instance of the component
      * @param  {Speech[]} speeches - the set of text to queue as a unit
      * @param  {Boolean} interrupt - used to indicate if the related text should be queued or replace existing
      *                               utterances
@@ -346,7 +346,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     fluid.textToSpeech.queueSpeechSequence = function (that, speeches, interrupt) {
         var sequence = fluid.transform(speeches, function (speech, index) {
             var toInterrupt = interrupt && !index; // only interrupt on the first string
-            return that.queueSpeech(speech.text, interrupt, speech.options);
+            return that.queueSpeech(speech.text, toInterrupt, speech.options);
         });
         return fluid.promise.sequence(sequence);
     };
@@ -356,7 +356,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * is required because if the SpeechSynthesis is cancelled remaining {SpeechSynthesisUtterance} are ignored and do
      * not fire their `onend` event.
      *
-     * @param  {fluid.textToSpeech} that
+     * @param  {fluid.textToSpeech} that - an instance of the component
      */
     fluid.textToSpeech.cancel = function (that) {
         // Safari does not fire the onend event from an utterance when the speech synthesis is cancelled.
@@ -434,7 +434,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * event provided in the utteranceEventMap, any corresponding event binding passed in directly through the
      * utteranceOpts will be rebound as component event listeners with the "external" namespace.
      *
-     * @param {fluid.textToSpeech.utterance} that
+     * @param {fluid.textToSpeech.utterance} that - an instance of the component
      * @param {Object} utteranceEventMap - a mapping from {SpeechSynthesisUtterance} events to component events.
      * @param {UtteranceOpts} utteranceOpts - options to configure the {SpeechSynthesisUtterance} with.
      *

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -202,6 +202,10 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 funcName: "fluid.textToSpeech.queueSpeech",
                 args: ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"]
             },
+            queueSpeechSequence: {
+                funcName: "fluid.textToSpeech.queueSpeechSequence",
+                args: ["{that}", "{arguments}.0", "{arguments}.1"]
+            },
             cancel: {
                 funcName: "fluid.textToSpeech.cancel",
                 args: ["{that}"]
@@ -344,6 +348,15 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             that.events.onSpeechQueued.fire(utteranceOpts, interrupt, promise);
         }, 100);
         return promise;
+    };
+
+    fluid.textToSpeech.queueSpeechSequence = function (that, speeches, interrupt) {
+        var sequence = fluid.transform(speeches, function (speech, index) {
+            console.log("speech:", speech);
+            var toInterrupt = interrupt && !index; // only interrupt on the first string
+            return that.queueSpeech(speech.text, interrupt, speech.options);
+        });
+        return fluid.promise.sequence(sequence);
     };
 
     /**

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -42,7 +42,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     * Adds a lister to a window event for each event defined on the component.
     * The name must match a valid window event.
     *
-    * @param {Component} that - the component itself
+    * @param {Component} that - an instance of `fluid.window`
     */
     fluid.window.bindEvents = function (that) {
         fluid.each(that.options.events, function (type, eventName) {
@@ -321,13 +321,14 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * Assembles the utterance options and fires onSpeechQueued which will kick off the creation of an utterance
      * component. If "interrupt" is true, this utterance will replace any existing ones.
      *
-     * @param {Component} that - the component
+     * @param {Component} that - an instance of `fluid.textToSpeech`
      * @param {String} text - the text to be synthesized
      * @param {Boolean} interrupt - used to indicate if this text should be queued or replace existing utterances
-     * @param {UtteranceOpts} options - options to configure the SpeechSynthesis utterance with. It is merged on top of the
-     *                           utteranceOpts from the component's model.
+     * @param {UtteranceOpts} options - options to configure the {SpeechSynthesisUtterance} with. It is merged on top of
+     *                                  the `utteranceOpts` from the component's model.
      *
-     * @return {Promise} - returns a promise that is resolved after the onSpeechQueued event has fired.
+     * @return {Promise} - returns a promise that is resolved/rejected from the related `fluid.textToSpeech.utterance`
+     *                     instance.
      */
     fluid.textToSpeech.queueSpeech = function (that, text, interrupt, options) {
         var promise = fluid.promise();
@@ -345,6 +346,13 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         return promise;
     };
 
+    /**
+     * Manually fires the `onEnd` event of each remaining `fluid.textToSpeech.utterance` component in the queue. This
+     * is required because if the SpeechSynthesis is cancelled remaining {SpeechSynthesisUtterance} are ignored and do
+     * not fire their `onend` event.
+     *
+     * @param  {Component} that - an instance of `fluid.textToSpeech`
+     */
     fluid.textToSpeech.cancel = function (that) {
         // Safari does not fire the onend event from an utterance when the speech synthesis is cancelled.
         // Manually triggering the onEnd event for each utterance as we empty the queue, before calling cancel.
@@ -421,11 +429,11 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * event provided in the utteranceEventMap, any corresponding event binding passed in directly through the
      * utteranceOpts will be rebound as component event listeners with the "external" namespace.
      *
-     * @param {Component} that - the component
-     * @param {Object} utteranceEventMap - a mapping from SpeechSynthesisUtterance events to component events.
-     * @param {UtteranceOpts} utteranceOpts - options to configure the SpeechSynthesis utterance with.
+     * @param {Component} that - an instance of `fluid.textToSpeech.utterance`
+     * @param {Object} utteranceEventMap - a mapping from {SpeechSynthesisUtterance} events to component events.
+     * @param {UtteranceOpts} utteranceOpts - options to configure the {SpeechSynthesisUtterance} with.
      *
-     * @return {SpeechSynthesisUtterance} - returns the created SpeechSynthesisUtterance object
+     * @return {SpeechSynthesisUtterance} - returns the created {SpeechSynthesisUtterance} object
      */
     fluid.textToSpeech.utterance.construct = function (that, utteranceEventMap, utteranceOpts) {
         var utterance = new SpeechSynthesisUtterance();

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -101,8 +101,14 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 options: {
                     listeners: {
                         "onBoundary.relay": "{textToSpeech}.events.utteranceOnBoundary.fire",
-                        "onEnd.relay": "{textToSpeech}.events.utteranceOnEnd.fire",
-                        "onError.relay": "{textToSpeech}.events.utteranceOnError.fire",
+                        "onEnd.relay": {
+                            listener: "{textToSpeech}.events.utteranceOnEnd.fire",
+                            priority: "before:resolvePromise"
+                        },
+                        "onError.relay": {
+                            listener: "{textToSpeech}.events.utteranceOnError.fire",
+                            priority: "before:rejectPromise"
+                        },
                         "onMark.relay": "{textToSpeech}.events.utteranceOnMark.fire",
                         "onPause.relay": "{textToSpeech}.events.utteranceOnPause.fire",
                         "onResume.relay": "{textToSpeech}.events.utteranceOnResume.fire",
@@ -315,7 +321,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     };
 
     /**
-     * Options to configure the SpeechSynthesis Utterance with.
+     * Values to configure the SpeechSynthesis Utterance with.
      * See: https://w3c.github.io/speech-api/speechapi.html#utterance-attributes
      *
      * @typedef {Object} Speech

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -146,7 +146,11 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                         "onCreate.queue": {
                             "this": "{fluid.textToSpeech}.queue",
                             method: "push",
-                            args: ["{that}"]
+                            args: ["{that}.utterance"]
+                        },
+                        "onCreate.speak": {
+                            listener: "{textToSpeech}.speak",
+                            args: ["{that}.utterance"]
                         },
                         "onEnd.destroy": {
                             func: "{that}.destroy",
@@ -211,15 +215,11 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             },
             speak: {
                 func: "{that}.invokeSpeechSynthesisFunc",
-                args: ["speak", "{that}.queue.0.utterance"]
+                args: ["speak", "{arguments}.0"]
             },
             invokeSpeechSynthesisFunc: "fluid.textToSpeech.invokeSpeechSynthesisFunc"
         },
         listeners: {
-            "onSpeechQueued.speak": {
-                func: "{that}.speak",
-                priority: "last"
-            },
             "utteranceOnStart.speaking": {
                 changePath: "speaking",
                 value: true,

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -352,7 +352,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
 
     fluid.textToSpeech.queueSpeechSequence = function (that, speeches, interrupt) {
         var sequence = fluid.transform(speeches, function (speech, index) {
-            console.log("speech:", speech);
             var toInterrupt = interrupt && !index; // only interrupt on the first string
             return that.queueSpeech(speech.text, interrupt, speech.options);
         });

--- a/src/framework/core/js/TextNodeParser.js
+++ b/src/framework/core/js/TextNodeParser.js
@@ -114,7 +114,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * found. The event is fired with the text node, language and index of the text node in the list of its parent's
      * child nodes..
      *
-     * Note: elements that return `false` to `that.hasTextToRead` are ignored.
+     * Note: elements that return `false` from `that.hasTextToRead` are ignored.
      *
      * @param {fluid.textNodeParser} that
      * @param {jQuery|DomElement} elm - the DOM node to parse
@@ -132,7 +132,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             var childNodes = elm.childNodes;
             var elementLang = elm.getAttribute("lang") || lang || that.getLang(elm);;
 
-            fluid.each(childNodes, function (childNode, childIndex) {
+            childNodes.forEach(function (childNode, childIndex) {
                 if (childNode.nodeType === Node.TEXT_NODE) {
                     var textNodeData = {
                         node: childNode,

--- a/src/framework/core/js/TextNodeParser.js
+++ b/src/framework/core/js/TextNodeParser.js
@@ -116,7 +116,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      *
      * Note: elements that return `false` from `that.hasTextToRead` are ignored.
      *
-     * @param {fluid.textNodeParser} that
+     * @param {fluid.textNodeParser} that - an instance of the component
      * @param {jQuery|DomElement} elm - the DOM node to parse
      * @param {String} lang - a valid BCP 47 language code.
      * @param {Event} afterParseEvent - the event to fire after parsing has completed.

--- a/src/framework/core/js/TextNodeParser.js
+++ b/src/framework/core/js/TextNodeParser.js
@@ -116,7 +116,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      *
      * Note: elements that return `false` to `that.hasTextToRead` are ignored.
      *
-     * @param {fluid.textNodeParser} that - the component instance
+     * @param {fluid.textNodeParser} that
      * @param {jQuery|DomElement} elm - the DOM node to parse
      * @param {String} lang - a valid BCP 47 language code.
      * @param {Event} afterParseEvent - the event to fire after parsing has completed.

--- a/src/framework/core/js/TextNodeParser.js
+++ b/src/framework/core/js/TextNodeParser.js
@@ -100,37 +100,58 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     };
 
     /**
+     * The parsed information of text node, including: the node itself, its specified language, and its index within its
+     * parent.
+     *
+     * @typedef {Object} TextNodeData
+     * @property {DomNode} node - The current child node being parsed
+     * @property {Integer} childIndex - The index of the child node being parsed relative to its parent
+     * @property {String} lang - a valid BCP 47 language code
+     */
+
+    /**
      * Recursively parses a DOM element and it's sub elements and fires the `onParsedTextNode` event for each text node
      * found. The event is fired with the text node, language and index of the text node in the list of its parent's
      * child nodes..
      *
      * Note: elements that return `false` to `that.hasTextToRead` are ignored.
      *
-     * @param {Component} that - an instance of `fluid.textNodeParser`
+     * @param {fluid.textNodeParser} that - the component instance
      * @param {jQuery|DomElement} elm - the DOM node to parse
      * @param {String} lang - a valid BCP 47 language code.
      * @param {Event} afterParseEvent - the event to fire after parsing has completed.
+     *
+     * @return {TextNodeData[]} the array of parsed elements. Only text nodes for elements that have passed the
+     *                          `that.hasTextToRead` check will be included.
      */
     fluid.textNodeParser.parse = function (that, elm, lang, afterParseEvent) {
         elm = fluid.unwrap(elm);
-        lang = lang || that.getLang(elm);
+        var parsed = [];
 
         if (that.hasTextToRead(elm)) {
             var childNodes = elm.childNodes;
-            var elementLang = elm.getAttribute("lang") || lang;
+            var elementLang = elm.getAttribute("lang") || lang || that.getLang(elm);;
 
-            $.each(childNodes, function (childIndex, childNode) {
+            fluid.each(childNodes, function (childNode, childIndex) {
                 if (childNode.nodeType === Node.TEXT_NODE) {
-                    that.events.onParsedTextNode.fire(childNode, elementLang, childIndex);
+                    var textNodeData = {
+                        node: childNode,
+                        lang: elementLang,
+                        childIndex: childIndex
+                    };
+                    parsed.push(textNodeData);
+                    that.events.onParsedTextNode.fire(textNodeData);
                 } else if (childNode.nodeType === Node.ELEMENT_NODE) {
-                    fluid.textNodeParser.parse(that, childNode, elementLang);
+                    parsed = parsed.concat(fluid.textNodeParser.parse(that, childNode, elementLang));
                 }
             });
         }
 
         if (afterParseEvent) {
-            afterParseEvent(that);
+            afterParseEvent(that, parsed);
         }
+
+        return parsed;
     };
 
 })(jQuery, fluid_3_0_0);

--- a/src/framework/preferences/js/SyllabificationEnactor.js
+++ b/src/framework/preferences/js/SyllabificationEnactor.js
@@ -63,7 +63,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             },
             "onParsedTextNode.syllabify": {
                 listener: "{that}.apply",
-                args: ["{arguments}.0", "{arguments}.1"]
+                args: ["{arguments}.0.node", "{arguments}.0.lang"]
             },
             "onNodeAdded.syllabify": {
                 listener: "{that}.parse",

--- a/tests/component-tests/orator/html/Orator-test.html
+++ b/tests/component-tests/orator/html/Orator-test.html
@@ -54,11 +54,12 @@
             Text <span class="flc-orator-domReader-test-wrap">wrapped text</span>
         </div>
         <p class="flc-orator-domReader-test" lang="en-CA">
-            Read<span></span>ing <strong>text</strong> from <em>DOM</em><span style="display: none;">hidden</span>
+            Read<span></span>ing <strong lang="en-US">text</strong> from <em>DOM</em><span style="display: none;">hidden</span>
         </p>
         <p class="flc-orator-selectionReader-test">
             <span class="flc-orator-selectionReader-test-selection">Selection Test</span>
             <span class="flc-orator-selectionReader-test-selectionTwo">Other Text</span>
+            <span class="flc-orator-selectionReader-test-selectionThree">Change <span lang="en-US" class="flc-orator-selectionReader-test-selectionFour">Language</span></span>
         </p>
         <div class="flc-orator-test">
             <article class="flc-orator-content">

--- a/tests/component-tests/orator/js/OratorTests-Utils.js
+++ b/tests/component-tests/orator/js/OratorTests-Utils.js
@@ -124,7 +124,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         range.setEnd(endNode, endOffset);
         selection.removeAllRanges();
         selection.addRange(range);
-    }
+    };
 
     fluid.tests.orator.selection.collapse = function () {
         var selection = window.getSelection();
@@ -133,7 +133,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     fluid.tests.orator.selection.getSelectionRange = function () {
         return window.getSelection().getRangeAt(0);
-    }
+    };
 
     /*******************************************************************************
      * Assertions

--- a/tests/component-tests/orator/js/OratorTests-Utils.js
+++ b/tests/component-tests/orator/js/OratorTests-Utils.js
@@ -116,10 +116,24 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         selection.addRange(range);
     };
 
+    fluid.tests.orator.selection.selectNodes = function (startNode, endNode, startOffset, endOffset) {
+        var range = document.createRange();
+        var selection = window.getSelection();
+
+        range.setStart(startNode, startOffset);
+        range.setEnd(endNode, endOffset);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+
     fluid.tests.orator.selection.collapse = function () {
         var selection = window.getSelection();
         selection.removeAllRanges();
     };
+
+    fluid.tests.orator.selection.getSelectionRange = function () {
+        return window.getSelection().getRangeAt(0);
+    }
 
     /*******************************************************************************
      * Assertions

--- a/tests/component-tests/orator/js/OratorTests.js
+++ b/tests/component-tests/orator/js/OratorTests.js
@@ -574,7 +574,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         modules: [{
             name: "fluid.orator.domReader",
             tests: [{
-                expect: 50,
+                expect: 51,
                 name: "DOM Reading",
                 sequence: [{
                     // Play sequence
@@ -605,7 +605,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     // Boundary event when paused
                     func: "{domReader}.events.utteranceOnBoundary.fire",
-                    args: [{charIndex: 8}]
+                    args: [{charIndex: 8, name: "word"}]
                 }, {
                     func: "jqUnit.assertNull",
                     args: ["The ttsBoundary model path should be null", "{domReader}.model.ttsBoundary"]
@@ -616,7 +616,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     // Boundary event with no parseQueue items
                     func: "{domReader}.events.utteranceOnBoundary.fire",
-                    args: [{charIndex: 8}]
+                    args: [{charIndex: 8, name: "word"}]
                 }, {
                     listener: "jqUnit.assertNodeNotExists",
                     args: ["The parseQueue is empty, no highlight should be added", "{domReader}.dom.highlight"],
@@ -639,8 +639,16 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                         parseItemCount: 2
                     }, "ADD", "domReaderTests"]
                 }, {
+                    // boundary event fired for sentence
                     funcName: "{domReader}.events.utteranceOnBoundary.fire",
-                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.0.blockIndex"}]
+                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.0.blockIndex", name: "sentence"}]
+                }, {
+                    func: "jqUnit.assertNull",
+                    args: ["The ttsBoundary model path should be null", "{domReader}.model.ttsBoundary"]
+                }, {
+                    // boundary event fired for word
+                    funcName: "{domReader}.events.utteranceOnBoundary.fire",
+                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.0.blockIndex", name: "word"}]
                 }, {
                     listener: "fluid.tests.orator.domReaderTester.verifyMark",
                     args: ["{domReader}.dom.highlight", 2, "{that}.options.testOptions.parseQueue.0.0.word"],
@@ -648,7 +656,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     changeEvent: "{domReader}.applier.modelChanged"
                 }, {
                     func: "{domReader}.events.utteranceOnBoundary.fire",
-                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.1.blockIndex"}]
+                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.1.blockIndex", name: "word"}]
                 }, {
                     funcName: "fluid.tests.orator.domReaderTester.verifyMark",
                     args: ["{domReader}.dom.highlight", 1, "{that}.options.testOptions.parseQueue.0.1.word"],

--- a/tests/component-tests/orator/js/OratorTests.js
+++ b/tests/component-tests/orator/js/OratorTests.js
@@ -372,6 +372,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     }, {
         parseIndex: 2,
         parseQueueIndex: 2,
+        boundary: 4,
+        expected: 1
+    }, {
+        parseIndex: 2,
+        parseQueueIndex: 2,
         boundary: 35,
         expected: undefined
     }];
@@ -569,7 +574,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         modules: [{
             name: "fluid.orator.domReader",
             tests: [{
-                expect: 49,
+                expect: 50,
                 name: "DOM Reading",
                 sequence: [{
                     // Play sequence
@@ -593,6 +598,21 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                         "{that}.options.testOptions.expectedSpeechRecord",
                         "{that}.options.testOptions.stoppedModel"
                     ]
+                }, {
+                    // set paused
+                    funcName: "{domReader}.applier.change",
+                    args: ["tts.paused", true, "ADD", "domReaderTests"]
+                }, {
+                    // Boundary event when paused
+                    func: "{domReader}.events.utteranceOnBoundary.fire",
+                    args: [{charIndex: 8}]
+                }, {
+                    func: "jqUnit.assertNull",
+                    args: ["The ttsBoundary model path should be null", "{domReader}.model.ttsBoundary"]
+                }, {
+                    // reset paused state
+                    funcName: "{domReader}.applier.change",
+                    args: ["tts.paused", false, "ADD", "domReaderTests"]
                 }, {
                     // Boundary event with no parseQueue items
                     func: "{domReader}.events.utteranceOnBoundary.fire",

--- a/tests/component-tests/orator/js/OratorTests.js
+++ b/tests/component-tests/orator/js/OratorTests.js
@@ -989,11 +989,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             options: {lang: "en"}
         }, {
             text: "Language",
-            options: {lang: "en-US"},
+            options: {lang: "en-US"}
         }, {
             text: "\n        ",
             options: {lang: "en"}
-      }]
+        }]
     }, {
         name: "Selected parent element - undefined options",
         selector: ".flc-orator-selectionReader-test",
@@ -1002,7 +1002,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             options: {lang: "en"}
         }, {
             text: "Language",
-            options: {lang: "en-US"},
+            options: {lang: "en-US"}
         }, {
             text: "\n        ",
             options: {lang: "en"}
@@ -1138,8 +1138,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var expected = [{
             text: "nge ",
             options: {lang: "en"}
-        },
-        {
+        }, {
             text: "Language",
             options: {lang: "en-US"}
         }];
@@ -1247,7 +1246,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     changeEvent: "{selectionReader}.applier.modelChanged"
                 }, {
                     // play
-                    func: "{selectionReader}.play",
+                    func: "{selectionReader}.play"
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Play", "{that}.options.testOpts.expected.textPlay"],
@@ -1255,7 +1254,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     changeEvent: "{selectionReader}.applier.modelChanged"
                 }, {
                     // stop
-                    func: "{selectionReader}.stop",
+                    func: "{selectionReader}.stop"
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Stop", "{that}.options.testOpts.expected.textSelected"],

--- a/tests/component-tests/orator/js/OratorTests.js
+++ b/tests/component-tests/orator/js/OratorTests.js
@@ -222,135 +222,156 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
 
     // fluid.orator.domReader.parse tests
-    fluid.tests.orator.domReader.parsed = [{
-        // 0
-        "blockIndex": 0,
-        "childIndex": 0,
-        "endOffset": 20,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 13,
-        "word": "Reading"
-    }, {
-        // 1
-        "blockIndex": 7,
-        "childIndex": 2,
-        "endOffset": 4,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 3,
-        "word": " "
-    }, {
-        // 2
-        "blockIndex": 8,
-        "childIndex": 0,
-        "endOffset": 4,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 0,
-        "word": "text"
-    }, {
-        // 3
-        "blockIndex": 12,
-        "childIndex": 4,
-        "endOffset": 1,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 0,
-        "word": " "
-    }, {
-        // 4
-        "blockIndex": 13,
-        "childIndex": 4,
-        "endOffset": 5,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 1,
-        "word": "from"
-    }, {
-        // 5
-        "blockIndex": 17,
-        "childIndex": 4,
-        "endOffset": 6,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 5,
-        "word": " "
-    }, {
-        // 6
-        "blockIndex": 18,
-        "childIndex": 0,
-        "endOffset": 3,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 0,
-        "word": "DOM"
-    }, {
-        // 7
-        "blockIndex": 21,
-        "childIndex": 7,
-        "endOffset": 9,
-        "lang": "en-CA",
-        "node": {},
-        "parentNode": {},
-        "startOffset": 0,
-        "word": "\n        "
-    }];
+    fluid.tests.orator.domReader.parsed = [
+        [{
+            // 0
+            "blockIndex": 0,
+            "childIndex": 0,
+            "endOffset": 20,
+            "lang": "en-CA",
+            "node": {},
+            "parentNode": {},
+            "startOffset": 13,
+            "word": "Reading"
+        }, {
+            // 1
+            "blockIndex": 7,
+            "childIndex": 2,
+            "endOffset": 4,
+            "lang": "en-CA",
+            "node": {},
+            "parentNode": {},
+            "startOffset": 3,
+            "word": " "
+        }],
+        [{
+            // 0
+            "blockIndex": 0,
+            "childIndex": 0,
+            "endOffset": 4,
+            "lang": "en-US",
+            "node": {},
+            "parentNode": {},
+            "startOffset": 0,
+            "word": "text"
+        }],
+        [{
+            // 0
+            "blockIndex": 0,
+            "childIndex": 4,
+            "endOffset": 5,
+            "lang": "en-CA",
+            "node": {},
+            "parentNode": {},
+            "startOffset": 1,
+            "word": "from"
+        }, {
+            // 1
+            "blockIndex": 4,
+            "childIndex": 4,
+            "endOffset": 6,
+            "lang": "en-CA",
+            "node": {},
+            "parentNode": {},
+            "startOffset": 5,
+            "word": " "
+        }, {
+            // 2
+            "blockIndex": 5,
+            "childIndex": 0,
+            "endOffset": 3,
+            "lang": "en-CA",
+            "node": {},
+            "parentNode": {},
+            "startOffset": 0,
+            "word": "DOM"
+        }, {
+            // 3
+            "blockIndex": 8,
+            "childIndex": 7,
+            "endOffset": 9,
+            "lang": "en-CA",
+            "node": {},
+            "parentNode": {},
+            "startOffset": 0,
+            "word": "\n        "
+        }]
+    ];
 
     // fluid.orator.domReader.parsedToString tests
-    fluid.tests.orator.domReader.str = "Reading text from DOM\n        ";
+    fluid.tests.orator.domReader.str = ["Reading ", "text", "from DOM\n        "];
 
     jqUnit.test("Test fluid.orator.domReader.parsedToString", function () {
-        var str = fluid.orator.domReader.parsedToString(fluid.tests.orator.domReader.parsed);
-        jqUnit.assertEquals("The parsed text should have been combined to a string", fluid.tests.orator.domReader.str, str);
+        fluid.each(fluid.tests.orator.domReader.parsed, function (parsed, index) {
+            var str = fluid.orator.domReader.parsedToString(parsed);
+            jqUnit.assertEquals("The parsed text should have been combined to a string: " + str, fluid.tests.orator.domReader.str[index], str);
+        });
     });
 
     // fluid.orator.domReader.getClosestIndex tests
     fluid.tests.orator.domReader.closestIndexTestCases = [{
         parseIndex: 0,
         boundary: -1,
+        parseQueueIndex: 0,
         expected: undefined
     }, {
         parseIndex: 0,
         boundary: 0,
+        parseQueueIndex: 0,
         expected: 0
     }, {
         parseIndex: 0,
         boundary: 6,
+        parseQueueIndex: 0,
         expected: 0
     }, {
         parseIndex: 0,
+        parseQueueIndex: 0,
         boundary: 7,
         expected: 1
     }, {
-        parseIndex: 2,
-        boundary: 27,
-        expected: 7
+        parseIndex: 1,
+        parseQueueIndex: 0,
+        boundary: 8,
+        expected: 1
     }, {
-        parseIndex: 5,
+        parseIndex: 0,
+        parseQueueIndex: 0,
+        boundary: 27,
+        expected: undefined
+    }, {
+        parseIndex: 0,
+        parseQueueIndex: 1,
+        boundary: -2,
+        expected: undefined
+    }, {
+        parseIndex: 0,
+        parseQueueIndex: 1,
         boundary: 2,
         expected: 0
     }, {
-        parseIndex: 7,
-        boundary: 18,
-        expected: 6
+        parseIndex: null,
+        parseQueueIndex: 2,
+        boundary: 1,
+        expected: 0
     }, {
-        parseIndex: 7,
-        boundary: 29,
-        expected: 7
+        parseIndex: 0,
+        parseQueueIndex: 2,
+        boundary: 1,
+        expected: 0
     }, {
-        parseIndex: 7,
-        boundary: 30,
-        expected: 7
+        parseIndex: 0,
+        parseQueueIndex: 2,
+        boundary: 4,
+        expected: 1
     }, {
-        parseIndex: 7,
+        parseIndex: 1,
+        parseQueueIndex: 2,
+        boundary: 8,
+        expected: 3
+    }, {
+        parseIndex: 2,
+        parseQueueIndex: 2,
         boundary: 35,
         expected: undefined
     }];
@@ -358,8 +379,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     jqUnit.test("Test fluid.orator.domReader.getClosestIndex", function () {
         fluid.each(fluid.tests.orator.domReader.closestIndexTestCases, function (testCase) {
             var mockThat = {parseQueue: fluid.tests.orator.domReader.parsed, model: {parseIndex: testCase.parseIndex}};
-            var closest = fluid.orator.domReader.getClosestIndex(mockThat, testCase.boundary);
-            jqUnit.assertEquals("Closest index for boundary \"" + testCase.boundary + "\" should be: " + testCase.expected, testCase.expected, closest);
+            var closest = fluid.orator.domReader.getClosestIndex(mockThat, testCase.boundary, testCase.parseQueueIndex);
+            var msg = "Closest index for boundary \"" + testCase.boundary + "\" and parseQueueIndex \"" + testCase.parseQueueIndex + "\" should be: " + testCase.expected;
+            jqUnit.assertEquals(msg, testCase.expected, closest);
         });
     });
 
@@ -441,7 +463,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
      *******************************************************************************/
 
     fluid.defaults("fluid.tests.orator.domReader", {
-        // gradeNames: ["fluid.orator.domReader", "fluid.tests.orator.mockTTS"],
         gradeNames: ["fluid.orator.domReader"],
         model: {
             tts: {
@@ -477,7 +498,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             startStopFireRecord: {
                 onStart: 1,
                 onStop: 1,
-                onSpeechQueued: 1
+                onSpeechQueued: 3
             },
             stoppedModel: {
                 speaking: false,
@@ -501,48 +522,57 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             },
             expectedSpeechRecord: [{
                 "interrupt": true,
-                "text": "Reading text from DOM"
+                "text": "Reading"
+            }, {
+                "interrupt": false,
+                "text": "text"
+            }, {
+                "interrupt": false,
+                "text": "from DOM"
             }],
             // a mock parseQueue for testing adding and removing the highlight
-            parseQueue: [{
-                "blockIndex": 0,
-                "childIndex": 0,
-                "endOffset": 20,
-                "lang": "en-CA",
-                "node": {},
-                "parentNode": {
-                    expander: {
-                        "this": "{domReader}.container",
-                        method: "get",
-                        args: [0]
-                    }
-                },
-                "startOffset": 13,
-                "word": "Reading"
-            }, {
-                "blockIndex": 8,
-                "childIndex": 0,
-                "endOffset": 4,
-                "lang": "en-CA",
-                "node": {},
-                "parentNode": {
-                    expander: {
-                        func: function (elm) {
-                            return $(elm).children()[1];
-                        },
-                        args: ["{domReader}.container"]
-                    }
-                },
-                "startOffset": 0,
-                "word": "text"
-            }]
+            parseQueue: [
+                [{
+                    "blockIndex": 0,
+                    "childIndex": 0,
+                    "endOffset": 20,
+                    "lang": "en-CA",
+                    "node": {},
+                    "parentNode": {
+                        expander: {
+                            "this": "{domReader}.container",
+                            method: "get",
+                            args: [0]
+                        }
+                    },
+                    "startOffset": 13,
+                    "word": "Reading"
+                }, {
+                    "blockIndex": 8,
+                    "childIndex": 0,
+                    "endOffset": 4,
+                    "lang": "en-CA",
+                    "node": {},
+                    "parentNode": {
+                        expander: {
+                            func: function (elm) {
+                                return $(elm).children()[1];
+                            },
+                            args: ["{domReader}.container"]
+                        }
+                    },
+                    "startOffset": 0,
+                    "word": "text"
+                }]
+            ]
         },
         modules: [{
             name: "fluid.orator.domReader",
             tests: [{
-                expect: 43,
+                expect: 49,
                 name: "DOM Reading",
                 sequence: [{
+                    // Play sequence
                     func: "{domReader}.play"
                 }, {
                     func: "fluid.tests.orator.domReaderTester.verifyParseQueue",
@@ -551,7 +581,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     listener: "fluid.tests.orator.domReaderTester.verifySpeakQueue",
                     args: ["{domReader}", "{that}.options.testOptions.expectedSpeechRecord"],
                     spec: {priority: "last:testing"},
-                    event: "{domReader}.events.utteranceOnEnd"
+                    event: "{domReader}.events.onStop"
                 }, {
                     funcName: "fluid.tests.orator.domReaderTester.verifyEmptyParseQueueState",
                     args: ["Self Voicing completed", "{domReader}"]
@@ -564,6 +594,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                         "{that}.options.testOptions.stoppedModel"
                     ]
                 }, {
+                    // Boundary event with no parseQueue items
                     func: "{domReader}.events.utteranceOnBoundary.fire",
                     args: [{charIndex: 8}]
                 }, {
@@ -572,28 +603,40 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     spec: {priority: "last:testing", path: "ttsBoundary"},
                     changeEvent: "{domReader}.applier.modelChanged"
                 }, {
+                    // reset ttsBoundary
+                    funcName: "{domReader}.applier.change",
+                    args: ["ttsBoundary", null, "ADD", "domReaderTests"]
+                }, {
+                    // Test boundary events with a populated parseQueue
                     // manually add items to parseQueue so that we can more easily test adding and removing the highlight
                     funcName: "fluid.tests.orator.domReaderTester.setParseQueue",
                     args: ["{domReader}", "{that}.options.testOptions.parseQueue"]
                 }, {
+                    // manually update parseQueue related model values
+                    funcName: "{domReader}.applier.change",
+                    args: ["", {
+                        parseQueueCount: 1,
+                        parseItemCount: 2
+                    }, "ADD", "domReaderTests"]
+                }, {
                     funcName: "{domReader}.events.utteranceOnBoundary.fire",
-                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.blockIndex"}]
+                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.0.blockIndex"}]
                 }, {
                     listener: "fluid.tests.orator.domReaderTester.verifyMark",
-                    args: ["{domReader}.dom.highlight", "{that}.options.testOptions.parseQueue.0.word"],
+                    args: ["{domReader}.dom.highlight", 2, "{that}.options.testOptions.parseQueue.0.0.word"],
                     spec: {priority: "last:testing", path: "ttsBoundary"},
                     changeEvent: "{domReader}.applier.modelChanged"
                 }, {
                     func: "{domReader}.events.utteranceOnBoundary.fire",
-                    args: [{charIndex: "{that}.options.testOptions.parseQueue.1.blockIndex"}]
+                    args: [{charIndex: "{that}.options.testOptions.parseQueue.0.1.blockIndex"}]
                 }, {
                     funcName: "fluid.tests.orator.domReaderTester.verifyMark",
-                    args: ["{domReader}.dom.highlight", "{that}.options.testOptions.parseQueue.1.word"],
+                    args: ["{domReader}.dom.highlight", 1, "{that}.options.testOptions.parseQueue.0.1.word"],
                     spec: {priority: "last:testing", path: "ttsBoundary"},
                     changeEvent: "{domReader}.applier.modelChanged"
                 }, {
-                    // simulate ending reading
-                    func: "{domReader}.events.utteranceOnEnd.fire"
+                    // simulate finished reading
+                    func: "{domReader}.events.onStop.fire"
                 }, {
                     funcName: "fluid.tests.orator.domReaderTester.verifyEmptyParseQueueState",
                     args: ["utteranceOnEnd fired", "{domReader}"],
@@ -620,7 +663,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     listener: "fluid.tests.orator.domReaderTester.verifySpeakQueue",
                     args: ["{domReader}", "{that}.options.testOptions.expectedSpeechRecord"],
                     spec: {priority: "last:testing"},
-                    event: "{domReader}.events.utteranceOnEnd"
+                    event: "{domReader}.events.onStop"
                 }, {
                     funcName: "fluid.tests.orator.domReaderTester.verifyEmptyParseQueueState",
                     args: ["Replayed Self Voicing completed", "{domReader}"]
@@ -729,7 +772,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     fluid.tests.orator.domReaderTester.verifyEmptyParseQueueState = function (testPrefix, that) {
         jqUnit.assertDeepEq(testPrefix + ": The parseQueue should be empty.", [], that.parseQueue);
-        jqUnit.assertEquals(testPrefix + ": The parseQueueLength model value should be 0.", 0, that.model.parseQueueLength);
+        jqUnit.assertEquals(testPrefix + ": The parseQueueCount model value should be 0.", 0, that.model.parseQueueCount);
+        jqUnit.assertEquals(testPrefix + ": The parseItemCount model value should be 0.", 0, that.model.parseItemCount);
         jqUnit.assertNull(testPrefix + ": The parseIndex model value should be null.", that.model.parseIndex);
         jqUnit.assertNull(testPrefix + ": The ttsBoundary model value should be null.", that.model.ttsBoundary);
         jqUnit.assertNodeNotExists(testPrefix + ": All highlights should be removed.", that.locate("highlight"));
@@ -740,14 +784,16 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     fluid.tests.orator.domReaderTester.verifyParseQueue = function (that, expected) {
-        jqUnit.assertDeepEq("The parsedQueueLength model value should have been set correctly", expected.length, that.model.parseQueueLength);
+        var expectedItemsCount = fluid.accumulate(expected, function (queue, count) {return queue.length + count;}, 0);
+        jqUnit.assertDeepEq("The parseQueueCount model value should have been set correctly", expected.length, that.model.parseQueueCount);
+        jqUnit.assertDeepEq("The parseItemCount model value should have been set correctly", expectedItemsCount, that.model.parseItemCount);
         jqUnit.assertDeepEq("The parseQueue should have been populated correctly", expected, that.parseQueue);
     };
 
-    fluid.tests.orator.domReaderTester.verifyMark = function (elm, expectedText) {
+    fluid.tests.orator.domReaderTester.verifyMark = function (elm, expectedHighlightCount, expectedText) {
         jqUnit.assertNodeExists("The highlight should have been added", elm);
-        jqUnit.assertEquals("Only one highlight should be present", 1, elm.length);
-        jqUnit.assertEquals("The correct textnode should be highlighted", elm.text(), expectedText);
+        jqUnit.assertEquals("The expeted number of highlight marks should be present: " + expectedHighlightCount, expectedHighlightCount, elm.length);
+        jqUnit.assertEquals("The correct text should be highlighted", elm.text(), expectedText);
     };
 
     fluid.tests.orator.domReaderTester.verifyRecords = function (that, expectedEvents, expectedSpeechRecord, expectedModel) {
@@ -934,6 +980,179 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         sandbox.restore();
     });
 
+    fluid.tests.orator.selectionReader.parseElementTestCases = [{
+        name: "Selected parent element - empty options",
+        selector: ".flc-orator-selectionReader-test",
+        options: {},
+        expected: [{
+            text: "\n            Selection Test\n            Other Text\n            Change ",
+            options: {lang: "en"}
+        }, {
+            text: "Language",
+            options: {lang: "en-US"},
+        }, {
+            text: "\n        ",
+            options: {lang: "en"}
+      }]
+    }, {
+        name: "Selected parent element - undefined options",
+        selector: ".flc-orator-selectionReader-test",
+        expected: [{
+            text: "\n            Selection Test\n            Other Text\n            Change ",
+            options: {lang: "en"}
+        }, {
+            text: "Language",
+            options: {lang: "en-US"},
+        }, {
+            text: "\n        ",
+            options: {lang: "en"}
+        }]
+    }, {
+        name: "Selected parent element - with options",
+        selector: ".flc-orator-selectionReader-test",
+        options: {
+            startOffset: "6",
+            endOffset: "8",
+            startContainer: ".flc-orator-selectionReader-test-selectionTwo",
+            endContainer: ".flc-orator-selectionReader-test-selectionTwo"
+        },
+        expected: [{
+            text: "Te",
+            options: {lang: "en"}
+        }]
+    }, {
+        name: "Selected element - empty options",
+        selector: ".flc-orator-selectionReader-test-selection",
+        options: {},
+        expected: [{
+            text: "Selection Test",
+            options: {lang: "en"}
+        }]
+    }, {
+        name: "Selected element - undefined options",
+        selector: ".flc-orator-selectionReader-test-selection",
+        expected: [{
+            text: "Selection Test",
+            options: {lang: "en"}
+        }]
+    }, {
+        name: "Selected element - with options",
+        selector: ".flc-orator-selectionReader-test-selection",
+        options: {
+            startOffset: "1",
+            endOffset: "6",
+            startContainer: ".flc-orator-selectionReader-test-selection",
+            endContainer: ".flc-orator-selectionReader-test-selection"
+        },
+        expected: [{
+            text: "elect",
+            options: {lang: "en"}
+        }]
+    }, {
+        name: "Selected element - startContainer not in element",
+        selector: ".flc-orator-selectionReader-test-selection",
+        options: {
+            startContainer: ".flc-orator-selectionReader-test-selectionTwo",
+            endContainer: ".flc-orator-selectionReader-test-selection"
+        },
+        expected: []
+    }, {
+        name: "Selected element - endContainer not in element",
+        selector: ".flc-orator-selectionReader-test-selection",
+        options: {
+            startContainer: ".flc-orator-selectionReader-test-selection",
+            endContainer: ".flc-orator-selectionReader-test-selectionTwo"
+        },
+        expected: []
+    }];
+
+    fluid.tests.orator.selectionReader.selectorToTextNode = function (selector) {
+        if (typeof(selector) === "string") {
+            return $(selector)[0].childNodes[0];
+        }
+    };
+
+    jqUnit.test("Test fluid.orator.selectionReader.parseElement", function () {
+        jqUnit.expect(fluid.tests.orator.selectionReader.parseElementTestCases.length);
+        var parser = fluid.textNodeParser();
+
+        fluid.each(fluid.tests.orator.selectionReader.parseElementTestCases, function (testCase) {
+            var elm = $(testCase.selector)[0];
+            var opts = fluid.copy(testCase.options);
+
+            if (fluid.get(opts, "startContainer")) {
+                opts.startContainer = fluid.tests.orator.selectionReader.selectorToTextNode(opts.startContainer);
+            }
+
+            if (fluid.get(opts, "endContainer")) {
+                opts.endContainer = fluid.tests.orator.selectionReader.selectorToTextNode(opts.endContainer);
+            }
+
+            var result = fluid.orator.selectionReader.parseElement(elm, parser.parse, opts);
+
+            jqUnit.assertDeepEq(testCase.name, testCase.expected, result);
+        });
+    });
+
+    jqUnit.test("Test fluid.orator.selectionReader.parseRange - element selected", function () {
+        var parser = fluid.textNodeParser();
+        var element = $(".flc-orator-selectionReader-test-selection");
+
+        var expected = [{
+            text: "Selection Test",
+            options: {lang: "en"}
+        }];
+
+        // Select Element
+        fluid.tests.orator.selection.selectNode(element);
+        var actual = fluid.orator.selectionReader.parseRange(fluid.tests.orator.selection.getSelectionRange(), parser.parse);
+        jqUnit.assertDeepEq("Speech[] should be generated correctly", expected, actual);
+
+        // clean up
+        fluid.tests.orator.selection.collapse();
+    });
+
+    jqUnit.test("Test fluid.orator.selectionReader.parseRange - text node selected", function () {
+        var parser = fluid.textNodeParser();
+        var node = $(".flc-orator-selectionReader-test-selection")[0].childNodes[0];
+
+        var expected = [{
+            text: "election",
+            options: {lang: "en"}
+        }];
+
+        // Select Element
+        fluid.tests.orator.selection.selectNodes(node, node, 1, 9);
+        var actual = fluid.orator.selectionReader.parseRange(fluid.tests.orator.selection.getSelectionRange(), parser.parse);
+        jqUnit.assertDeepEq("Speech[] should be generated correctly", expected, actual);
+
+        // clean up
+        fluid.tests.orator.selection.collapse();
+    });
+
+    jqUnit.test("Test fluid.orator.selectionReader.parseRange - selection across nodes", function () {
+        var parser = fluid.textNodeParser();
+        var startNode = $(".flc-orator-selectionReader-test-selectionThree")[0].childNodes[0];
+        var endNode = $(".flc-orator-selectionReader-test-selectionFour")[0].childNodes[0];
+
+        var expected = [{
+            text: "nge ",
+            options: {lang: "en"}
+        },
+        {
+            text: "Language",
+            options: {lang: "en-US"}
+        }];
+
+        // Select Element
+        fluid.tests.orator.selection.selectNodes(startNode, endNode, 3, endNode.textContent.length);
+        var actual = fluid.orator.selectionReader.parseRange(fluid.tests.orator.selection.getSelectionRange(), parser.parse);
+        jqUnit.assertDeepEq("Speech[] should be generated correctly", expected, actual);
+
+        // clean up
+        fluid.tests.orator.selection.collapse();
+    });
+
     /*******************************************************************************
      * IoC unit tests for fluid.orator.selectionReader
      *******************************************************************************/
@@ -1011,7 +1230,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             name: "fluid.orator.selectionReader",
             tests: [{
                 expect: 29,
-                name: "fluid.orator.selectionReader",
+                name: "control flow",
                 sequence: [{
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Init", "{that}.options.testOpts.expected.noSelection"],
@@ -1029,7 +1248,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     // play
                     func: "{selectionReader}.play",
-                    args: ["play", true]
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Play", "{that}.options.testOpts.expected.textPlay"],
@@ -1038,7 +1256,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     // stop
                     func: "{selectionReader}.stop",
-                    args: ["play", true]
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Stop", "{that}.options.testOpts.expected.textSelected"],

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -18,7 +18,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     "use strict";
 
     fluid.registerNamespace("fluid.tests");
-    
+
     /**
      * Ensures that TTS is supported in the browser, including the following cases:
      * - Feature is not detected

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -232,6 +232,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         tts.cancel();
     };
 
+    // Due to https://issues.fluidproject.org/browse/FLUID-6418
     // Need to wrap jqUnit.assertUndefined because the framework will throw an error when trying to resolve
     // {tts}.utterance after it has already been detached.
     fluid.tests.textToSpeech.testUtteranceDetached = function (msg, tts) {

--- a/tests/framework-tests/core/js/TextNodeParserTests.js
+++ b/tests/framework-tests/core/js/TextNodeParserTests.js
@@ -172,21 +172,25 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             listeners: {
                 "onParsedTextNode.record": {
                     listener: "fluid.tests.textNodeParser.record",
-                    args: ["{that}.record", "{arguments}.0", "{arguments}.1", "{arguments}.2"]
+                    args: ["{that}.record", "{arguments}.0"]
                 }
             }
         });
 
-        fluid.tests.textNodeParser.record = function (record, childNode, lang, childIndex) {
-            record.push({
-                text: childNode.textContent.trim(),
-                lang: lang,
-                childIndex: childIndex
-            });
+        fluid.tests.textNodeParser.nodeToText = function (textNodeData) {
+            return {
+                text: textNodeData.node.textContent.trim(),
+                lang: textNodeData.lang,
+                childIndex: textNodeData.childIndex
+            }
+        };
+
+        fluid.tests.textNodeParser.record = function (record, textNodeData) {
+            record.push(fluid.tests.textNodeParser.nodeToText(textNodeData));
         };
 
         jqUnit.test("Test fluid.textNodeParser", function () {
-            jqUnit.expect(1);
+            jqUnit.expect(2);
             var that = fluid.tests.textNodeParser({
                 listeners: {
                     "afterParse.test": {
@@ -197,7 +201,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     }
                 }
             });
-            that.parse($(".flc-textNodeParser-test"));
+            var parsed = that.parse($(".flc-textNodeParser-test"));
+            parsed = fluid.transform(parsed, fluid.tests.textNodeParser.nodeToText);
+
+            jqUnit.assertDeepEq("The returned parsed TextNodeData[] should be populated correctly.", fluid.tests.textNodeParser.parsed, parsed);
         });
 
     });

--- a/tests/framework-tests/core/js/TextNodeParserTests.js
+++ b/tests/framework-tests/core/js/TextNodeParserTests.js
@@ -182,7 +182,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 text: textNodeData.node.textContent.trim(),
                 lang: textNodeData.lang,
                 childIndex: textNodeData.childIndex
-            }
+            };
         };
 
         fluid.tests.textNodeParser.record = function (record, textNodeData) {

--- a/tests/framework-tests/preferences/html/CaptionsEnactor-test.html
+++ b/tests/framework-tests/preferences/html/CaptionsEnactor-test.html
@@ -25,8 +25,6 @@
         <script src="../../../../src/framework/renderer/js/RendererUtilities.js"></script>
         <script src="../../../../src/framework/enhancement/js/ContextAwareness.js"></script>
         <script src="../../../../src/framework/enhancement/js/ProgressiveEnhancement.js"></script>
-        <script src="../../../../src/components/textToSpeech/js/TextToSpeech.js"></script>
-        <script src="../../../../src/components/textToSpeech/js/MockTTS.js"></script>
         <script src="../../../../src/framework/preferences/js/UIEnhancer.js"></script>
         <script src="../../../../src/framework/preferences/js/PrefsEditor.js"></script>
         <script src="../../../../src/framework/preferences/js/Enactors.js"></script>

--- a/tests/framework-tests/preferences/html/LetterSpaceEnactor-test.html
+++ b/tests/framework-tests/preferences/html/LetterSpaceEnactor-test.html
@@ -24,8 +24,6 @@
         <script type="text/javascript" src="../../../../src/framework/renderer/js/RendererUtilities.js"></script>
         <script type="text/javascript" src="../../../../src/framework/enhancement/js/ContextAwareness.js"></script>
         <script type="text/javascript" src="../../../../src/framework/enhancement/js/ProgressiveEnhancement.js"></script>
-        <script type="text/javascript" src="../../../../src/components/textToSpeech/js/TextToSpeech.js"></script>
-        <script type="text/javascript" src="../../../../src/components/textToSpeech/js/MockTTS.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/UIEnhancer.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/PrefsEditor.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/Enactors.js"></script>

--- a/tests/framework-tests/preferences/html/LocalizationEnactor-test.html
+++ b/tests/framework-tests/preferences/html/LocalizationEnactor-test.html
@@ -24,8 +24,6 @@
         <script type="text/javascript" src="../../../../src/framework/renderer/js/RendererUtilities.js"></script>
         <script type="text/javascript" src="../../../../src/framework/enhancement/js/ContextAwareness.js"></script>
         <script type="text/javascript" src="../../../../src/framework/enhancement/js/ProgressiveEnhancement.js"></script>
-        <script type="text/javascript" src="../../../../src/components/textToSpeech/js/TextToSpeech.js"></script>
-        <script type="text/javascript" src="../../../../src/components/textToSpeech/js/MockTTS.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/UIEnhancer.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/PrefsEditor.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/Enactors.js"></script>

--- a/tests/framework-tests/preferences/html/WordSpaceEnactor-test.html
+++ b/tests/framework-tests/preferences/html/WordSpaceEnactor-test.html
@@ -24,8 +24,6 @@
         <script type="text/javascript" src="../../../../src/framework/renderer/js/RendererUtilities.js"></script>
         <script type="text/javascript" src="../../../../src/framework/enhancement/js/ContextAwareness.js"></script>
         <script type="text/javascript" src="../../../../src/framework/enhancement/js/ProgressiveEnhancement.js"></script>
-        <script type="text/javascript" src="../../../../src/components/textToSpeech/js/TextToSpeech.js"></script>
-        <script type="text/javascript" src="../../../../src/components/textToSpeech/js/MockTTS.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/UIEnhancer.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/PrefsEditor.js"></script>
         <script type="text/javascript" src="../../../../src/framework/preferences/js/Enactors.js"></script>


### PR DESCRIPTION
When reading through text, if the a language code is supplied it will be passed to the web speech api. This includes both reading through the page or a reading a selection.

https://issues.fluidproject.org/browse/FLUID-6278

dev release for testing: 3.0.0-dev.20191007T194251Z.4ef5356a5.FLUID-6278

Note: that there may be issues with MS Edge if the synthesizer for the particular language is not available. 

