### PR TITLE
FLUID-6529: turn off coverage check for patches

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 0%
+    patch: off
 
 comment: false
 


### PR DESCRIPTION
Extracted @jobara's change from 472133ecf5630d6f189c2bd26309492682bdfab3 so that we can get it merged independently and stop getting errors about patch coverage.