### PR TITLE
FLUID-6422: Refactoring fluid.textNodeParser.hasTextToRead

### DIFF
--- a/src/components/orator/js/Orator.js
+++ b/src/components/orator/js/Orator.js
@@ -307,9 +307,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             parser: {
                 type: "fluid.textNodeParser",
                 options: {
-                    invokers: {
-                        hasTextToRead: "fluid.textNodeParser.hasVisibleText"
-                    },
                     listeners: {
                         "onParsedTextNode.addToParseQueue": "{domReader}.addToParseQueue"
                     }
@@ -855,12 +852,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         },
         components: {
             parser: {
-                type: "fluid.textNodeParser",
-                options: {
-                    invokers: {
-                        hasTextToRead: "fluid.textNodeParser.hasVisibleText"
-                    }
-                }
+                type: "fluid.textNodeParser"
             }
         },
         listeners: {

--- a/src/framework/core/js/TextNodeParser.js
+++ b/src/framework/core/js/TextNodeParser.js
@@ -55,37 +55,28 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * Determines if there is text in an element that should be read.
      * Will return false in the following conditions:
      * - elm is falsey (undefined, null, etc.)
-     * - elm's offsetHeight is 0 (e.g. display none set on itself or its parent)
+     * - elm's offsetParent is falsey, unless elm is the `body` element
      * - elm has no text or only whitespace
+     * - elm or an ancestor has "aria-hidden=true", unless the `acceptAriaHidden` parameter is set
      *
      * NOTE: Text added by pseudo elements (e.g. :before, :after) are not considered.
-     * NOTE: This method is not supported in IE 11 because innerText returns the text for some hidden elements
+     * NOTE: This method is not supported in IE 11 because innerText returns the text for some hidden elements,
      *       that is inconsistent with modern browsers.
      *
      * @param {jQuery|DomElement} elm - either a DOM node or a jQuery element
+     * @param {Boolean} acceptAriaHidden - if set, will return `true` even if the `elm` or one of its ancestors has
+     *                                    `aria-hidden="true"`.
      *
      * @return {Boolean} - returns true if there is rendered text within the element and false otherwise.
-     *                     (See rules above)
+     *                     (See conditions in description above)
      */
-    fluid.textNodeParser.hasTextToRead = function (elm) {
+    fluid.textNodeParser.hasTextToRead = function (elm, acceptAriaHidden) {
         elm = fluid.unwrap(elm);
 
         return elm &&
-               !!elm.offsetHeight &&
-               fluid.textNodeParser.isWord(elm.innerText);
-    };
-
-    /**
-     * Similar to `fluid.textNodeParser.hasTextToRead` except adds the following condition:
-     * - elm or its parent has `aria-hidden="true"` set.
-     *
-     * @param {jQuery|DomElement} elm - either a DOM node or a jQuery element
-     *
-     * @return {Boolean} - returns true if there is rendered text within the element and false otherwise.
-     *                     (See rules above)
-     */
-    fluid.textNodeParser.hasVisibleText = function (elm) {
-        return fluid.textNodeParser.hasTextToRead(elm) && !$(elm).closest("[aria-hidden=\"true\"]").length;
+               (elm.tagName.toLowerCase() === "body" || elm.offsetParent) &&
+               fluid.textNodeParser.isWord(elm.innerText) &&
+               (acceptAriaHidden || !$(elm).closest("[aria-hidden=\"true\"]").length);
     };
 
     /**

--- a/src/framework/preferences/js/SyllabificationEnactor.js
+++ b/src/framework/preferences/js/SyllabificationEnactor.js
@@ -77,6 +77,13 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                     listeners: {
                         "afterParse.boil": "{syllabification}.events.afterParse",
                         "onParsedTextNode.boil": "{syllabification}.events.onParsedTextNode"
+                    },
+                    invokers: {
+                        hasTextToRead: {
+                            // apply to text nodes even if they have the ariaHidden attribute set
+                            funcName: "fluid.textNodeParser.hasTextToRead",
+                            args: ["{arguments}.0", true]
+                        }
                     }
                 }
             },

--- a/tests/framework-tests/core/html/TextNodeParser-test.html
+++ b/tests/framework-tests/core/html/TextNodeParser-test.html
@@ -5,6 +5,7 @@
         <title>Text Node Parser tests</title>
 
         <link rel="stylesheet" media="screen" href="../../../lib/qunit/css/qunit.css" />
+        <link rel="stylesheet" media="screen" href="../../../../src/framework/core/css/fluid.css" />
 
         <script src="../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script src="../../../../src/framework/core/js/Fluid.js"></script>
@@ -67,6 +68,16 @@
                     var div2 = $("<div>");
                 </script>
             </span>
+            <div class="flc-textNodeParser-test-checkDOMText-floatParent">
+                <div style="float:left">Left</div>
+                <div style="float:right">Right</div>
+            </div>
+            <div class="flc-textNodeParser-test-checkDOMText-fixedParent">
+                <div style="position:fixed; bottom: 0; right: 0">Position: Fixed</div>
+            </div>
+            <div class="flc-textNodeParser-test-checkDOMText-absoluteParent">
+                <div style="position:absolute; bottom: 1rem; right: 0">Position: Absolute</div>
+            </div>
         </div>
 
         <div class="flc-textNodeParser-test-lang-none">

--- a/tests/framework-tests/core/js/TextNodeParserTests.js
+++ b/tests/framework-tests/core/js/TextNodeParserTests.js
@@ -45,54 +45,48 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
          * fluid.textNodeParser.hasTextToRead Tests
          ****************************************************************/
 
-        fluid.tests.textNodeParser.assertTextToRead = function (textToReadFn, testCases) {
+        fluid.tests.textNodeParser.assertTextToRead = function (testCases) {
             // The innerText method called in fluid.textNodeParser.hasTextToRead returns text from some hidden elements
             // that modern browsers do not.
             if ($.browser.msie) {
                 jqUnit.assert("Tests were not run because innerText works differently on IE 11 and is used for a feature not supported in IE");
             } else {
-                // test trueCase
-                fluid.each(testCases.trueCase, function (selector) {
-                    jqUnit.assertTrue("\"" + selector + "\" should have text to read.", textToReadFn($(selector)));
+                var checkAriaHidden = true;
+                var hasTextNoAriaHiddenCheck =  testCases.hasTextToRead.concat(testCases.ariaHidden);
+                var noTextWithAriaHiddenCheck = testCases.noTextToRead.concat(testCases.ariaHidden);
+
+                // test has text to read
+                fluid.each(testCases.hasTextToRead, function (selector) {
+                    jqUnit.assertTrue("\"" + selector + "\" should have text to read.", fluid.textNodeParser.hasTextToRead($(selector), checkAriaHidden));
+                });
+                fluid.each(hasTextNoAriaHiddenCheck, function (selector) {
+                    jqUnit.assertTrue("acceptAriaHidden = true - \"" + selector + "\" should have text to read.", fluid.textNodeParser.hasTextToRead($(selector), true));
                 });
 
-                // test falseCase
-                fluid.each(testCases.falseCase, function (selector) {
-                    jqUnit.assertFalse("\"" + selector + "\" shouldn't have text to read.", textToReadFn($(selector)));
+                // test no text to read
+                fluid.each(noTextWithAriaHiddenCheck, function (selector) {
+                    jqUnit.assertFalse("\"" + selector + "\" shouldn't have text to read.", fluid.textNodeParser.hasTextToRead($(selector)));
+                });
+                fluid.each(testCases.noTextToRead, function (selector) {
+                    jqUnit.assertFalse("acceptAriaHidden = true - \"" + selector + "\" shouldn't have text to read.", fluid.textNodeParser.hasTextToRead($(selector), true));
                 });
             }
         };
 
         fluid.tests.textNodeParser.hasTextToReadTestCases = {
-            "trueCase": [
-                ".flc-textNodeParser-test-checkDOMText"
-            ],
-            "falseCase": [
-                ".flc-textNodeParser-test-checkDOMText-noNode",
-                ".flc-textNodeParser-test-checkDOMText-empty",
-                ".flc-textNodeParser-test-checkDOMText-script",
-                ".flc-textNodeParser-test-checkDOMText-nestedScript"
-            ]
-        };
-
-        jqUnit.test("Test fluid.textNodeParser.hasTextToRead", function () {
-            fluid.tests.textNodeParser.assertTextToRead(fluid.textNodeParser.hasTextToRead, fluid.tests.textNodeParser.hasTextToReadTestCases);
-        });
-
-        /****************************************************************
-         * fluid.textNodeParser.hasTextToRead Tests
-         ****************************************************************/
-
-        fluid.tests.textNodeParser.hasVisibleTextToReadTestCases = {
-            "trueCase": [
+            "hasTextToRead": [
+                "body",
                 ".flc-textNodeParser-test-checkDOMText",
                 ".flc-textNodeParser-test-checkDOMText-ariaHiddenFalse",
                 ".flc-textNodeParser-test-checkDOMText-ariaHiddenFalse-nested",
                 ".flc-textNodeParser-test-checkDOMText-hiddenA11y",
                 ".flc-textNodeParser-test-checkDOMText-hiddenA11y-nested",
-                ".flc-textNodeParser-test-checkDOMText-visible"
+                ".flc-textNodeParser-test-checkDOMText-visible",
+                ".flc-textNodeParser-test-checkDOMText-floatParent",
+                ".flc-textNodeParser-test-checkDOMText-fixedParent",
+                ".flc-textNodeParser-test-checkDOMText-absoluteParent"
             ],
-            "falseCase": [
+            "noTextToRead": [
                 ".flc-textNodeParser-test-checkDOMText-noNode",
                 ".flc-textNodeParser-test-checkDOMText-none",
                 ".flc-textNodeParser-test-checkDOMText-none-nested",
@@ -100,17 +94,19 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 ".flc-textNodeParser-test-checkDOMText-visHidden-nested",
                 ".flc-textNodeParser-test-checkDOMText-hidden",
                 ".flc-textNodeParser-test-checkDOMText-hidden-nested",
-                ".flc-textNodeParser-test-checkDOMText-ariaHiddenTrue",
-                ".flc-textNodeParser-test-checkDOMText-ariaHiddenTrue-nested",
                 ".flc-textNodeParser-test-checkDOMText-nestedNone",
                 ".flc-textNodeParser-test-checkDOMText-empty",
                 ".flc-textNodeParser-test-checkDOMText-script",
                 ".flc-textNodeParser-test-checkDOMText-nestedScript"
+            ],
+            "ariaHidden": [
+                ".flc-textNodeParser-test-checkDOMText-ariaHiddenTrue",
+                ".flc-textNodeParser-test-checkDOMText-ariaHiddenTrue-nested"
             ]
         };
 
-        jqUnit.test("Test fluid.textNodeParser.hasVisibleText", function () {
-            fluid.tests.textNodeParser.assertTextToRead(fluid.textNodeParser.hasVisibleText, fluid.tests.textNodeParser.hasTextToReadTestCases);
+        jqUnit.test("Test fluid.textNodeParser.hasTextToRead", function () {
+            fluid.tests.textNodeParser.assertTextToRead(fluid.tests.textNodeParser.hasTextToReadTestCases);
         });
 
         /****************************************************************


### PR DESCRIPTION
- combined with fluid.textNodeParser.hasVisibleText
- improvements to algorithm for ignoring non-rendered text

Dev release to test with UIO+: 3.0.0-dev.20191104T213827Z.4f3dd87a8.FLUID-6422-UIO-Plus-Build (has merged FLUID-6148 branch)

https://issues.fluidproject.org/browse/FLUID-6422