### PR TITLE
NOJIRA: fix mixed content errors

### DIFF
--- a/demos/prefsFramework/index.html
+++ b/demos/prefsFramework/index.html
@@ -4,9 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="shortcut icon" href="http://www.education.noaa.gov/education_web/images/favicon.ico">
-        <link rel="icon" type="image/x-icon" href="http://www.education.noaa.gov/favicon.ico">
-
         <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
 

--- a/tests/manual-tests/framework/preferences/assortedContent/index.html
+++ b/tests/manual-tests/framework/preferences/assortedContent/index.html
@@ -187,7 +187,7 @@
                                 <td>&lt;figure&gt;, &lt;figcaption&gt;</td>
                                 <td>
                                     <figure class="test-figure">
-                                        <img alt="Fluid Infusion logo" src="http://wiki.fluidproject.org/download/attachments/24939866/INFUSION_orange.png">
+                                        <img alt="Fluid Infusion logo" src="https://wiki.fluidproject.org/download/attachments/24939866/INFUSION_orange.png">
                                         <figcaption>The Fluid Infusion logo</figcaption>
                                     </figure>
                                 </td>


### PR DESCRIPTION
This PR addresses mixed content errors flagged by Netlify by removing (broken) insecure links to favicons on the NOAA website and updating a link to an image on the Fluid Project wiki to use SSL.