### PR TITLE
FLUID-6454: Removed title attribute from navbar

### DIFF
--- a/demos/pager/css/pager.css
+++ b/demos/pager/css/pager.css
@@ -138,4 +138,3 @@
  .demo-pager-next-character::after {
      content: ">";
  }
- 

--- a/demos/pager/css/pager.css
+++ b/demos/pager/css/pager.css
@@ -127,3 +127,14 @@
  .demo-pager-page-size  label {
     margin-right: 2px;
  }
+
+ /***********************************************
+ * Styles for pager previous and next page symbol
+ */
+ .demo-pager-previous-character::before {
+     content: "<";
+ }
+
+ .demo-pager-next-character::after {
+     content: ">";
+ }

--- a/demos/pager/css/pager.css
+++ b/demos/pager/css/pager.css
@@ -138,3 +138,4 @@
  .demo-pager-next-character::after {
      content: ">";
  }
+ 

--- a/demos/pager/css/pager.css
+++ b/demos/pager/css/pager.css
@@ -127,14 +127,3 @@
  .demo-pager-page-size  label {
     margin-right: 2px;
  }
-
- /***********************************************
- * Styles for pager previous and next page symbol
- */
- .demo-pager-previous-character::before {
-     content: "<";
- }
-
- .demo-pager-next-character::after {
-     content: ">";
- }

--- a/demos/pager/index.html
+++ b/demos/pager/index.html
@@ -62,7 +62,7 @@
 
             <div class="flc-pager-top">
                 <ul class="demo-pager-bar fl-force-left fl-focus">
-                    <li class="flc-pager-previous demo-pager-previous"><a href="#">&lt; Previous</a></li>
+                    <li class="flc-pager-previous demo-pager-previous"><a href="#"><span class="demo-pager-previous-character"></span> Previous</a></li>
                     <li>
                         <ul class="flc-pager-links demo-pager-links">
                             <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
@@ -70,7 +70,7 @@
                             <li class="flc-pager-pageLink"><a href="#">2</a></li>
                         </ul>
                     </li>
-                    <li class="demo-pager-next flc-pager-next"><a href="#">Next &gt;</a></li>
+                    <li class="demo-pager-next flc-pager-next"><a href="#">Next <span class="demo-pager-next-character"></span></a></li>
                 </ul>
             </div>
 
@@ -108,7 +108,7 @@
 
             <div class="flc-pager-bottom">
                 <ul class="demo-pager-bar fl-force-left fl-focus">
-                    <li class="flc-pager-previous demo-pager-previous"><a href="#">&lt; Previous</a></li>
+                    <li class="flc-pager-previous demo-pager-previous"><a href="#"><span class="demo-pager-previous-character"></span> Previous</a></li>
                     <li>
                         <ul class="flc-pager-links demo-pager-links">
                             <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
@@ -116,7 +116,7 @@
                             <li class="flc-pager-pageLink"><a href="#">2</a></li>
                         </ul>
                     </li>
-                    <li class="flc-pager-next demo-pager-next"><a href="#">Next &gt;</a></li>
+                    <li class="flc-pager-next demo-pager-next"><a href="#">Next <span class="demo-pager-next-character"></span></a></li>
                 </ul>
             </div>
 

--- a/demos/pager/index.html
+++ b/demos/pager/index.html
@@ -62,7 +62,7 @@
 
             <div class="flc-pager-top">
                 <ul class="demo-pager-bar fl-force-left fl-focus">
-                    <li class="flc-pager-previous demo-pager-previous"><a href="#" title="Previous Page">&lt; Previous</a></li>
+                    <li class="flc-pager-previous demo-pager-previous"><a href="#">&lt; Previous</a></li>
                     <li>
                         <ul class="flc-pager-links demo-pager-links">
                             <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
@@ -70,7 +70,7 @@
                             <li class="flc-pager-pageLink"><a href="#">2</a></li>
                         </ul>
                     </li>
-                    <li class="demo-pager-next flc-pager-next"><a href="#" title="Next Page">Next &gt;</a></li>
+                    <li class="demo-pager-next flc-pager-next"><a href="#">Next &gt;</a></li>
                 </ul>
             </div>
 

--- a/demos/pager/index.html
+++ b/demos/pager/index.html
@@ -62,7 +62,7 @@
 
             <div class="flc-pager-top">
                 <ul class="demo-pager-bar fl-force-left fl-focus">
-                    <li class="flc-pager-previous demo-pager-previous"><a href="#"><span class="demo-pager-previous-character"></span> Previous</a></li>
+                    <li class="flc-pager-previous demo-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#"> Previous</a></li>
                     <li>
                         <ul class="flc-pager-links demo-pager-links">
                             <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
@@ -70,7 +70,7 @@
                             <li class="flc-pager-pageLink"><a href="#">2</a></li>
                         </ul>
                     </li>
-                    <li class="demo-pager-next flc-pager-next"><a href="#">Next <span class="demo-pager-next-character"></span></a></li>
+                    <li class="demo-pager-next flc-pager-next"><a href="#">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
                 </ul>
             </div>
 
@@ -108,7 +108,7 @@
 
             <div class="flc-pager-bottom">
                 <ul class="demo-pager-bar fl-force-left fl-focus">
-                    <li class="flc-pager-previous demo-pager-previous"><a href="#"><span class="demo-pager-previous-character"></span> Previous</a></li>
+                    <li class="flc-pager-previous demo-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#"> Previous</a></li>
                     <li>
                         <ul class="flc-pager-links demo-pager-links">
                             <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
@@ -116,7 +116,7 @@
                             <li class="flc-pager-pageLink"><a href="#">2</a></li>
                         </ul>
                     </li>
-                    <li class="flc-pager-next demo-pager-next"><a href="#">Next <span class="demo-pager-next-character"></span></a></li>
+                    <li class="flc-pager-next demo-pager-next"><a href="#">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
                 </ul>
             </div>
 

--- a/examples/components/pager/annotateSortedColumn/index.html
+++ b/examples/components/pager/annotateSortedColumn/index.html
@@ -63,7 +63,7 @@
                         <li class="flc-pager-pageLink"><a href="#">2</a></li>
                     </ul>
                 </li>
-                <li class="example-pager-next flc-pager-next"><a href="#" title="Next Page">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
+                <li class="example-pager-next flc-pager-next"><a href="#" >Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
             </ul>
         </div>
 

--- a/examples/components/pager/annotateSortedColumn/index.html
+++ b/examples/components/pager/annotateSortedColumn/index.html
@@ -55,7 +55,7 @@
 
         <div class="flc-pager-top">
             <ul class="example-pager-bar fl-force-left fl-focus">
-                <li class="flc-pager-previous example-pager-previous"><a href="#" title="Previous Page">&lt; Previous</a></li>
+                <li class="flc-pager-previous example-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#"> Previous</a></li>
                 <li>
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
@@ -63,7 +63,7 @@
                         <li class="flc-pager-pageLink"><a href="#">2</a></li>
                     </ul>
                 </li>
-                <li class="example-pager-next flc-pager-next"><a href="#" title="Next Page">Next &gt;</a></li>
+                <li class="example-pager-next flc-pager-next"><a href="#" title="Next Page">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
             </ul>
         </div>
 
@@ -101,7 +101,7 @@
 
         <div class="flc-pager-bottom">
             <ul class="example-pager-bar fl-force-left fl-focus">
-                <li class="flc-pager-previous example-pager-previous"><a href="#">&lt; Previous</a></li>
+                <li class="flc-pager-previous example-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#"> Previous</a></li>
                 <li>
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
@@ -109,7 +109,7 @@
                         <li class="flc-pager-pageLink"><a href="#">2</a></li>
                     </ul>
                 </li>
-                <li class="flc-pager-next example-pager-next"><a href="#">Next &gt;</a></li>
+                <li class="flc-pager-next example-pager-next"><a href="#">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
             </ul>
         </div>
 

--- a/examples/components/pager/initialPageIndex/index.html
+++ b/examples/components/pager/initialPageIndex/index.html
@@ -56,7 +56,7 @@
 
         <div class="flc-pager-top">
             <ul class="example-pager-bar fl-force-left fl-focus">
-                <li class="flc-pager-previous example-pager-previous"><a href="#" title="Previous Page">&lt; Previous</a></li>
+                <li class="flc-pager-previous example-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#" > Previous</a></li>
                 <li>
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
@@ -64,7 +64,7 @@
                         <li class="flc-pager-pageLink"><a href="#">2</a></li>
                     </ul>
                 </li>
-                <li class="example-pager-next flc-pager-next"><a href="#" title="Next Page">Next &gt;</a></li>
+                <li class="example-pager-next flc-pager-next"><a href="#" >Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
             </ul>
         </div>
 
@@ -102,7 +102,7 @@
 
         <div class="flc-pager-bottom">
             <ul class="example-pager-bar fl-force-left fl-focus">
-                <li class="flc-pager-previous example-pager-previous"><a href="#">&lt; Previous</a></li>
+                <li class="flc-pager-previous example-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#"> Previous</a></li>
                 <li>
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
@@ -110,7 +110,7 @@
                         <li class="flc-pager-pageLink"><a href="#">2</a></li>
                     </ul>
                 </li>
-                <li class="flc-pager-next example-pager-next"><a href="#">Next &gt;</a></li>
+                <li class="flc-pager-next example-pager-next"><a href="#">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
             </ul>
         </div>
 

--- a/examples/components/pager/markupDriven/index.html
+++ b/examples/components/pager/markupDriven/index.html
@@ -31,8 +31,8 @@
                 <li class="fl-pager-pageLink flc-pager-pageLink"><a href="#">5</a></li>
                 <li class="fl-pager-pageLink flc-pager-pageLink"><a href="#">6</a></li>
                 <li class="fl-pager-pageLink flc-pager-pageLink"><a href="#">7 (last)</a></li>
-                <li class="fl-pager-previous flc-pager-previous"><a href="#">&lt; previous</a></li>
-                <li class="fl-pager-next flc-pager-next"><a href="#">next &gt;</a></li>
+                <li class="fl-pager-previous flc-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#"> Previous</a></li>
+                <li class="fl-pager-next flc-pager-next"><a href="#">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
             </ul>
             <table id="students-page1">
               <caption>Student Grades</caption>
@@ -325,8 +325,8 @@
                 <li class="fl-pager-pageLink flc-pager-pageLink"><a href="#">5</a></li>
                 <li class="fl-pager-pageLink flc-pager-pageLink"><a href="#">6</a></li>
                 <li class="fl-pager-pageLink flc-pager-pageLink"><a href="#">7 (last)</a></li>
-                <li class="fl-pager-previous flc-pager-previous"><a href="#">&lt; previous</a></li>
-                <li class="fl-pager-next flc-pager-next"><a href="#">next &gt;</a></li>
+                <li class="fl-pager-previous flc-pager-previous"><span class="demo-pager-previous-character" aria-hidden="true">&lt;</span><a href="#"> Previous</a></li>
+                <li class="fl-pager-next flc-pager-next"><a href="#">Next </a><span class="demo-pager-next-character" aria-hidden="true">&gt;</span></li>
             </ul>
 
           </form>


### PR DESCRIPTION
There's a title attribute on the "Previous" link and the "Next" link. The issue here is that the link has accessible text that will result in screen readers announcing previous twice (e.g. "link, Previous, Previous page" in VoiceOver. It's not recommended that the title attribute be used on links because of inconsistent browser support and the potential for duplicate content being announced by screen readers. 
Reference from MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title#Accessibility_concerns