### PR TITLE
FLUID-6482: add guard to fluid.getCallerInfo if atDepth exceeds stack size

### DIFF
--- a/src/framework/core/js/FluidDebugging.js
+++ b/src/framework/core/js/FluidDebugging.js
@@ -138,7 +138,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
     fluid.getCallerInfo = function (atDepth) {
         atDepth = (atDepth || 3) - stackStyle.offset;
         var stack = fluid.decodeStack();
-        var element = stack && stack[atDepth][0];
+        var element = stack && stack[atDepth] && stack[atDepth][0];
         if (element) {
             var lastslash = element.lastIndexOf("/");
             if (lastslash === -1) {


### PR DESCRIPTION
See https://issues.fluidproject.org/browse/FLUID-6482 for details of this issue (seen on Safari).