### PR TITLE
FLUID-6607: remove normalize.css dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /.bundle/
 /src/lib/hypher/
 /src/lib/jquery/
-/src/lib/normalize/
 /src/lib/open-dyslexic/
 /src/lib/opensans/
 /src/lib/roboto/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -200,7 +200,6 @@ module.exports = function (grunt) {
                 "src/lib/jquery/core",
                 "src/lib/jquery/plugins",
                 "src/lib/jquery/ui/js",
-                "src/lib/normalize",
                 "src/lib/open-dyslexic",
                 "src/lib/opensans",
                 "src/lib/roboto",
@@ -336,11 +335,6 @@ module.exports = function (grunt) {
                         "node_modules/jquery-ui/ui/widgets/tooltip.js"
                     ],
                     dest: "src/lib/jquery/ui/js/",
-                    expand: true,
-                    flatten: true
-                }, {
-                    src: "node_modules/normalize.css/normalize.css",
-                    dest: "src/lib/normalize/css/",
                     expand: true,
                     flatten: true
                 }, {

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ Distribution bundles can be [viewed on unpkg](https://unpkg.com/browse/infusion/
 * jQueryUI
 * jQueryScrollToPlugin
 * jQueryTouchPunchPlugin
-* normalize
 * open-dyslexic
 * opensans
 * roboto

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ Distribution bundles can be [viewed on unpkg](https://unpkg.com/browse/infusion/
 * open-dyslexic
 * opensans
 * roboto
-* url-polyfill
 
 ## How Do I Run Tests?
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Distribution bundles can be [viewed on unpkg](https://unpkg.com/browse/infusion/
 * open-dyslexic
 * opensans
 * roboto
+* url-polyfill
 
 ## How Do I Run Tests?
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -88,7 +88,6 @@ categorized by license:
 * [jquery.selectbox v0.5 (forked)](https://github.com/fluid-project/jquery.selectbox)
 * [jquery.simulate v1.0.2](https://github.com/eduardolundgren/jquery-simulate)
 * [Micro Clearfix](http://nicolasgallagher.com/micro-clearfix-hack/)
-* [Normalize v8.0.0](https://necolas.github.io/normalize.css/)
 * [url-polyfill v1.0.14](https://github.com/lifaon74/url-polyfill)
 
 ### Open Font License

--- a/demos/inlineEdit/index.html
+++ b/demos/inlineEdit/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-    <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
     <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
     <link rel="stylesheet" type="text/css" href="../../src/lib/jquery/ui/css/default-theme/core.css" />
     <link rel="stylesheet" type="text/css" href="../../src/lib/jquery/ui/css/default-theme/tooltip.css" />

--- a/demos/keyboard-a11y/index.html
+++ b/demos/keyboard-a11y/index.html
@@ -5,7 +5,6 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
     <title>Keyboard Accessbility Demo</title>
-    <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
     <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
     <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
     <link rel="stylesheet" type="text/css" href="../../src/components/overviewPanel/css/OverviewPanel.css" />

--- a/demos/orator/index.html
+++ b/demos/orator/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-    <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
     <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
     <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
     <link rel="stylesheet" type="text/css" href="../../src/components/orator/css/Orator.css" />

--- a/demos/overviewPanel/index.html
+++ b/demos/overviewPanel/index.html
@@ -5,7 +5,6 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
         <title>Overview Panel Demo</title>
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../src/components/overviewPanel/css/OverviewPanel.css" />

--- a/demos/pager/index.html
+++ b/demos/pager/index.html
@@ -7,7 +7,6 @@
 
         <title>Pager Demo</title>
 
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../src/components/pager/css/Pager.css" media="all" />

--- a/demos/prefsFramework/index.html
+++ b/demos/prefsFramework/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
 
         <!-- CSS required for the Prefs Editor -->

--- a/demos/progress/css/progress.css
+++ b/demos/progress/css/progress.css
@@ -125,6 +125,8 @@
     background-color: #8bc5eb;
     border: 1px solid black;
     color: black;
+    font-family: inherit;
+    font-size: 100%;
     padding: 3px 15px 3px 15px;
 }
 

--- a/demos/progress/index.html
+++ b/demos/progress/index.html
@@ -5,7 +5,6 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
         <title>Progress Example</title>
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../src/components/overviewPanel/css/OverviewPanel.css" />

--- a/demos/renderer/css/renderer.css
+++ b/demos/renderer/css/renderer.css
@@ -57,3 +57,10 @@ th {
 ul {
     list-style: none;
 }
+
+button,
+input,
+select {
+    font-family: inherit;
+    font-size: 100%;
+}

--- a/demos/renderer/index.html
+++ b/demos/renderer/index.html
@@ -5,14 +5,13 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
         <title>Renderer Example</title>
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../src/components/overviewPanel/css/OverviewPanel.css" />
         <link type="text/css" rel="stylesheet" media="all" href="css/renderer.css" />
 
         <script type="text/javascript" src="../../src/lib/jquery/core/js/jquery.js"></script>
-        
+
         <script type="text/javascript" src="../../src/framework/core/js/FluidDocument.js"></script>
         <script type="text/javascript" src="../../src/framework/core/js/Fluid.js"></script>
         <script type="text/javascript" src="../../src/framework/core/js/FluidDOMUtilities.js"></script>

--- a/demos/reorderer/gridReorderer/index.html
+++ b/demos/reorderer/gridReorderer/index.html
@@ -6,7 +6,6 @@
 
         <title>Grid Reorderer Demo - Letter Puzzle</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/components/reorderer/css/Reorderer.css" />

--- a/demos/reorderer/imageReorderer/index.html
+++ b/demos/reorderer/imageReorderer/index.html
@@ -6,7 +6,6 @@
 
         <title>Image Reorderer</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/components/reorderer/css/Reorderer.css" />
@@ -29,7 +28,7 @@
         <script type="text/javascript" src="../../../src/lib/jquery/ui/js/mouse.js"></script>
         <script type="text/javascript" src="../../../src/lib/jquery/ui/js/draggable.js"></script>
         <script type="text/javascript" src="../../../src/lib/jquery/plugins/touchPunch/js/jquery.ui.touch-punch.js"></script>
-        
+
         <script type="text/javascript" src="../../../src/framework/core/js/FluidDocument.js"></script>
         <script type="text/javascript" src="../../../src/framework/core/js/jquery.keyboard-a11y.js"></script>
         <script type="text/javascript" src="../../../src/framework/core/js/Fluid.js"></script>

--- a/demos/reorderer/layoutReorderer/index.html
+++ b/demos/reorderer/layoutReorderer/index.html
@@ -5,7 +5,6 @@
 
         <title>Simple Layout Reorderer Sample</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/components/reorderer/css/Reorderer.css" />

--- a/demos/reorderer/listReorderer/index.html
+++ b/demos/reorderer/listReorderer/index.html
@@ -6,7 +6,6 @@
 
         <title>Conference Planning Tasks</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../src/components/reorderer/css/Reorderer.css" />
@@ -27,7 +26,7 @@
         <script type="text/javascript" src="../../../src/lib/jquery/ui/js/mouse.js"></script>
         <script type="text/javascript" src="../../../src/lib/jquery/ui/js/draggable.js"></script>
         <script type="text/javascript" src="../../../src/lib/jquery/plugins/touchPunch/js/jquery.ui.touch-punch.js"></script>
-        
+
         <script type="text/javascript" src="../../../src/framework/core/js/FluidDocument.js"></script>
         <script type="text/javascript" src="../../../src/framework/core/js/jquery.keyboard-a11y.js"></script>
         <script type="text/javascript" src="../../../src/framework/core/js/Fluid.js"></script>

--- a/demos/switch/index.html
+++ b/demos/switch/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-    <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
     <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
     <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
     <link rel="stylesheet" type="text/css" href="../../src/components/overviewPanel/css/OverviewPanel.css" />

--- a/demos/tableOfContents/index.html
+++ b/demos/tableOfContents/index.html
@@ -6,7 +6,6 @@
 
         <title>Table of Contents Template</title>
 
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../src/components/overviewPanel/css/OverviewPanel.css" />

--- a/demos/textfieldControl/index.html
+++ b/demos/textfieldControl/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-    <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
     <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
     <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
     <link rel="stylesheet" type="text/css" href="../../src/components/textfieldControl/css/TextfieldSlider.css" />

--- a/demos/uiOptions/index.html
+++ b/demos/uiOptions/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluidDebugging.css" />
 

--- a/demos/uploader/index.html
+++ b/demos/uploader/index.html
@@ -5,7 +5,6 @@
 
         <title>Uploader</title>
 
-        <link rel="stylesheet" type="text/css" href="../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/demo.css" />
         <link rel="stylesheet" type="text/css" href="../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../src/components/overviewPanel/css/OverviewPanel.css" />

--- a/examples/components/pager/annotateSortedColumn/index.html
+++ b/examples/components/pager/annotateSortedColumn/index.html
@@ -7,7 +7,6 @@
 
         <title>Pager Example: Annotate Sorted Column</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/components/pager/css/Pager.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/lib/jquery/ui/css/default-theme/core.css" />

--- a/examples/components/pager/initialPageIndex/index.html
+++ b/examples/components/pager/initialPageIndex/index.html
@@ -7,7 +7,6 @@
 
         <title>Pager Example: Initial Page Index</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/components/pager/css/Pager.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/lib/jquery/ui/css/default-theme/core.css" />

--- a/examples/components/pager/markupDriven/css/pager.css
+++ b/examples/components/pager/markupDriven/css/pager.css
@@ -12,6 +12,8 @@ td {
 }
 
 input {
+    font-family: inherit;
+    font-size: 100%;
     width: 3em;
 }
 

--- a/examples/components/pager/markupDriven/index.html
+++ b/examples/components/pager/markupDriven/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="css/pager.css" />
 

--- a/examples/components/progress/bidirectionalAnimation/index.html
+++ b/examples/components/progress/bidirectionalAnimation/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Progress: Animate Forward and Back</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/progress.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 

--- a/examples/components/progress/noAnimation/index.html
+++ b/examples/components/progress/noAnimation/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Progress: No Animation</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="Stylesheet" media="screen" href="../shared/css/progress.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 

--- a/examples/components/reorderer/tableRow/index.html
+++ b/examples/components/reorderer/tableRow/index.html
@@ -3,7 +3,6 @@
     <head>
         <title>Reorder Table</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
         <link href="css/reorderer.css" type="text/css" rel="stylesheet" />
 

--- a/examples/framework/preferences/captionsPreference/index.html
+++ b/examples/framework/preferences/captionsPreference/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/conditionalAdjusters-singlePanel/index.html
+++ b/examples/framework/preferences/conditionalAdjusters-singlePanel/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/conditionalAdjusters/index.html
+++ b/examples/framework/preferences/conditionalAdjusters/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/fullPagePanelStyle/index.html
+++ b/examples/framework/preferences/fullPagePanelStyle/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/examples/framework/preferences/localizationPreference/urlPath/en/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/en/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/localizationPreference/urlPath/es/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/es/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/localizationPreference/urlPath/fa/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/fa/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/localizationPreference/urlPath/fr/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/fr/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/localizationPreference/urlPath/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/preferences/css/PrefsEditor.css" />

--- a/examples/framework/preferences/minimalFootprint/fullPage.html
+++ b/examples/framework/preferences/minimalFootprint/fullPage.html
@@ -3,7 +3,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/examples/framework/preferences/minimalFootprint/html/prefsEditorPreview.html
+++ b/examples/framework/preferences/minimalFootprint/html/prefsEditorPreview.html
@@ -3,7 +3,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/preferences/css/Enactors.css" />
         <link rel="stylesheet" type="text/css" href="../css/style.css" />

--- a/examples/framework/preferences/minimalFootprint/index.html
+++ b/examples/framework/preferences/minimalFootprint/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/preferences/css/Enactors.css" />
         <link rel="stylesheet" type="text/css" href="css/style.css" />

--- a/examples/framework/preferences/shared/html/SeparatedPanelPrefsEditorFrame.html
+++ b/examples/framework/preferences/shared/html/SeparatedPanelPrefsEditorFrame.html
@@ -3,7 +3,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/examples/framework/preferences/usingGrades/css/usingGrades.css
+++ b/examples/framework/preferences/usingGrades/css/usingGrades.css
@@ -14,3 +14,9 @@ main {
     max-width: 950px;
     width: 95%;
 }
+
+button,
+input {
+    font-family: inherit;
+    font-size: 100%;
+}

--- a/examples/framework/preferences/usingGrades/index.html
+++ b/examples/framework/preferences/usingGrades/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/preferences/css/Enactors.css" />

--- a/examples/framework/renderer/dataBinding/index.html
+++ b/examples/framework/renderer/dataBinding/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <title>Renderer Example: Data-Binding</title>
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/renderer-examples.css" />
 
         <script type="text/javascript" src="../../../../src/lib/jquery/core/js/jquery.js"></script>

--- a/examples/framework/renderer/programmaticTree/index.html
+++ b/examples/framework/renderer/programmaticTree/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <title>Renderer Example: Data-Binding with Programmatically-generated Component Tree</title>
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/renderer-examples.css" />
 
         <script type="text/javascript" src="../../../../src/lib/jquery/core/js/jquery.js"></script>

--- a/examples/framework/renderer/selectors/index.html
+++ b/examples/framework/renderer/selectors/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <title>Renderer Example: Selector-based</title>
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../shared/css/renderer-examples.css" />
 
         <script type="text/javascript" src="../../../../src/lib/jquery/core/js/jquery.js"></script>

--- a/examples/framework/renderer/shared/css/renderer-examples.css
+++ b/examples/framework/renderer/shared/css/renderer-examples.css
@@ -68,5 +68,11 @@ td > span {
 .model-dump {
     border: solid 1px;
     font-family: monospace;
-    font-size: larger;
+    font-size: 18px;
+}
+
+button,
+input {
+    font-family: inherit;
+    font-size: 100%;
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "jquery.scrollto": "2.1.2",
         "lodash": "4.17.20",
         "ncp": "2.0.0",
-        "normalize.css": "8.0.1",
         "npm-run-all": "4.1.5",
         "nyc": "15.1.0",
         "open-dyslexic": "1.0.3",

--- a/src/components/inlineEdit/css/InlineEdit.css
+++ b/src/components/inlineEdit/css/InlineEdit.css
@@ -2,7 +2,10 @@
 
 .fl-inlineEdit-edit {
     border: 2px solid #0085ff;
-    margin-left: -1px;
+    font-family: inherit;
+    font-size: 100%;
+    line-height: 1.15;
+    margin: 0 0 0 -1px;
 }
 
 .fl-inlineEdit-simple-editableText {

--- a/src/components/inlineEdit/inlineEditDependencies.json
+++ b/src/components/inlineEdit/inlineEditDependencies.json
@@ -10,7 +10,6 @@
         "dependencies": [
             "jQuery",
             "jQueryUI",
-            "normalize",
             "framework",
             "undo",
             "tooltip"

--- a/src/components/orator/css/Orator.css
+++ b/src/components/orator/css/Orator.css
@@ -23,6 +23,13 @@
 .fl-orator-controller > * {
     background-color: #666;
     min-width: 3.6rem;
+    padding: 1px 6px;
+}
+
+.fl-orator-controller button {
+    font-family: inherit;
+    font-size: 100%;
+    margin: 0;
 }
 
 .fl-orator-controller > *:not(:first-child) {

--- a/src/components/overviewPanel/overviewPanelDependencies.json
+++ b/src/components/overviewPanel/overviewPanelDependencies.json
@@ -7,7 +7,6 @@
         ],
         "dependencies": [
             "jQuery",
-            "normalize",
             "opensans",
             "roboto",
             "framework",

--- a/src/components/pager/pagerDependencies.json
+++ b/src/components/pager/pagerDependencies.json
@@ -10,7 +10,6 @@
         ],
         "dependencies": [
             "jQuery",
-            "normalize",
             "framework",
             "renderer",
             "tooltip"

--- a/src/components/progress/progressDependencies.json
+++ b/src/components/progress/progressDependencies.json
@@ -7,7 +7,6 @@
         ],
         "dependencies": [
             "jQuery",
-            "normalize",
             "framework"
         ]
     }

--- a/src/components/reorderer/reordererDependencies.json
+++ b/src/components/reorderer/reordererDependencies.json
@@ -18,7 +18,6 @@
             "jQuery",
             "jQueryUI",
             "jQueryTouchPunchPlugin",
-            "normalize",
             "framework"
         ]
     }

--- a/src/components/slidingPanel/slidingPanelDependencies.json
+++ b/src/components/slidingPanel/slidingPanelDependencies.json
@@ -9,7 +9,6 @@
         "dependencies": [
             "jQuery",
             "jQueryUI",
-            "normalize",
             "framework"
         ]
     }

--- a/src/components/switch/css/Switch.css
+++ b/src/components/switch/css/Switch.css
@@ -14,6 +14,8 @@
     border-radius: calc(var(--fl-switch-knobSize) + var(--fl-switch-knobMargin));
     box-sizing: content-box;
     display: flex;
+    font-family: inherit;
+    font-size: 100%;
     margin: 0 1em;
     padding: 0;
     width: calc(var(--fl-switch-knobSize) * 3);

--- a/src/components/switch/switchDependencies.json
+++ b/src/components/switch/switchDependencies.json
@@ -10,7 +10,6 @@
         ],
         "dependencies": [
             "jQuery",
-            "normalize",
             "framework"
         ]
     }

--- a/src/components/tableOfContents/tableOfContentsDependencies.json
+++ b/src/components/tableOfContents/tableOfContentsDependencies.json
@@ -7,7 +7,6 @@
         ],
         "dependencies": [
             "jQuery",
-            "normalize",
             "framework",
             "renderer"
         ]

--- a/src/components/textfieldControl/css/TextfieldSlider.css
+++ b/src/components/textfieldControl/css/TextfieldSlider.css
@@ -7,6 +7,8 @@
 /* Textfield Stlying */
 
 .fl-textfieldSlider .fl-textfieldSlider-textField {
+    font-family: inherit;
+    font-size: 100%;
     margin: 0;
     margin-left: 1rem;
     text-align: center;

--- a/src/components/textfieldControl/css/TextfieldStepper.css
+++ b/src/components/textfieldControl/css/TextfieldStepper.css
@@ -23,6 +23,8 @@
 /* Textfield Styling */
 
 .fl-textfieldStepper .fl-textfieldStepper-textField {
+    font-family: inherit;
+    font-size: 100%;
     margin: 0 0.5rem;
     text-align: center;
     width: 7rem;

--- a/src/components/textfieldControl/textfieldControlDependencies.json
+++ b/src/components/textfieldControl/textfieldControlDependencies.json
@@ -13,7 +13,6 @@
         ],
         "dependencies": [
             "jQuery",
-            "normalize",
             "framework"
         ]
     }

--- a/src/components/tooltip/tooltipDependencies.json
+++ b/src/components/tooltip/tooltipDependencies.json
@@ -8,7 +8,6 @@
         "dependencies": [
             "jQuery",
             "jQueryUI",
-            "normalize",
             "framework"
         ]
     }

--- a/src/components/uploader/uploaderDependencies.json
+++ b/src/components/uploader/uploaderDependencies.json
@@ -16,7 +16,6 @@
             "jQuery",
             "jQueryUI",
             "jQueryScrollToPlugin",
-            "normalize",
             "framework",
             "progress",
             "enhancement"

--- a/src/framework/preferences/css/sass/PrefsEditor.scss
+++ b/src/framework/preferences/css/sass/PrefsEditor.scss
@@ -53,6 +53,8 @@ $icon-font: 'PrefsFramework-Icons';
     // Drop downs
     select {
         border: 2px solid #ebebeb;
+        font-family: inherit;
+        font-size: 100%;
 
         &#textFont {
             display: block;

--- a/src/framework/preferences/css/sass/PrefsEditor.scss
+++ b/src/framework/preferences/css/sass/PrefsEditor.scss
@@ -203,6 +203,8 @@ $icon-font: 'PrefsFramework-Icons';
         background-color: #fff;
         border: 2px solid #000;
         border-radius: 0.4rem;
+        font-family: inherit;
+        font-size: 100%;
         height: 2.4375em;
         width: 2.4375em;
     }

--- a/src/framework/preferences/css/sass/SeparatedPanelPrefsEditor.scss
+++ b/src/framework/preferences/css/sass/SeparatedPanelPrefsEditor.scss
@@ -21,6 +21,10 @@ $icon-font: 'PrefsFramework-Icons';
     src: url('../../../lib/opensans/fonts/OpenSans-SemiBold.woff');
 }
 
+body {
+    margin: 0;
+}
+
 // Top bar and show/hide button
 .fl-prefsEditor-separatedPanel {
     display: flex;

--- a/src/framework/preferences/html/SeparatedPanelPrefsEditorFrame.html
+++ b/src/framework/preferences/html/SeparatedPanelPrefsEditorFrame.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/src/framework/preferences/preferencesDependencies.json
+++ b/src/framework/preferences/preferencesDependencies.json
@@ -51,7 +51,6 @@
             "jQuery",
             "jQueryUI",
             "hypher",
-            "normalize",
             "opensans",
             "url-polyfill",
             "framework",

--- a/src/thirdPartyDependencies.json
+++ b/src/thirdPartyDependencies.json
@@ -66,13 +66,6 @@
             "jQuery"
         ]
     },
-    "normalize": {
-        "name": "normalize.css",
-        "description": "Normalize.css makes browsers render all elements more consistently and in line with modern standards. It precisely targets only the styles that need normalizing.",
-        "cssFiles": [
-            "./lib/normalize/css/normalize.css"
-        ]
-    },
     "opensans": {
         "name": "opensans",
         "description": "Open Sans web font",

--- a/tests/framework-tests/preferences/html/SeparatedPanelPrefsEditorFrame.html
+++ b/tests/framework-tests/preferences/html/SeparatedPanelPrefsEditorFrame.html
@@ -5,7 +5,6 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
         <title>Preferences Editor</title>
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/tests/framework-tests/preferences/html/SeparatedPanelPrefsEditorResponsiveTestPage.html
+++ b/tests/framework-tests/preferences/html/SeparatedPanelPrefsEditorResponsiveTestPage.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>SeparatedPanel Preferences Editor Responsive Test Page</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../src/framework/core/css/fluid.css" />
 
         <!-- CSS required for the Prefs Editor -->

--- a/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
+++ b/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
@@ -146,7 +146,8 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
     };
 
     fluid.tests.prefs.assertStoredSettings = function (storedSettings) {
-        jqUnit.assertDeepEq("Only the changed preferences are saved", fluid.tests.prefs.bwSkin, storedSettings);
+        // Only check the "preferences" part of the model to avoid FLUID-6610
+        jqUnit.assertDeepEq("Only the changed preferences are saved", fluid.tests.prefs.bwSkin.preferences, storedSettings.preferences);
     };
 
     fluid.tests.prefs.assertSecondShow = function (separatedPanel) {

--- a/tests/manual-tests/components/inlineEdit/dropdown/index.html
+++ b/tests/manual-tests/components/inlineEdit/dropdown/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Dropdown Inline Edit</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../lib/jquery/plugins/selectbox/selectbox.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/lib/jquery/ui/css/default-theme/core.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/lib/jquery/ui/css/default-theme/tooltip.css" />

--- a/tests/manual-tests/components/inlineEdit/rich/index.html
+++ b/tests/manual-tests/components/inlineEdit/rich/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Rich Text Inline Edit</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/components/inlineEdit/css/InlineEdit.css" />
         <link rel="stylesheet" type="text/css" href="css/InlineEdit.css" />
@@ -17,7 +16,7 @@
         <script src="../../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script src="../../../../../src/lib/jquery/ui/js/version.js"></script>
         <script src="../../../../../src/lib/jquery/ui/js/keycode.js"></script>
-        
+
         <script src="../../../../../src/framework/core/js/FluidDocument.js"></script>
         <script src="../../../../../src/framework/core/js/jquery.keyboard-a11y.js"></script>
         <script src="../../../../../src/framework/core/js/Fluid.js"></script>

--- a/tests/manual-tests/components/reorderer/dynamic/index.html
+++ b/tests/manual-tests/components/reorderer/dynamic/index.html
@@ -3,7 +3,6 @@
     <head>
 
         <title>Dynamic Reorderer</title>
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
         <link type="text/css" rel="stylesheet" href="css/reorderer.css" />
 

--- a/tests/manual-tests/framework/core/multipleVersions/index.html
+++ b/tests/manual-tests/framework/core/multipleVersions/index.html
@@ -3,8 +3,6 @@
     <head>
         <title>Multiple Versions of Infusion</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
-
         <!-- styling for manual tests -->
         <link rel="stylesheet" type="text/css" href="../../../shared/css/manualTests.css" />
 
@@ -26,7 +24,7 @@
         <script src="../../../../../src/lib/jquery/ui/js/unique-id.js"></script>
         <script src="../../../../../src/lib/jquery/ui/js/mouse.js"></script>
         <script src="../../../../../src/lib/jquery/ui/js/draggable.js"></script>
-        
+
         <script src="../../../../../src/framework/core/js/FluidDocument.js"></script>
         <script src="../../../../../src/framework/core/js/jquery.keyboard-a11y.js"></script>
         <script src="../../../../../src/framework/core/js/Fluid.js"></script>

--- a/tests/manual-tests/framework/core/performance-fastInvokers/index.html
+++ b/tests/manual-tests/framework/core/performance-fastInvokers/index.html
@@ -4,8 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Performance Tests: Fast Invokers</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
-
         <!-- styling for manual tests -->
         <link rel="stylesheet" type="text/css" href="../../../shared/css/manualTests.css" />
 

--- a/tests/manual-tests/framework/core/performance-get/index.html
+++ b/tests/manual-tests/framework/core/performance-get/index.html
@@ -4,8 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Performance Tests: fluid.get</title>
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
-
         <!-- styling for manual tests -->
         <link rel="stylesheet" type="text/css" href="../../../shared/css/manualTests.css" />
 

--- a/tests/manual-tests/framework/preferences/assortedContent/html/SeparatedPanelPrefsEditorFrame.html
+++ b/tests/manual-tests/framework/preferences/assortedContent/html/SeparatedPanelPrefsEditorFrame.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/tests/manual-tests/framework/preferences/assortedContent/index.html
+++ b/tests/manual-tests/framework/preferences/assortedContent/index.html
@@ -4,7 +4,6 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
 
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/preferences/css/Enactors.css" />

--- a/tests/manual-tests/framework/preferences/fullPage-schema/index.html
+++ b/tests/manual-tests/framework/preferences/fullPage-schema/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/tests/manual-tests/framework/preferences/fullPage/index.html
+++ b/tests/manual-tests/framework/preferences/fullPage/index.html
@@ -3,7 +3,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../src/framework/core/css/fluid.css" />
 
         <!-- Component styles -->

--- a/tests/manual-tests/framework/preferences/shared/html/prefsEditorPreview.html
+++ b/tests/manual-tests/framework/preferences/shared/html/prefsEditorPreview.html
@@ -3,7 +3,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <link rel="stylesheet" type="text/css" href="../../../../../../src/lib/normalize/css/normalize.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/core/css/fluid.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../src/framework/preferences/css/Enactors.css" />
         <link rel="stylesheet" type="text/css" href="../../../../../../demos/uiOptions/css/uiOptions.css" />


### PR DESCRIPTION
This PR required minimal CSS changes, as follows:

- In several components and throughout demos, `button`, `input`, and `select` elements were given the following CSS to preserve their expected font family and size: `font-family: inherit; font-size: 100%`.
- In the separated panel preferences editor stylesheet, a `margin: 0` rule was added to the `body` element to preserve the prefs editor panel's position flush at the top of the window.