### PR TITLE
FLUID-6619: announce contrast themes with VoiceOver/Edge

### DIFF
--- a/src/framework/preferences/js/Panels.js
+++ b/src/framework/preferences/js/Panels.js
@@ -778,9 +778,6 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                 theme: themeValue
             }));
 
-            // Aria-label set to prevent Firefox from reading out the display 'a'
-            label.attr("aria-label", themeValue);
-
             var labelTheme = theme[index];
             if (labelTheme === defaultThemeName) {
                 label.addClass(defaultLabelStyle);

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -1244,7 +1244,6 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
             inputValue = input.value;
             label = labels.eq(index);
             jqUnit.assertTrue("The contrast label has appropriate css applied", label.hasClass(that.options.classnameMap.theme[inputValue]));
-            jqUnit.assertEquals("The aria-label is " + that.options.messageBase.contrast[index], that.options.messageBase.contrast[index], label.attr("aria-label"));
             jqUnit.assertEquals("The input has the correct name attribute", that.id, $(input).attr("name"));
         });
 

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -1317,7 +1317,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         modules: [{
             name: "Test the contrast settings panel with controlValues replaced",
             tests: [{
-                expect: 15,
+                expect: 12,
                 name: "Test the rendering of the contrast panel",
                 sequence: [{
                     listener: "fluid.tests.contrastPanel.testDefault",

--- a/tests/framework-tests/preferences/js/PanelsTests.js
+++ b/tests/framework-tests/preferences/js/PanelsTests.js
@@ -1266,7 +1266,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         modules: [{
             name: "Test the contrast settings panel",
             tests: [{
-                expect: 33,
+                expect: 24,
                 name: "Test the rendering of the contrast panel",
                 sequence: [{
                     listener: "fluid.tests.contrastPanel.testDefault",


### PR DESCRIPTION
This restores accessible labels to VoiceOver with Edge/Chrome on macOS. Should be tested on with Firefox on Windows using NVDA/JAWS to make sure it doesn't regress the behaviour that the `aria-label` was added to address.