### PR TITLE
FLUID-6499: added font display swap for font faces

### DIFF
--- a/demos/uiOptions/css/uiOptions.css
+++ b/demos/uiOptions/css/uiOptions.css
@@ -4,26 +4,32 @@
 @font-face {
   font-family: Lato;
   src: url(../fonts/Lato-Regular.woff);
+  font-display: swap;
 }
 @font-face {
   font-family: LatoLight;
   src: url(../fonts/Lato-Light.woff);
+  font-display: swap;
 }
 @font-face {
   font-family: LatoLightItalic;
   src: url(../fonts/Lato-LightItalic.woff);
+  font-display: swap;
 }
 @font-face {
   font-family: LatoBlack;
   src: url(../fonts/Lato-Black.woff);
+  font-display: swap;
 }
 @font-face {
   font-family: LatoRegular;
   src: url(../fonts/Lato-Regular.woff);
+  font-display: swap;
 }
 @font-face {
   font-family: LoveYaLikeASister;
   src: url(../fonts/LoveYaLikeASister.ttf);
+  font-display: swap;
 }
 
 

--- a/src/components/orator/css/Orator.css
+++ b/src/components/orator/css/Orator.css
@@ -1,6 +1,7 @@
 @font-face {
     font-family:'Orator-Icons';
-    src:url("../fonts/Orator-Icons.woff")
+    src:url("../fonts/Orator-Icons.woff");
+    font-display: swap
 }
 
 /* controller */

--- a/src/components/orator/css/Orator.css
+++ b/src/components/orator/css/Orator.css
@@ -1,7 +1,7 @@
 @font-face {
     font-family:'Orator-Icons';
     src:url("../fonts/Orator-Icons.woff");
-    font-display: swap
+    font-display: swap;
 }
 
 /* controller */

--- a/src/components/overviewPanel/css/OverviewPanel.css
+++ b/src/components/overviewPanel/css/OverviewPanel.css
@@ -2,27 +2,32 @@
 @font-face {
     font-family: "Icons";
     src:url('../fonts/OverviewPanel-Icons.woff');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'OpenSans';
     src: url('../../../lib/opensans/fonts/OpenSans-Regular.woff');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'OpenSans';
     src: url('../../../lib/opensans/fonts/OpenSans-Bold.woff');
+    font-display: swap;
     font-weight: bold;
 }
 
 @font-face {
     font-family: 'RobotoSlab';
     src: url('../../../lib/roboto/fonts/Roboto-Slab-Regular.woff');
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'RobotoSlab';
     src: url('../../../lib/roboto/fonts/Roboto-Slab-Bold.woff');
+    font-display: swap;
     font-weight: bold;
 }
 

--- a/src/components/uploader/css/Uploader.css
+++ b/src/components/uploader/css/Uploader.css
@@ -1,6 +1,7 @@
 @font-face {
     font-family: 'InfusionIcons';
     src: url('../fonts/Uploader-Icons.woff');
+    font-display: swap;
 }
 
 /*

--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -7,6 +7,7 @@
 @font-face {
     font-family: 'PrefsFramework-Icons';
     src: url('../fonts/PrefsFramework-Icons.woff');
+    font-display: swap;
 }
 
 .fl-prefsEditor {

--- a/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditor.styl
@@ -5,6 +5,7 @@
     src:url('../../../lib/opensans/fonts/OpenSans-Light.woff');
     font-weight: 300;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -12,6 +13,7 @@
     src:url('../../../lib/opensans/fonts/OpenSans-Regular.woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -19,6 +21,7 @@
     src:url('../../../lib/opensans/fonts/OpenSans-SemiBold.woff');
     font-weight: 600;
     font-style: normal;
+    font-display: swap;
 }
 
 // Top bar and show/hide button

--- a/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
+++ b/src/framework/preferences/css/stylus/SeparatedPanelPrefsEditorFrame.styl
@@ -5,6 +5,7 @@
     src: url("../../../lib/opensans/fonts/OpenSans-Light.woff");
     font-weight: 300;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -12,6 +13,7 @@
     src:url('../../../lib/opensans/fonts/OpenSans-Regular.woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -19,6 +21,7 @@
     src:url('../../../lib/opensans/fonts/OpenSans-SemiBold.woff');
     font-weight: 600;
     font-style: normal;
+    font-display: swap;
 }
 
 html {

--- a/src/framework/preferences/css/stylus/utils/Fonts.styl
+++ b/src/framework/preferences/css/stylus/utils/Fonts.styl
@@ -35,7 +35,7 @@ fontFaces = {
                 fontWeight: 600
                 fontStyle: normal
             },
-            italic: {            
+            italic: {
                 filename:"OpenDyslexic-Italic.woff"
                 fontWeight: normal
                 fontStyle: italic
@@ -56,25 +56,26 @@ build-fonts-Enactors(textFont, textFontFaces) {
         fontDirectory = textFontFaces[fontFamilyName].fontDirectory
         fontFamily = textFontFaces[fontFamilyName].fontFamily
         fontFamilyDefs = textFontFaces[fontFamilyName].definitions;
-        for def in fontFamilyDefs {                
+        for def in fontFamilyDefs {
                 fontDef = textFontFaces[fontFamilyName][definitions][def]
                 @font-face {
                     font-family: fontFamily;
                     src: url(fontDirectory + fontDef.filename);
                     font-weight: fontDef.fontWeight;
                     font-style: fontDef.fontStyle;
+                    font-display: swap;
             }
             }
         }
 
     for fontName in textFont {
         font = textFont[fontName].fontFamily;
-        
+
         {fontName},
         {fontName} * {
             &:not([class*='icon']) {
                 font-family: unquote(font) !important;
             }
         }
-    }    
+    }
 }


### PR DESCRIPTION
## Description

Leverages the [font-display CSS feature](https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools#how-to-avoid-showing-invisible-text) to ensure text is user-visible while webfonts are loading.

<!-- Description of the pull request -->

## Steps to test

1. Go to a webpage implementing UIO
2. inspect the page
3. go to audit tab and run lighthouse 

**Expected behavior:** <!-- What should happen -->

_Ensure text remains visible during webfont load_ should no longer come up under Diagnostics because it has already been applied.

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

N/A

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->

https://issues.fluidproject.org/browse/FLUID-6499