### PR TITLE
FLUID-6486: vagrant: Use Fedora 31 box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ ram = ENV["VM_RAM"] || 2048
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "inclusivedesign/fedora28"
+  config.vm.box = "inclusivedesign/fedora31"
 
   # Your working directory will be synced to /home/vagrant/sync in the VM.
   config.vm.synced_folder ".", "#{app_directory}"


### PR DESCRIPTION
We're currently using Fedora 28 which went [End-Of-Life](https://fedoraproject.org/wiki/End_of_life) (EOL) on 2019-05-28. It also means we're testing with Firefox 66 which was released in March 2019.