### PR TITLE
FLUID-6520 Specify browsers to run tests on

### DIFF
--- a/tests/testem.js
+++ b/tests/testem.js
@@ -38,7 +38,7 @@ fluid.defaults("fluid.tests.testem", {
         tests:   "%infusion/tests"
     },
     testemOptions: {
-        launch: "Chrome,Edge,Firefox",
+        launch: "Chrome,Firefox",
         ignore_missing_launchers: true,
         disable_watching: true,
         tap_quiet_logs: true

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -38,7 +38,8 @@ fluid.defaults("fluid.tests.testem", {
         tests:   "%infusion/tests"
     },
     testemOptions: {
-        skip: "PhantomJS,Opera,Safari",
+        launch: "Chrome,Firefox",
+        ignore_missing_launchers: true,
         disable_watching: true,
         tap_quiet_logs: true
     }

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -38,7 +38,7 @@ fluid.defaults("fluid.tests.testem", {
         tests:   "%infusion/tests"
     },
     testemOptions: {
-        launch: "Chrome,Firefox",
+        launch: "Chrome,Edge,Firefox",
         ignore_missing_launchers: true,
         disable_watching: true,
         tap_quiet_logs: true


### PR DESCRIPTION
Instead of specifying a growing number of browsers that we do not want to run tests on, specify the list of browsers we actually care about.