### PR TITLE
FLUDI-6400: Prefs Framework primary schema updates

### DIFF
--- a/examples/framework/preferences/shared/js/primarySchema.js
+++ b/examples/framework/preferences/shared/js/primarySchema.js
@@ -30,14 +30,14 @@ var example = example || {};
             "default": 60,
             "minimum": 0,
             "maximum": 100,
-            "divisibleBy": 5
+            "multipleOf": 5
         },
         "example.wordsPerMinute": {
             "type": "number",
             "default": 180,
             "minimum": 130,
             "maximum": 250,
-            "divisibleBy": 10
+            "multipleOf": 10
         },
         "example.increaseSize": {
             "type": "boolean",
@@ -48,14 +48,14 @@ var example = example || {};
             "default": 2,
             "minimum": 1,
             "maximum": 5,
-            "divisibleBy": 1
+            "multipleOf": 1
         },
         "example.magnification": {
             "type": "number",
             "default": 100,
             "minimum": 100,
             "maximum": 400,
-            "divisibleBy": 10
+            "multipleOf": 10
         },
         "example.magnifierPosition": {
             "type": "string",

--- a/src/framework/preferences/js/LetterSpacePanel.js
+++ b/src/framework/preferences/js/LetterSpacePanel.js
@@ -30,7 +30,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "model.value": "value",
                 "range.min": "minimum",
                 "range.max": "maximum",
-                "step": "divisibleBy"
+                "step": "multipleOf"
             }
         },
         panelOptions: {

--- a/src/framework/preferences/js/LetterSpaceSchemas.js
+++ b/src/framework/preferences/js/LetterSpaceSchemas.js
@@ -73,7 +73,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "default": 1,
                 "minimum": 0.9,
                 "maximum": 2,
-                "divisibleBy": 0.1
+                "multipleOf": 0.1
             }
         }
     });

--- a/src/framework/preferences/js/LocalizationPanel.js
+++ b/src/framework/preferences/js/LocalizationPanel.js
@@ -28,7 +28,8 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         preferenceMap: {
             "fluid.prefs.localization": {
                 "model.value": "value",
-                "controlValues.localization": "enum"
+                "controlValues.localization": "enum",
+                "stringArrayIndex.localization": "enumLabels"
             }
         },
         mergePolicy: {
@@ -42,9 +43,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             localizationDescr: ".flc-prefsEditor-localization-descr"
         },
         selectorsToIgnore: ["header"],
-        stringArrayIndex: {
-            localization: ["localization-default", "localization-en", "localization-fr", "localization-es", "localization-fa"]
-        },
         protoTree: {
             label: {messagekey: "label"},
             localizationDescr: {messagekey: "description"},
@@ -53,9 +51,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 optionlist: "${{that}.options.controlValues.localization}",
                 selection: "${value}"
             }
-        },
-        controlValues: {
-            localization: ["default", "en", "fr", "es", "fa"]
         }
     });
 

--- a/src/framework/preferences/js/LocalizationSchemas.js
+++ b/src/framework/preferences/js/LocalizationSchemas.js
@@ -60,7 +60,14 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             "fluid.prefs.localization": {
                 "type": "string",
                 "default": "",
-                "enum": ["", "en", "en_CA", "en_US", "fr", "es", "fa"]
+                "enum": ["", "en", "en_CA", "en_US", "fr", "es", "fa"],
+                "enumLabels": [
+                    "localization-default",
+                    "localization-en",
+                    "localization-fr",
+                    "localization-es",
+                    "localization-fa"
+                ]
             }
         }
     });

--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -897,7 +897,8 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         preferenceMap: {
             "fluid.prefs.textFont": {
                 "model.value": "value",
-                "controlValues.textFont": "enum"
+                "controlValues.textFont": "enum",
+                "stringArrayIndex.textFont": "enumLabels"
             }
         },
         mergePolicy: {
@@ -911,9 +912,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             textFontDescr: ".flc-prefsEditor-text-font-descr"
         },
         selectorsToIgnore: ["header"],
-        stringArrayIndex: {
-            textFont: ["textFont-default", "textFont-times", "textFont-comic", "textFont-arial", "textFont-verdana", "textFont-open-dyslexic"]
-        },
         protoTree: {
             label: {messagekey: "textFontLabel"},
             textFontDescr: {messagekey: "textFontDescr"},
@@ -930,10 +928,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 }
             }
         },
-        classnameMap: null, // must be supplied by implementors
-        controlValues: {
-            textFont: ["default", "times", "comic", "arial", "verdana", "open-dyslexic"]
-        }
+        classnameMap: null // must be supplied by implementors
     });
 
     /*********************************
@@ -970,7 +965,8 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         preferenceMap: {
             "fluid.prefs.contrast": {
                 "model.value": "value",
-                "controlValues.theme": "enum"
+                "controlValues.theme": "enum",
+                "stringArrayIndex.theme": "enumLabels"
             }
         },
         listeners: {
@@ -987,22 +983,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         selectorsToIgnore: ["header"],
         styles: {
             defaultThemeLabel: "fl-prefsEditor-themePicker-defaultThemeLabel"
-        },
-        stringArrayIndex: {
-            theme: [
-                "contrast-default",
-                "contrast-bw",
-                "contrast-wb",
-                "contrast-by",
-                "contrast-yb",
-                "contrast-lgdg",
-                "contrast-gw",
-                "contrast-gd",
-                "contrast-bbr"
-            ]
-        },
-        controlValues: {
-            theme: ["default", "bw", "wb", "by", "yb", "lgdg", "gw", "gd", "bbr"]
         }
     });
 

--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -877,7 +877,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "model.value": "value",
                 "range.min": "minimum",
                 "range.max": "maximum",
-                "step": "divisibleBy"
+                "step": "multipleOf"
             }
         },
         panelOptions: {
@@ -950,7 +950,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "model.value": "value",
                 "range.min": "minimum",
                 "range.max": "maximum",
-                "step": "divisibleBy"
+                "step": "multipleOf"
             }
         },
         panelOptions: {

--- a/src/framework/preferences/js/StarterGrades.js
+++ b/src/framework/preferences/js/StarterGrades.js
@@ -238,6 +238,19 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                     messageBase: "{messageLoader}.resources.textFont.resourceText",
                     resources: {
                         template: "{templateLoader}.resources.textFont"
+                    },
+                    stringArrayIndex: {
+                        textFont: [
+                            "textFont-default",
+                            "textFont-times",
+                            "textFont-comic",
+                            "textFont-arial",
+                            "textFont-verdana",
+                            "textFont-open-dyslexic"
+                        ]
+                    },
+                    controlValues: {
+                        textFont: ["default", "times", "comic", "arial", "verdana", "open-dyslexic"]
                     }
                 }
             },
@@ -254,6 +267,22 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                     messageBase: "{messageLoader}.resources.contrast.resourceText",
                     resources: {
                         template: "{templateLoader}.resources.contrast"
+                    },
+                    stringArrayIndex: {
+                        theme: [
+                            "contrast-default",
+                            "contrast-bw",
+                            "contrast-wb",
+                            "contrast-by",
+                            "contrast-yb",
+                            "contrast-lgdg",
+                            "contrast-gw",
+                            "contrast-gd",
+                            "contrast-bbr"
+                        ]
+                    },
+                    controlValues: {
+                        theme: ["default", "bw", "wb", "by", "yb", "lgdg", "gw", "gd", "bbr"]
                     }
                 }
             },

--- a/src/framework/preferences/js/StarterSchemas.js
+++ b/src/framework/preferences/js/StarterSchemas.js
@@ -191,7 +191,15 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             "fluid.prefs.textFont": {
                 "type": "string",
                 "default": "default",
-                "enum": ["default", "times", "comic", "arial", "verdana", "open-dyslexic"]
+                "enum": ["default", "times", "comic", "arial", "verdana", "open-dyslexic"],
+                "enumLabels": [
+                    "textFont-default",
+                    "textFont-times",
+                    "textFont-comic",
+                    "textFont-arial",
+                    "textFont-verdana",
+                    "textFont-open-dyslexic"
+                ]
             }
         }
     });
@@ -202,7 +210,18 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             "fluid.prefs.contrast": {
                 "type": "string",
                 "default": "default",
-                "enum": ["default", "bw", "wb", "by", "yb", "lgdg", "gw", "gd", "bbr"]
+                "enum": ["default", "bw", "wb", "by", "yb", "lgdg", "gw", "gd", "bbr"],
+                "enumLabels": [
+                    "contrast-default",
+                    "contrast-bw",
+                    "contrast-wb",
+                    "contrast-by",
+                    "contrast-yb",
+                    "contrast-lgdg",
+                    "contrast-gw",
+                    "contrast-gd",
+                    "contrast-bbr"
+                ]
             }
         }
     });

--- a/src/framework/preferences/js/StarterSchemas.js
+++ b/src/framework/preferences/js/StarterSchemas.js
@@ -167,7 +167,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "default": 1,
                 "minimum": 0.5,
                 "maximum": 2,
-                "divisibleBy": 0.1
+                "multipleOf": 0.1
             }
         }
     });
@@ -180,7 +180,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "default": 1,
                 "minimum": 0.7,
                 "maximum": 2,
-                "divisibleBy": 0.1
+                "multipleOf": 0.1
             }
         }
     });

--- a/src/framework/preferences/js/WordSpacePanel.js
+++ b/src/framework/preferences/js/WordSpacePanel.js
@@ -30,7 +30,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "model.value": "value",
                 "range.min": "minimum",
                 "range.max": "maximum",
-                "step": "divisibleBy"
+                "step": "multipleOf"
             }
         },
         panelOptions: {

--- a/src/framework/preferences/js/WordSpaceSchemas.js
+++ b/src/framework/preferences/js/WordSpaceSchemas.js
@@ -73,7 +73,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 "default": 1,
                 "minimum": 0.7,
                 "maximum": 2,
-                "divisibleBy": 0.1
+                "multipleOf": 0.1
             }
         }
     });

--- a/tests/framework-tests/core/js/FluidJSTests.js
+++ b/tests/framework-tests/core/js/FluidJSTests.js
@@ -1102,7 +1102,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "default": 1,
                 "min": 1,
                 "max": 2,
-                "divisibleBy": 0.1
+                "multipleOf": 0.1
             }
         }
     });

--- a/tests/framework-tests/preferences/js/AuxBuilderTests.js
+++ b/tests/framework-tests/preferences/js/AuxBuilderTests.js
@@ -625,7 +625,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             "default": 1,
             "minimum": 1,
             "maximum": 2,
-            "divisibleBy": 0.1
+            "multipleOf": 0.1
         },
         "fluid.prefs.emphasizeLinks": {
             "type": "boolean",
@@ -1508,7 +1508,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "model.value": "value",
                 "range.min": "minimum",
                 "range.max": "maximum",
-                "model.step": "divisibleBy" // to test that model paths without the "default" keyword are mapped correctly.
+                "model.step": "multipleOf" // to test that model paths without the "default" keyword are mapped correctly.
             }
         }
     });
@@ -1546,7 +1546,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             "default": false,
             "minimum": 20,
             "maximum": 100,
-            "divisibleBy": 0.1
+            "multipleOf": 0.1
         },
         "fluid.prefs.subPanel4": {
             "type": "boolean",

--- a/tests/framework-tests/preferences/js/AuxBuilderTests.js
+++ b/tests/framework-tests/preferences/js/AuxBuilderTests.js
@@ -320,7 +320,14 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "fluid.prefs.contrast": {
                     "type": "string",
                     "default": "default",
-                    "enum": ["default", "bw", "wb", "by", "yb"]
+                    "enum": ["default", "bw", "wb", "by", "yb"],
+                    "enumLabels": [
+                        "contrast-default",
+                        "contrast-bw",
+                        "contrast-wb",
+                        "contrast-by",
+                        "contrast-yb"
+                    ]
                 }
             },
             expectedOutput: {
@@ -372,6 +379,15 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                                 },
                                 controlValues: {
                                     theme: ["default", "bw", "wb", "by", "yb"]
+                                },
+                                stringArrayIndex: {
+                                    theme: [
+                                        "contrast-default",
+                                        "contrast-bw",
+                                        "contrast-wb",
+                                        "contrast-by",
+                                        "contrast-yb"
+                                    ]
                                 },
                                 resources: {
                                     template: "templateLoader.resources.fluid_tests_prefs_panel_contrast"

--- a/tests/framework-tests/preferences/js/LocalizationPanelTests.js
+++ b/tests/framework-tests/preferences/js/LocalizationPanelTests.js
@@ -38,6 +38,18 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             template: {
                 href: "../../../../src/framework/preferences/html/PrefsEditorTemplate-localization.html"
             }
+        },
+        stringArrayIndex: {
+            localization: [
+                "localization-default",
+                "localization-en",
+                "localization-fr",
+                "localization-es",
+                "localization-fa"
+            ]
+        },
+        controlValues: {
+            localization: ["default", "en", "fr", "es", "fa"]
         }
     });
 

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -1030,6 +1030,19 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "verdana": "fl-font-verdana",
                 "open-dyslexic": "fl-font-open-dyslexic"
             }
+        },
+        stringArrayIndex: {
+            textFont: [
+                "textFont-default",
+                "textFont-times",
+                "textFont-comic",
+                "textFont-arial",
+                "textFont-verdana",
+                "textFont-open-dyslexic"
+            ]
+        },
+        controlValues: {
+            textFont: ["default", "times", "comic", "arial", "verdana", "open-dyslexic"]
         }
     });
 
@@ -1182,6 +1195,22 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "gw": "fl-theme-gw",
                 "bbr": "fl-theme-bbr"
             }
+        },
+        stringArrayIndex: {
+            theme: [
+                "contrast-default",
+                "contrast-bw",
+                "contrast-wb",
+                "contrast-by",
+                "contrast-yb",
+                "contrast-lgdg",
+                "contrast-gw",
+                "contrast-gd",
+                "contrast-bbr"
+            ]
+        },
+        controlValues: {
+            theme: ["default", "bw", "wb", "by", "yb", "lgdg", "gw", "gd", "bbr"]
         }
     });
 

--- a/tests/framework-tests/preferences/js/PrimaryBuilderTests.js
+++ b/tests/framework-tests/preferences/js/PrimaryBuilderTests.js
@@ -28,7 +28,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     "default": 1,
                     "minimum": 1,
                     "maximum": 10,
-                    "divisibleBy": 1
+                    "multipleOf": 1
                 }
             }
         }
@@ -44,7 +44,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     "default": 1,
                     "minimum": 1,
                     "maximum": 2,
-                    "divisibleBy": 0.2
+                    "multipleOf": 0.2
                 }
             }
         }
@@ -87,7 +87,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                             "default": 1,
                             "minimum": 1,
                             "maximum": 10,
-                            "divisibleBy": 1
+                            "multipleOf": 1
                         },
                         "fluid.prefs.textSize": fluid.defaults(
                             "fluid.tests.customTextSize").schema.properties["fluid.prefs.textSize"]
@@ -160,7 +160,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             "fluid.prefs.contrast"
         ]);
         jqUnit.assertEquals("Supplied primary schema should override the default schema grades",
-            0.2, schema.properties["fluid.prefs.textSize"].divisibleBy);
+            0.2, schema.properties["fluid.prefs.textSize"].multipleOf);
     };
 
     fluid.tests.primaryBuilder = function (schema) {


### PR DESCRIPTION
First steps for Prefs Framework refactoring. Updating the primary schema entries to use `multipleOf` instead of `divisibleBy` and to have a property for `enumLabels`.

https://issues.fluidproject.org/browse/FLUID-6400