### PR TITLE
FLUID-6518: Add missing styles for textFieldStepper focus.

### DIFF
--- a/src/framework/preferences/css/stylus/utils/Themes.styl
+++ b/src/framework/preferences/css/stylus/utils/Themes.styl
@@ -283,6 +283,10 @@ build-themes-Enactors(contrastThemes) {
                 visibility: hidden;
             }
 
+            .fl-textfieldStepper .fl-textfieldStepper-focus {
+                outline-color: fColor;
+            }
+
             // Orator
             .fl-orator-highlight {
                 color: bColor !important;
@@ -514,6 +518,11 @@ build-themes-Enactors(contrastThemes) {
                 .fl-orator-selectionReader-control.fl-orator-selectionReader-below:hover:after,
                 .fl-orator-selectionReader-control.fl-orator-selectionReader-below:before {
                     border-bottom-color: bColor;
+                }
+
+                // TextfieldStepper
+                .fl-textfieldStepper .fl-textfieldStepper-focus {
+                    outline-color: bColor;
                 }
             }
         }


### PR DESCRIPTION
The textFieldStepper adds focus to a parent element using a class name 
added via JavaScript. Because of the special nature, the focus styling 
needed to be explicitly added for the contrast themes.

https://issues.fluidproject.org/browse/FLUID-6518