### PR TITLE
NOJIRA: migrate to fluid-testem package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "eslint-config-fluid": "1.3.0",
         "eslint-plugin-markdown": "1.0.2",
         "fluid-grunt-lint-all": "1.0.8",
-        "gpii-testem": "2.1.11",
+        "fluid-testem": "2.1.13",
         "grunt": "1.1.0",
         "grunt-contrib-clean": "2.0.0",
         "grunt-contrib-compress": "1.6.0",

--- a/tests/bundle-tests/testem.js
+++ b/tests/bundle-tests/testem.js
@@ -3,10 +3,10 @@
 var fluid = require("../../src/module/fluid");
 fluid.setLogging(true);
 
-require("gpii-testem");
+require("fluid-testem");
 
 fluid.defaults("fluid.tests.bundle.testem", {
-    gradeNames: ["gpii.testem.coverage"],
+    gradeNames: ["fluid.testem.coverage"],
     testPages:  [
         "tests/bundle-tests/infusion-all.html",
         "tests/bundle-tests/infusion-all-min.html",

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -3,10 +3,10 @@
 var fluid = require("../src/module/fluid");
 fluid.setLogging(true);
 
-require("gpii-testem");
+require("fluid-testem");
 
 fluid.defaults("fluid.tests.testem", {
-    gradeNames: ["gpii.testem.instrumentation"],
+    gradeNames: ["fluid.testem.instrumentation"],
     coverageDir: "coverage",
     reportsDir: "reports",
     testPages:  ["tests/all-tests.html"],


### PR DESCRIPTION
I get a deprecation warning when running NPM install because the [gpii-testem](https://www.npmjs.com/package/gpii-testem) package has been migrated to [fluid-testem](https://www.npmjs.com/package/fluid-testem). This resolves the issue.