### PR TITLE
FLUID-6500: Improve usability of arrayToSetMembership and setMembershipToArray transforms

### DIFF
--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -388,7 +388,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * https://docs.fluidproject.org/infusion/development/ModelTransformationAPI.html#fluidtransformsarraytosetmembership
      *
      * @param {Array} value - The Array to be transformed into an object.
-     * @param {Object} [transformSpec] - The options provided to the transformation rule.
+     * @param {Object} [transformSpec] - (optional) The options provided to the transformation rule.
      * @return {Object} - The transformed object
      *
      */
@@ -402,18 +402,21 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             missingValue = fluid.get(transformSpec, "missingValue") ? transformSpec.missingValue : false,
             options = fluid.get(transformSpec, "options");
 
-        // When <options> are provided in the transformation rule, use them for keys in the output object.
-        fluid.each(options, function (outPath, key) {
-            /**
-             * Write to output object the value <presentValue> or <missingValue> depending on whether key is
-             * found in user input.
-             */
-            var outVal = (value.indexOf(key) !== -1) ? presentValue : missingValue;
-            fluid.set(output, outPath, outVal);
-        });
-
-        // Otherwise, when no <options> are provided, use items from the <value> array as keys.
-        if (!options) {
+        /**
+         * When <options> are provided in the transformation rule, use them for keys in the output object.
+         * Otherwise, use items from the <value> array as keys.
+         */
+        if (options !== undefined) {
+            fluid.each(options, function (outPath, key) {
+                /**
+                 * Write to output object the value <presentValue> or <missingValue> depending on whether key is
+                 * found in user input.
+                 */
+                var outVal = (value.indexOf(key) !== -1) ? presentValue : missingValue;
+                fluid.set(output, outPath, outVal);
+            });
+        }
+        else {
             fluid.each(value, function (outPath) {
                 // Write <presentValue> for all the items present in the <value> array.
                 fluid.set(output, outPath, presentValue);
@@ -489,29 +492,32 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * https://docs.fluidproject.org/infusion/development/ModelTransformationAPI.html#fluidtransformssetmembershiptoarray
      *
      * @param {Object} input - The object to be transformed into an array.
-     * @param {Object} [transformSpec] - The options provided to the transformation rule.
+     * @param {Object} [transformSpec] - (optional) The options provided to the transformation rule.
      * @return {Array} - The transformed array
      *
      */
     fluid.transforms.setMembershipToArray = function (input, transformSpec) {
         // <input> should be an object.
-        if (!input || !fluid.isPlainObject(input, true)) {
+        if (!fluid.isPlainObject(input, true)) {
             fluid.fail("setMembershipToArray didn't find object at inputPath nor passed as value.");
         }
         var outputArr = [];
         var presentValue = fluid.get(transformSpec, "presentValue") ? transformSpec.presentValue : true,
             options = fluid.get(transformSpec, "options");
 
-        // When <options> are provided in the transformation rule, use them for entries in the output array.
-        fluid.each(options, function (outputVal, key) {
-            // Write to output array the key of the <input> object if it's value matches the <presentValue>
-            if (fluid.get(input, key) === presentValue) {
-                outputArr.push(outputVal);
-            }
-        });
-
-        // Otherwise, when no <options> are provided, use the <input> object for entries in the output array.
-        if (!options) {
+        /**
+         * When <options> are provided in the transformation rule, use them for entries in the output array.
+         * Otherwise, use the <input> object for entries in the output array.
+         */
+        if (options !== undefined) {
+            fluid.each(options, function (outputVal, key) {
+                // Write to output array the key of the <input> object if it's value matches the <presentValue>
+                if (fluid.get(input, key) === presentValue) {
+                    outputArr.push(outputVal);
+                }
+            });
+        }
+        else {
             fluid.each(input, function (keyValue, outputVal) {
                 // Write to output array the key of the <input> object if it's value matches the <presentValue>
                 if (keyValue === presentValue) {

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -388,7 +388,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * https://docs.fluidproject.org/infusion/development/ModelTransformationAPI.html#fluidtransformsarraytosetmembership
      *
      * @param {Array} value - The Array to be transformed into an object.
-     * @param {Object} transformSpec (OPTIONAL) - The options provided to the transformation rule.
+     * @param {Object} [transformSpec] - The options provided to the transformation rule.
      * @return {Object} - The transformed object
      *
      */
@@ -489,7 +489,7 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
      * https://docs.fluidproject.org/infusion/development/ModelTransformationAPI.html#fluidtransformssetmembershiptoarray
      *
      * @param {Object} input - The object to be transformed into an array.
-     * @param {Object} transformSpec (OPTIONAL) - The options provided to the transformation rule.
+     * @param {Object} [transformSpec] - The options provided to the transformation rule.
      * @return {Array} - The transformed array
      *
      */

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -398,28 +398,29 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             fluid.fail("arrayToSetMembership didn't find array at inputPath nor passed as value.");
         }
         var output = {};
-        var presentValue = fluid.get(transformSpec, "presentValue") ? transformSpec.presentValue : true,
-            missingValue = fluid.get(transformSpec, "missingValue") ? transformSpec.missingValue : false,
-            options = fluid.get(transformSpec, "options");
+        transformSpec = transformSpec || {};
+        var presentValue = (transformSpec.presentValue === undefined) ? true : transformSpec.presentValue,
+            missingValue = (transformSpec.missingValue === undefined) ? false : transformSpec.missingValue,
+            options = transformSpec.options;
 
         /**
-         * When <options> are provided in the transformation rule, use them for keys in the output object.
-         * Otherwise, use items from the <value> array as keys.
+         * When no <options> are provided in the transformation rule, use items from the <value> array as keys.
+         * Otherwise, use <options> for keys in the output object.
          */
-        if (options !== undefined) {
+        if (options === undefined) {
+            fluid.each(value, function (outPath) {
+                // Write <presentValue> for all the items present in the <value> array.
+                output[outPath] = presentValue;
+            });
+        }
+        else {
             fluid.each(options, function (outPath, key) {
                 /**
                  * Write to output object the value <presentValue> or <missingValue> depending on whether key is
                  * found in user input.
                  */
                 var outVal = (value.indexOf(key) !== -1) ? presentValue : missingValue;
-                fluid.set(output, outPath, outVal);
-            });
-        }
-        else {
-            fluid.each(value, function (outPath) {
-                // Write <presentValue> for all the items present in the <value> array.
-                fluid.set(output, outPath, presentValue);
+                output[outPath] = outVal;
             });
         }
 
@@ -502,25 +503,26 @@ var fluid_3_0_0 = fluid_3_0_0 || {};
             fluid.fail("setMembershipToArray didn't find object at inputPath nor passed as value.");
         }
         var outputArr = [];
-        var presentValue = fluid.get(transformSpec, "presentValue") ? transformSpec.presentValue : true,
-            options = fluid.get(transformSpec, "options");
+        transformSpec = transformSpec || {};
+        var presentValue = (transformSpec.presentValue === undefined) ? true : transformSpec.presentValue,
+            options = transformSpec.options;
 
         /**
-         * When <options> are provided in the transformation rule, use them for entries in the output array.
-         * Otherwise, use the <input> object for entries in the output array.
+         * When no <options> are provided in the transformation rule, use the <input> object for entries in the output array.
+         * Otherwise, use <options> for entries in the output array.
          */
-        if (options !== undefined) {
-            fluid.each(options, function (outputVal, key) {
+        if (options === undefined) {
+            fluid.each(input, function (keyValue, outputVal) {
                 // Write to output array the key of the <input> object if it's value matches the <presentValue>
-                if (fluid.get(input, key) === presentValue) {
+                if (keyValue === presentValue) {
                     outputArr.push(outputVal);
                 }
             });
         }
         else {
-            fluid.each(input, function (keyValue, outputVal) {
+            fluid.each(options, function (outputVal, key) {
                 // Write to output array the key of the <input> object if it's value matches the <presentValue>
-                if (keyValue === presentValue) {
+                if (input[key] === presentValue) {
                     outputArr.push(outputVal);
                 }
             });

--- a/tests/framework-tests/core/js/ModelTransformationTests.js
+++ b/tests/framework-tests/core/js/ModelTransformationTests.js
@@ -5029,7 +5029,135 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     /* --------------- array to set-membership tests -------------------- */
     fluid.tests.transforms.arrayToSetMembershipTests = [{
-        message: "basic test 1",
+        message: "arrayToSetMembership() should return an object when no specifications are provided to the transformation rule.",
+        model: {
+            a: [ "foo", "bar" ]
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    inputPath: "a"
+                }
+            }
+        },
+        expected: {
+            b: {
+                foo: true,
+                bar: true
+            }
+        },
+        expectedInputPaths: [ "a" ],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.setMembershipToArray",
+                    outputPath: "a",
+                    inputPath: "b"
+                }
+            ]
+        },
+        fullyInvertible: true
+    }, {
+        message: "arrayToSetMembership() should return an object when presentValue and missingValue are provided to the transformation rule.",
+        model: {
+            a: [ "foo", "bar" ]
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    inputPath: "a",
+                    presentValue: "yes",
+                    missingValue: "no"
+                }
+            }
+        },
+        expected: {
+            b: {
+                foo: "yes",
+                bar: "yes"
+            }
+        },
+        expectedInputPaths: [ "a" ],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.setMembershipToArray",
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "yes",
+                    missingValue: "no"
+                }
+            ]
+        },
+        fullyInvertible: true
+    }, {
+        message: "arrayToSetMembership() should return an object when only presentValue is provided to the transformation rule.",
+        model: {
+            a: [ "foo", "bar" ]
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    inputPath: "a",
+                    presentValue: "yes"
+                }
+            }
+        },
+        expected: {
+            b: {
+                foo: "yes",
+                bar: "yes"
+            }
+        },
+        expectedInputPaths: [ "a" ],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.setMembershipToArray",
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "yes"
+                }
+            ]
+        },
+        fullyInvertible: true
+    }, {
+        message: "arrayToSetMembership() should return an object when only missingValue is provided to the transformation rule.",
+        model: {
+            a: [ "foo", "bar" ]
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    inputPath: "a",
+                    missingValue: "no"
+                }
+            }
+        },
+        expected: {
+            b: {
+                foo: true,
+                bar: true
+            }
+        },
+        expectedInputPaths: [ "a" ],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.setMembershipToArray",
+                    outputPath: "a",
+                    inputPath: "b",
+                    missingValue: "no"
+                }
+            ]
+        },
+        fullyInvertible: true
+    }, {
+        message: "arrayToSetMembership() should return an object when presentValue, missingValue, and options are provided to the transformation rule.",
         model: {
             a: [ "foo", "bar" ]
         },
@@ -5041,18 +5169,18 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     presentValue: "yes",
                     missingValue: "no",
                     options: {
-                        "foo": "settingF",
-                        "bar": "settingB",
-                        "tar": "settingT"
+                        "foo": "hasFoo",
+                        "bar": "hasBar",
+                        "tar": "hasTar"
                     }
                 }
             }
         },
         expected: {
             b: {
-                settingF: "yes",
-                settingB: "yes",
-                settingT: "no"
+                hasFoo: "yes",
+                hasBar: "yes",
+                hasTar: "no"
             }
         },
         expectedInputPaths: [ "a" ],
@@ -5065,16 +5193,16 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     presentValue: "yes",
                     missingValue: "no",
                     options: {
-                        "settingF": "foo",
-                        "settingB": "bar",
-                        "settingT": "tar"
+                        "hasFoo": "foo",
+                        "hasBar": "bar",
+                        "hasTar": "tar"
                     }
                 }
             ]
         },
         fullyInvertible: true
     }, {
-        message: "basic test with defaulted present and missing values",
+        message: "arrayToSetMembership() should return an object when only options is provided to the transformation rule.",
         model: {
             a: [ "foo", "bar" ]
         },
@@ -5084,115 +5212,370 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     type: "fluid.transforms.arrayToSetMembership",
                     inputPath: "a",
                     options: {
-                        "foo": "settingF",
-                        "bar": "settingB",
-                        "tar": "settingT"
+                        "foo": "hasFoo",
+                        "bar": "hasBar",
+                        "tar": "hasTar"
                     }
                 }
             }
         },
         expected: {
             b: {
-                settingF: true,
-                settingB: true,
-                settingT: false
+                hasFoo: true,
+                hasBar: true,
+                hasTar: false
             }
         },
+        expectedInputPaths: [ "a" ],
         invertedRules: {
             transform: [
                 {
                     type: "fluid.transforms.setMembershipToArray",
                     outputPath: "a",
                     inputPath: "b",
-                    presentValue: true,
-                    missingValue: false,
                     options: {
-                        "settingF": "foo",
-                        "settingB": "bar",
-                        "settingT": "tar"
+                        "hasFoo": "foo",
+                        "hasBar": "bar",
+                        "hasTar": "tar"
                     }
                 }
             ]
         },
         fullyInvertible: true
-    },  {
-        message: "FLUID-5907 test: escaping of EL values",
+    }, {
+        message: "arrayToSetMembership() should return an object when presentValue and options are provided to the transformation rule.",
         model: {
-            "http://registry.gpii.net/common/trackingTTS": [ "focus", "caret" ]
+            a: [ "foo", "bar" ]
         },
         transform: {
-            transform: {
-                type: "fluid.transforms.arrayToSetMembership",
-                inputPath: "http://registry\\.gpii\\.net/common/trackingTTS",
-                outputPath: "",
-                presentValue: true,
-                missingValue: false,
-                options: {
-                    focus: "reviewCursor\\.followFocus",
-                    caret: "reviewCursor\\.followCaret",
-                    mouse: "reviewCursor\\.followMouse"
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    inputPath: "a",
+                    presentValue: "yes",
+                    options: {
+                        "foo": "hasFoo",
+                        "bar": "hasBar",
+                        "tar": "hasTar"
+                    }
                 }
             }
         },
         expected: {
-            "reviewCursor.followFocus": true,
-            "reviewCursor.followCaret": true,
-            "reviewCursor.followMouse": false
+            b: {
+                hasFoo: "yes",
+                hasBar: "yes",
+                hasTar: false
+            }
         },
+        expectedInputPaths: [ "a" ],
         invertedRules: {
             transform: [
                 {
                     type: "fluid.transforms.setMembershipToArray",
-                    outputPath: "http://registry\\.gpii\\.net/common/trackingTTS",
-                    inputPath: "",
-                    presentValue: true,
-                    missingValue: false,
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "yes",
                     options: {
-                        "reviewCursor\\.followFocus": "focus",
-                        "reviewCursor\\.followCaret": "caret",
-                        "reviewCursor\\.followMouse": "mouse"
+                        "hasFoo": "foo",
+                        "hasBar": "bar",
+                        "hasTar": "tar"
                     }
                 }
             ]
         },
         fullyInvertible: true
+    }, {
+        message: "arrayToSetMembership() should return an object when missingValue and options are provided to the transformation rule.",
+        model: {
+            a: [ "foo", "bar" ]
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    inputPath: "a",
+                    missingValue: "no",
+                    options: {
+                        "foo": "hasFoo",
+                        "bar": "hasBar",
+                        "tar": "hasTar"
+                    }
+                }
+            }
+        },
+        expected: {
+            b: {
+                hasFoo: true,
+                hasBar: true,
+                hasTar: "no"
+            }
+        },
+        expectedInputPaths: [ "a" ],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.setMembershipToArray",
+                    outputPath: "a",
+                    inputPath: "b",
+                    missingValue: "no",
+                    options: {
+                        "hasFoo": "foo",
+                        "hasBar": "bar",
+                        "hasTar": "tar"
+                    }
+                }
+            ]
+        },
+        fullyInvertible: true
+    }, {
+        message: "arrayToSetMembership() should throw an error when the input is not an array.",
+        model: {
+            a: "foo"
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    inputPath: "a"
+                }
+            }
+        },
+        errorTexts: "arrayToSetMembership didn't find array at inputPath nor passed as value.",
+        expectedInputPaths: [ "a" ],
+        fullyInvertible: false
     }];
 
-    jqUnit.test("arrayToSetMembership and setMembershipToArray transformation tests", function () {
+    jqUnit.test("arrayToSetMembership transformation tests", function () {
         fluid.tests.transforms.testOneStructure(fluid.tests.transforms.arrayToSetMembershipTests, {
             method: "assertDeepEq"
         });
     });
 
-    /* --------------- array to set-membership tests -------------------- */
+    /* --------------- set-membership to array tests -------------------- */
     fluid.tests.transforms.setMembershipToArrayTests = [{
-        message: "basic test",
+        message: "setMembershipToArray() should return an array when no specifications are provided to the transformation rule.",
         model: {
             a: {
-                settingF: "yes",
-                settingB: "yes",
-                settingT: "no"
+                foo: true,
+                bar: true,
+                tar: false
             }
         },
         transform: {
-            b: {
-                transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a"
+                }
+            }
+        },
+        expected: {
+            b: ["foo", "bar"]
+        },
+        expectedInputPaths: ["a"],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "a",
+                    inputPath: "b"
+                }
+            ]
+        },
+        weaklyInvertible: true
+    }, {
+        message: "setMembershipToArray() should return a fully invertible array when each key has value equal to the passed or the default presentValue.",
+        model: {
+            a: {
+                foo: true,
+                bar: true
+            }
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a"
+                }
+            }
+        },
+        expected: {
+            b: ["foo", "bar"]
+        },
+        expectedInputPaths: ["a"],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "a",
+                    inputPath: "b"
+                }
+            ]
+        },
+        fullyInvertible: true
+    }, {
+        message: "setMembershipToArray() should return an array when presentValue and missingValue are provided to the transformation rule.",
+        model: {
+            a: {
+                foo: "yes",
+                bar: "yes",
+                tar: "no"
+            }
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a",
+                    presentValue: "yes",
+                    missingValue: "no"
+                }
+            }
+        },
+        expected: {
+            b: ["foo", "bar"]
+        },
+        expectedInputPaths: ["a"],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "yes",
+                    missingValue: "no"
+                }
+            ]
+        },
+        weaklyInvertible: true
+    }, {
+        message: "setMembershipToArray() should return an array when only presentValue is provided to the transformation rule.",
+        model: {
+            a: {
+                foo: "yes",
+                bar: "yes",
+                tar: "no"
+            }
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a",
+                    presentValue: "yes"
+                }
+            }
+        },
+        expected: {
+            b: ["foo", "bar"]
+        },
+        expectedInputPaths: ["a"],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "yes"
+                }
+            ]
+        },
+        weaklyInvertible: true
+    }, {
+        message: "setMembershipToArray() should return an empty array when input object doesn't have any key with the value same as the passed presentValue.",
+        model: {
+            a: {
+                foo: "yes",
+                bar: "yes",
+                tar: "no"
+            }
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a",
+                    presentValue: "exist"
+                }
+            }
+        },
+        expected: {
+            b: []
+        },
+        expectedInputPaths: ["a"],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "exist"
+                }
+            ]
+        },
+        weaklyInvertible: true
+    }, {
+        message: "setMembershipToArray() should return an array when only missingValue is provided to the transformation rule.",
+        model: {
+            a: {
+                foo: "yes",
+                bar: "yes",
+                tar: "no"
+            }
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a",
+                    missingValue: "no"
+                }
+            }
+        },
+        expected: {
+            b: []
+        },
+        expectedInputPaths: ["a"],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "a",
+                    inputPath: "b",
+                    missingValue: "no"
+                }
+            ]
+        },
+        weaklyInvertible: true
+    }, {
+        message: "setMembershipToArray() should return an array when presentValue, missingValue, and options are provided to the transformation rule.",
+        model: {
+            a: {
+                hasFoo: "yes",
+                hasBar: "yes",
+                hasTar: "no"
+            }
+        },
+        transform: {
+            "b": {
+                "transform": {
                     type: "fluid.transforms.setMembershipToArray",
                     inputPath: "a",
                     presentValue: "yes",
                     missingValue: "no",
                     options: {
-                        "settingF": "foo",
-                        "settingB": "bar",
-                        "settingT": "tar"
+                        hasFoo: "foo",
+                        hasBar: "bar",
+                        hasTar: "tar"
                     }
                 }
             }
         },
         expected: {
-            b: [ "foo", "bar" ]
+            b: ["foo", "bar"]
         },
-        expectedInputPaths: [ "a" ],
+        expectedInputPaths: ["a"],
         invertedRules: {
             transform: [
                 {
@@ -5201,102 +5584,157 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     inputPath: "b",
                     presentValue: "yes",
                     missingValue: "no",
-                    options: { //(paths)
-                        "foo": "settingF",
-                        "bar": "settingB",
-                        "tar": "settingT"
+                    options: {
+                        foo: "hasFoo",
+                        bar: "hasBar",
+                        tar: "hasTar"
                     }
                 }
             ]
         },
         fullyInvertible: true
     }, {
-        message: "basic test with defaults for present and missing value",
+        message: "setMembershipToArray() should return an array when presentValue and options are provided to the transformation rule.",
         model: {
-            detections: {
-                hasMouse: true,
-                hasKeyboard: true,
-                hasTrackpad: false,
-                hasHeadtracker: false
+            a: {
+                hasFoo: "yes",
+                hasBar: "yes",
+                hasTar: "no"
             }
         },
         transform: {
-            controls: {
-                transform: {
+            "b": {
+                "transform": {
                     type: "fluid.transforms.setMembershipToArray",
-                    inputPath: "detections",
+                    inputPath: "a",
+                    presentValue: "yes",
                     options: {
-                        hasMouse: "mouse",
-                        hasKeyboard: "keyboard",
-                        hasTrackpad: "trackpad",
-                        hasHeadtracker: "headtracker"
+                        hasFoo: "foo",
+                        hasBar: "bar",
+                        hasTar: "tar"
                     }
                 }
             }
         },
         expected: {
-            controls: [ "mouse", "keyboard" ]
+            b: ["foo", "bar"]
         },
+        expectedInputPaths: ["a"],
         invertedRules: {
             transform: [
                 {
                     type: "fluid.transforms.arrayToSetMembership",
-                    outputPath: "detections",
-                    inputPath: "controls",
-                    presentValue: true,
-                    missingValue: false,
-                    options: { //(paths)
-                        mouse: "hasMouse",
-                        keyboard: "hasKeyboard",
-                        trackpad: "hasTrackpad",
-                        headtracker: "hasHeadtracker"
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "yes",
+                    options: {
+                        foo: "hasFoo",
+                        bar: "hasBar",
+                        tar: "hasTar"
                     }
                 }
             ]
         },
-        fullyInvertible: true
+        weaklyInvertible: true
     }, {
-        message: "Checking for missing / extra values",
+        message: "setMembershipToArray() should return an array when missingValue and options are provided to the transformation rule.",
         model: {
-            detections: {
-                hasMouse: "supported",
-                hasKeyboard: "supported",
-                hasTrackpad: "not supported",
-                hasHeadtracker: "not supported",
-                hasTelephone: "supported"
+            a: {
+                hasFoo: "yes",
+                hasBar: "yes",
+                hasTar: "no"
+            }
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a",
+                    missingValue: "no",
+                    options: {
+                        hasFoo: "foo",
+                        hasBar: "bar",
+                        hasTar: "tar"
+                    }
+                }
+            }
+        },
+        expected: {
+            b: []
+        },
+        expectedInputPaths: ["a"],
+        invertedRules: {
+            transform: [
+                {
+                    type: "fluid.transforms.arrayToSetMembership",
+                    outputPath: "a",
+                    inputPath: "b",
+                    missingValue: "no",
+                    options: {
+                        foo: "hasFoo",
+                        bar: "hasBar",
+                        tar: "hasTar"
+                    }
+                }
+            ]
+        },
+        weaklyInvertible: true
+    }, {
+        message: "setMembershipToArray() should throw an error when input is not an object.",
+        model: {
+            a: "foo"
+        },
+        transform: {
+            "b": {
+                "transform": {
+                    type: "fluid.transforms.setMembershipToArray",
+                    inputPath: "a"
+                }
+            }
+        },
+        errorTexts: "setMembershipToArray didn't find object at inputPath nor passed as value.",
+        expectedInputPaths: [ "a" ],
+        fullyInvertible: false
+    }, {
+        message: "setMembershipToArray() should return an array with only those values for which options have been provided in the transformation rule.",
+        model: {
+            a: {
+                hasFoo: "yes",
+                hasBar: "no",
+                hasTar: "yes",
+                hasRar: "no"
             }
         },
         transform: {
             transform: {
                 type: "fluid.transforms.setMembershipToArray",
-                inputPath: "detections",
-                outputPath: "controls",
-                presentValue: "supported",
-                missingValue: "not supported",
+                inputPath: "a",
+                outputPath: "b",
+                presentValue: "yes",
+                missingValue: "no",
                 options: {
-                    hasMouse: "mouse",
-                    hasKeyboard: "keyboard",
-                    hasTrackpad: "trackpad",
-                    hasHeadtracker: "headtracker"
+                    hasFoo: "foo",
+                    hasBar: "bar",
+                    hasRar: "rar"
                 }
             }
         },
         expected: {
-            controls: [ "mouse", "keyboard" ]
+            b: ["foo"]
         },
+        expectedInputPaths: ["a"],
         invertedRules: {
             transform: [
                 {
                     type: "fluid.transforms.arrayToSetMembership",
-                    outputPath: "detections",
-                    inputPath: "controls",
-                    presentValue: "supported",
-                    missingValue: "not supported",
+                    outputPath: "a",
+                    inputPath: "b",
+                    presentValue: "yes",
+                    missingValue: "no",
                     options: {
-                        mouse: "hasMouse",
-                        keyboard: "hasKeyboard",
-                        trackpad: "hasTrackpad",
-                        headtracker: "hasHeadtracker"
+                        foo: "hasFoo",
+                        bar: "hasBar",
+                        rar: "hasRar"
                     }
                 }
             ]


### PR DESCRIPTION
This pull request improves the `arrayToSetMembership` and `setMembershipToArray` transformations by removing the 3rd argument `transformer` and making the 2nd argument `transformSpec` optional. It also includes a detailed description in the form of JSDoc comments and a set of test cases for both the transformations.