### PR TITLE
NOJIRA: update engines to supported Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "lint": "grunt lint"
     },
     "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
     },
     "dependencies": {
         "fluid-resolve": "1.3.0"


### PR DESCRIPTION
Related to https://issues.fluidproject.org/browse/FLUID-6556, this PR updates the `engines` configuration in `package.json` to indicate that we only support Node >= 12.