### PR TITLE
FLUID-6431: Updating selection button rendering on text change.

### DIFF
--- a/src/components/orator/js/Orator.js
+++ b/src/components/orator/js/Orator.js
@@ -841,7 +841,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
         },
         model: {
             enabled: true,
-            showUI: false,
             play: false,
             text: ""
         },
@@ -869,15 +868,14 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             "onToggleControl.togglePlay": "{that}.toggle"
         },
         modelListeners: {
-            "showUI": {
+            "text": [{
+                func: "{that}.stop",
+                namespace: "stopPlayingWhenTextChanges"
+            }, {
                 funcName: "fluid.orator.selectionReader.renderControl",
                 args: ["{that}", "{change}.value"],
                 namespace: "render"
-            },
-            "text": {
-                func: "{that}.stop",
-                namespace: "stopPlayingWhenTextChanges"
-            },
+            }],
             "play": [{
                 func: "fluid.orator.selectionReader.queueSpeech",
                 args: ["{that}", "{change}.value", "{fluid.textToSpeech}.queueSpeechSequence"],
@@ -894,15 +892,6 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
                 namespace: "updateText"
             }
         },
-        modelRelay: [{
-            source: "text",
-            target: "showUI",
-            backward: "never",
-            namespace: "showUIControl",
-            singleTransform: {
-                type: "fluid.transforms.stringToBoolean"
-            }
-        }],
         invokers: {
             getSelection: {
                 funcName: "fluid.orator.selectionReader.getSelection",

--- a/tests/component-tests/orator/js/OratorTests-Utils.js
+++ b/tests/component-tests/orator/js/OratorTests-Utils.js
@@ -161,7 +161,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     fluid.tests.orator.verifySelectionState = function (that, testPrefix, expectedModel) {
         jqUnit.assertDeepEq(testPrefix + ": The model should be set correctly.", expectedModel, that.model);
 
-        if (expectedModel.showUI) {
+        if (expectedModel.text) {
             fluid.tests.orator.assertNodeInDOM(testPrefix + ": The selection control should be present", that.control);
             jqUnit.assertFalse(testPrefix + ": The selection control should not be hidden", that.control.prop("hidden"));
 

--- a/tests/component-tests/orator/js/OratorTests.js
+++ b/tests/component-tests/orator/js/OratorTests.js
@@ -1198,7 +1198,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         gradeNames: ["fluid.orator.selectionReader"],
         // gradeNames: ["fluid.orator.selectionReader", "fluid.tests.orator.mockTTS"],
         model: {
-            showUI: false,
             play: false,
             text: "",
             enabled: true
@@ -1230,31 +1229,26 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         testOpts: {
             expected: {
                 noSelection: {
-                    showUI: false,
                     play: false,
                     text: "",
                     enabled: true
                 },
                 textSelected: {
-                    showUI: true,
                     play: false,
                     text: "Selection Test",
                     enabled: true
                 },
                 textPlay: {
-                    showUI: true,
                     play: true,
                     text: "Selection Test",
                     enabled: true
                 },
                 text2Selected: {
-                    showUI: true,
                     play: false,
                     text: "Other Text",
                     enabled: true
                 },
                 disabled: {
-                    showUI: false,
                     play: false,
                     text: "",
                     enabled: false
@@ -1278,7 +1272,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Selection", "{that}.options.testOpts.expected.textSelected"],
-                    spec: {priority: "last:testing", path: "showUI"},
+                    spec: {priority: "last:testing", path: "text"},
                     changeEvent: "{selectionReader}.applier.modelChanged"
                 }, {
                     // play
@@ -1320,7 +1314,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Selection Collapsed", "{that}.options.testOpts.expected.noSelection"],
-                    spec: {priority: "last:testing", path: "showUI"},
+                    spec: {priority: "last:testing", path: "text"},
                     changeEvent: "{selectionReader}.applier.modelChanged"
                 }, {
                     // Disable after selection
@@ -1329,7 +1323,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Selection before disabled", "{that}.options.testOpts.expected.text2Selected"],
-                    spec: {priority: "last:testing", path: "showUI"},
+                    spec: {priority: "last:testing", path: "text"},
                     changeEvent: "{selectionReader}.applier.modelChanged"
                 }, {
                     func: "{selectionReader}.applier.change",
@@ -1337,7 +1331,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Disabled", "{that}.options.testOpts.expected.disabled"],
-                    spec: {priority: "last:testing", path: "showUI"},
+                    spec: {priority: "last:testing", path: "text"},
                     changeEvent: "{selectionReader}.applier.modelChanged"
                 }, {
                     // Selection while disabled
@@ -1353,7 +1347,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selectionReader}", "Enabled after selection", "{that}.options.testOpts.expected.text2Selected"],
-                    spec: {priority: "last:testing", path: "showUI"},
+                    spec: {priority: "last:testing", path: "text"},
                     changeEvent: "{selectionReader}.applier.modelChanged"
                 }]
             }]
@@ -1451,7 +1445,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         jqUnit.notVisible("The controller should not be visible when it is disabled", that.controller.container);
         jqUnit.assertFalse("The domReader should be disabled", that.domReader.model.enabled);
         fluid.tests.orator.verifySelectionState(that.selectionReader, "selectionReader disabled by orator", {
-            showUI: false,
             play: false,
             text: "",
             enabled: false

--- a/tests/framework-tests/preferences/js/SelfVoicingEnactorTests.js
+++ b/tests/framework-tests/preferences/js/SelfVoicingEnactorTests.js
@@ -119,7 +119,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selfVoicing}.orator.selectionReader", "Selection", {
-                        showUI: true,
                         play: false,
                         text: "text",
                         enabled: true
@@ -132,12 +131,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 }, {
                     listener: "fluid.tests.orator.verifySelectionState",
                     args: ["{selfVoicing}.orator.selectionReader", "Remove Selection UI", {
-                        showUI: false,
                         play: false,
                         text: "",
                         enabled: false
                     }],
-                    spec: {priority: "last:testing", path: "showUI"},
+                    spec: {priority: "last:testing", path: "text"},
                     changeEvent: "{selfVoicing}.orator.selectionReader.applier.modelChanged"
                 }]
             }]


### PR DESCRIPTION
Right Clicks in some browsers also perform a selection. In Safari and 
Chrome those selectionchange events fire twice but with the same text 
selection so there is no time where the UI would have been removed. By 
rendering the text on all selection changes, the UI is always at the 
beginning of the text and will follow right click selections.

https://issues.fluidproject.org/browse/FLUID-6431