### PR TITLE
FLUID-6519 ci: Disable git autocrlf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       HEADLESS: true
 
     steps:
+    - name: Prepare git
+      run: git config --global core.autocrlf false
+
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Somehow this was missed in the PR to add Win/macOS tests.

It already exists in the [Kettle](https://github.com/fluid-project/kettle/blob/master/.github/workflows/ci.yml#L23-L24) repo and works fine.