### PR TITLE
FLUID-6608: remove url-polyfill dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 /src/lib/open-dyslexic/
 /src/lib/opensans/
 /src/lib/roboto/
-/src/lib/url-polyfill/
 /tests/lib/jquery-simulate/
 /tests/lib/mockjax/
 /tests/lib/sinon/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,7 +204,6 @@ module.exports = function (grunt) {
                 "src/lib/open-dyslexic",
                 "src/lib/opensans",
                 "src/lib/roboto",
-                "src/lib/url-polyfill",
                 "tests/lib/jquery-simulate",
                 "tests/lib/mockjax",
                 "tests/lib/sinon"
@@ -361,11 +360,6 @@ module.exports = function (grunt) {
                 }, {
                     src: "node_modules/sinon/pkg/sinon.js",
                     dest: "tests/lib/sinon/js/",
-                    expand: true,
-                    flatten: true
-                }, {
-                    src: "node_modules/url-polyfill/url-polyfill.js",
-                    dest: "src/lib/url-polyfill/js/",
                     expand: true,
                     flatten: true
                 }]

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ Distribution bundles can be [viewed on unpkg](https://unpkg.com/browse/infusion/
 * open-dyslexic
 * opensans
 * roboto
-* url-polyfill
 
 ## How Do I Run Tests?
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -89,7 +89,6 @@ categorized by license:
 * [jquery.simulate v1.0.2](https://github.com/eduardolundgren/jquery-simulate)
 * [Micro Clearfix](http://nicolasgallagher.com/micro-clearfix-hack/)
 * [Normalize v8.0.0](https://necolas.github.io/normalize.css/)
-* [url-polyfill v1.0.14](https://github.com/lifaon74/url-polyfill)
 
 ### Open Font License
 

--- a/examples/framework/preferences/captionsPreference/index.html
+++ b/examples/framework/preferences/captionsPreference/index.html
@@ -15,7 +15,6 @@
         <script type="text/javascript" src="../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../src/lib/jquery/ui/js/version.js"></script>
         <script type="text/javascript" src="../../../../src/lib/jquery/ui/js/keycode.js"></script>
-        <script type="text/javascript" src="../../../../src/lib/url-polyfill/js/url-polyfill.js"></script>
 
 
         <script type="text/javascript" src="../../../../src/framework/core/js/Fluid.js"></script>

--- a/examples/framework/preferences/localizationPreference/urlPath/en/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/en/index.html
@@ -14,7 +14,6 @@
         <script type="text/javascript" src="../../../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/version.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/keycode.js"></script>
-        <script type="text/javascript" src="../../../../../../src/lib/url-polyfill/js/url-polyfill.js"></script>
 
         <script type="text/javascript" src="../../../../../../src/framework/core/js/Fluid.js"></script>
         <script type="text/javascript" src="../../../../../../src/framework/core/js/FluidDocument.js"></script>

--- a/examples/framework/preferences/localizationPreference/urlPath/es/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/es/index.html
@@ -14,7 +14,6 @@
         <script type="text/javascript" src="../../../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/version.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/keycode.js"></script>
-        <script type="text/javascript" src="../../../../../../src/lib/url-polyfill/js/url-polyfill.js"></script>
 
         <script type="text/javascript" src="../../../../../../src/framework/core/js/Fluid.js"></script>
         <script type="text/javascript" src="../../../../../../src/framework/core/js/FluidDocument.js"></script>

--- a/examples/framework/preferences/localizationPreference/urlPath/fa/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/fa/index.html
@@ -14,7 +14,6 @@
         <script type="text/javascript" src="../../../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/version.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/keycode.js"></script>
-        <script type="text/javascript" src="../../../../../../src/lib/url-polyfill/js/url-polyfill.js"></script>
 
         <script type="text/javascript" src="../../../../../../src/framework/core/js/Fluid.js"></script>
         <script type="text/javascript" src="../../../../../../src/framework/core/js/FluidDocument.js"></script>

--- a/examples/framework/preferences/localizationPreference/urlPath/fr/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/fr/index.html
@@ -14,7 +14,6 @@
         <script type="text/javascript" src="../../../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/version.js"></script>
         <script type="text/javascript" src="../../../../../../src/lib/jquery/ui/js/keycode.js"></script>
-        <script type="text/javascript" src="../../../../../../src/lib/url-polyfill/js/url-polyfill.js"></script>
 
         <script type="text/javascript" src="../../../../../../src/framework/core/js/Fluid.js"></script>
         <script type="text/javascript" src="../../../../../../src/framework/core/js/FluidDocument.js"></script>

--- a/examples/framework/preferences/localizationPreference/urlPath/index.html
+++ b/examples/framework/preferences/localizationPreference/urlPath/index.html
@@ -14,7 +14,6 @@
         <script type="text/javascript" src="../../../../../src/lib/jquery/core/js/jquery.js"></script>
         <script type="text/javascript" src="../../../../../src/lib/jquery/ui/js/version.js"></script>
         <script type="text/javascript" src="../../../../../src/lib/jquery/ui/js/keycode.js"></script>
-        <script type="text/javascript" src="../../../../../src/lib/url-polyfill/js/url-polyfill.js"></script>
 
         <script type="text/javascript" src="../../../../../src/framework/core/js/Fluid.js"></script>
         <script type="text/javascript" src="../../../../../src/framework/core/js/FluidDocument.js"></script>

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
         "roboto-fontface": "0.10.0",
         "serve": "11.3.2",
         "sinon": "9.1.0",
-        "testem": "3.2.0",
-        "url-polyfill": "1.1.10"
+        "testem": "3.2.0"
     }
 }

--- a/src/framework/preferences/preferencesDependencies.json
+++ b/src/framework/preferences/preferencesDependencies.json
@@ -53,7 +53,6 @@
             "hypher",
             "normalize",
             "opensans",
-            "url-polyfill",
             "framework",
             "enhancement",
             "renderer",

--- a/src/thirdPartyDependencies.json
+++ b/src/thirdPartyDependencies.json
@@ -98,12 +98,5 @@
             "./lib/roboto/fonts/Roboto-Slab-Regular.woff",
             "./lib/roboto/fonts/Roboto-Slab-Thin.woff"
         ]
-    },
-    "url-polyfill": {
-        "name": "url-polyfill",
-        "description": "Polyfill URL and URLSearchParams to match last WHATWG specifications",
-        "files": [
-            "./lib/url-polyfill/js/url-polyfill.js"
-        ]
     }
 }

--- a/tests/framework-tests/preferences/html/CaptionsEnactor-test.html
+++ b/tests/framework-tests/preferences/html/CaptionsEnactor-test.html
@@ -8,7 +8,6 @@
         <link rel="stylesheet" media="screen" href="../../../lib/qunit/css/qunit.css" />
 
         <script src="../../../../src/lib/jquery/core/js/jquery.js"></script>
-        <script src="../../../../src/lib/url-polyfill/js/url-polyfill.js"></script>
         <script src="../../../../src/framework/core/js/Fluid.js"></script>
         <script src="../../../../src/framework/core/js/FluidPromises.js"></script>
         <script src="../../../../src/framework/core/js/FluidDocument.js"></script>


### PR DESCRIPTION
The URL api is now available in all of our supported browsers (https://caniuse.com/url) so I think it can safely be removed.