### PR TITLE
FLUID-6620: convert Textfield Stepper to number input

### DIFF
--- a/demos/textfieldControl/index.html
+++ b/demos/textfieldControl/index.html
@@ -76,7 +76,7 @@
                 <span class="demo-smallIcon">A</span>
                 <span class="flc-textfieldStepper-focusContainer fl-textfieldStepper-focusContainer">
                     <button class="flc-textfieldStepper-decrease" type="button">-</button>
-                    <input class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="text">
+                    <input class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="number">
                     <button class="flc-textfieldStepper-increase" type="button">+</button>
                 </span>
                 <span class="demo-largeIcon">A</span>

--- a/src/components/textfieldControl/css/TextfieldStepper.css
+++ b/src/components/textfieldControl/css/TextfieldStepper.css
@@ -23,11 +23,18 @@
 /* Textfield Styling */
 
 .fl-textfieldStepper .fl-textfieldStepper-textField {
+    -moz-appearance: textfield;
     font-family: inherit;
     font-size: 100%;
     margin: 0 0.5rem;
     text-align: center;
     width: 7rem;
+}
+
+.fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-inner-spin-button,
+.fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-outer-spin-button {
+    appearance: none;
+    margin: 0;
 }
 
 /* Textfield Button Styling */

--- a/src/components/textfieldControl/css/TextfieldStepper.css
+++ b/src/components/textfieldControl/css/TextfieldStepper.css
@@ -33,7 +33,7 @@
 
 .fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-inner-spin-button,
 .fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-outer-spin-button {
-    appearance: none;
+    -webkit-appearance: none;
     margin: 0;
 }
 

--- a/src/components/textfieldControl/js/TextfieldStepper.js
+++ b/src/components/textfieldControl/js/TextfieldStepper.js
@@ -80,13 +80,6 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                             // down arrow === 40
                             args: ["{that}.container", "keydown", 40, "{textfieldStepper}.decrease"]
                         }
-                    },
-                    modelListeners: {
-                        "value": {
-                            "this": "{that}.container",
-                            method: "attr",
-                            args: ["value", "{change}.value"]
-                        }
                     }
                 }
             },

--- a/src/components/textfieldControl/js/TextfieldStepper.js
+++ b/src/components/textfieldControl/js/TextfieldStepper.js
@@ -51,12 +51,17 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                                     "range.min": {
                                         "this": "{textfield}.container",
                                         method: "attr",
-                                        args: ["aria-valuemin", "{change}.value"]
+                                        args: ["min", "{change}.value"]
                                     },
                                     "range.max": {
                                         "this": "{textfield}.container",
                                         method: "attr",
-                                        args: ["aria-valuemax", "{change}.value"]
+                                        args: ["max", "{change}.value"]
+                                    },
+                                    "step": {
+                                        "this": "{textfield}.container",
+                                        method: "attr",
+                                        args: ["step", "{change}.value"]
                                     }
                                 }
                             }
@@ -74,18 +79,13 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                             listener: "fluid.textfieldStepper.bindKeyEvent",
                             // down arrow === 40
                             args: ["{that}.container", "keydown", 40, "{textfieldStepper}.decrease"]
-                        },
-                        "onCreate.addRole": {
-                            "this": "{that}.container",
-                            method: "attr",
-                            args: ["role", "spinbutton"]
                         }
                     },
                     modelListeners: {
                         "value": {
                             "this": "{that}.container",
                             method: "attr",
-                            args: ["aria-valuenow", "{change}.value"]
+                            args: ["value", "{change}.value"]
                         }
                     }
                 }

--- a/src/components/textfieldControl/js/TextfieldStepper.js
+++ b/src/components/textfieldControl/js/TextfieldStepper.js
@@ -68,19 +68,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                         }
                     },
                     attrs: "{textfieldStepper}.options.attrs",
-                    strings: "{textfieldStepper}.options.strings",
-                    listeners: {
-                        "onCreate.bindUpArrow": {
-                            listener: "fluid.textfieldStepper.bindKeyEvent",
-                            // up arrow === 38
-                            args: ["{that}.container", "keydown", 38, "{textfieldStepper}.increase"]
-                        },
-                        "onCreate.bindDownArrow": {
-                            listener: "fluid.textfieldStepper.bindKeyEvent",
-                            // down arrow === 40
-                            args: ["{that}.container", "keydown", 40, "{textfieldStepper}.decrease"]
-                        }
-                    }
+                    strings: "{textfieldStepper}.options.strings"
                 }
             },
             increaseButton: {
@@ -194,15 +182,6 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         coefficient = coefficient || 1;
         var newValue = that.model.value + (coefficient * that.model.step);
         that.applier.change("value", newValue);
-    };
-
-    fluid.textfieldStepper.bindKeyEvent = function (elm, keyEvent, keyCode, fn) {
-        $(elm).on(keyEvent, function (event) {
-            if (event.which === keyCode) {
-                fn();
-                event.preventDefault();
-            }
-        });
     };
 
     fluid.defaults("fluid.textfieldStepper.button", {

--- a/src/framework/preferences/css/sass/PrefsEditor.scss
+++ b/src/framework/preferences/css/sass/PrefsEditor.scss
@@ -202,7 +202,7 @@ $icon-font: 'PrefsFramework-Icons';
 
     .fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-inner-spin-button,
     .fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-outer-spin-button {
-        appearance: none;
+        -webkit-appearance: none;
         margin: 0;
     }
 

--- a/src/framework/preferences/css/sass/PrefsEditor.scss
+++ b/src/framework/preferences/css/sass/PrefsEditor.scss
@@ -193,10 +193,17 @@ $icon-font: 'PrefsFramework-Icons';
     /* height and width specified in ems instead of rems
        to respond to emphasize links preferences */
     .fl-textfieldStepper .fl-textfieldStepper-textField {
+        -moz-appearance: textfield;
         height: 2em;
         margin: 0 0.5em;
         text-align: center;
         width: 4em;
+    }
+
+    .fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-inner-spin-button,
+    .fl-textfieldStepper .fl-textfieldStepper-textField::-webkit-outer-spin-button {
+        appearance: none;
+        margin: 0;
     }
 
     .fl-textfieldStepper .fl-textfieldStepper-button {

--- a/src/framework/preferences/css/sass/PrefsEditor.scss
+++ b/src/framework/preferences/css/sass/PrefsEditor.scss
@@ -194,6 +194,8 @@ $icon-font: 'PrefsFramework-Icons';
        to respond to emphasize links preferences */
     .fl-textfieldStepper .fl-textfieldStepper-textField {
         -moz-appearance: textfield;
+        font-family: inherit;
+        font-size: 100%;
         height: 2em;
         margin: 0 0.5em;
         text-align: center;

--- a/src/framework/preferences/html/PrefsEditorTemplate-letterSpace.html
+++ b/src/framework/preferences/html/PrefsEditorTemplate-letterSpace.html
@@ -8,7 +8,7 @@
         <span class="fl-icon-letter-space-condensed" role="presentation"></span>
         <span class="flc-textfieldStepper-focusContainer fl-textfieldStepper-focusContainer">
             <button class="flc-textfieldStepper-decrease" type="button">-</button>
-            <input aria-labelledby="letter-space-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="text">
+            <input aria-labelledby="letter-space-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="number">
             <button class="flc-textfieldStepper-increase" type="button">+</button>
         </span>
         <span class="fl-icon-letter-space-expanded" role="presentation"></span>

--- a/src/framework/preferences/html/PrefsEditorTemplate-lineSpace.html
+++ b/src/framework/preferences/html/PrefsEditorTemplate-lineSpace.html
@@ -8,7 +8,7 @@
         <span class="fl-icon-line-space-condensed" role="presentation"></span>
         <span class="flc-textfieldStepper-focusContainer fl-textfieldStepper-focusContainer">
             <button class="flc-textfieldStepper-decrease" type="button">-</button>
-            <input aria-labelledby="line-space-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="text">
+            <input aria-labelledby="line-space-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="number">
             <button class="flc-textfieldStepper-increase" type="button">+</button>
         </span>
         <span class="fl-icon-line-space-expanded" role="presentation"></span>

--- a/src/framework/preferences/html/PrefsEditorTemplate-textSize.html
+++ b/src/framework/preferences/html/PrefsEditorTemplate-textSize.html
@@ -8,7 +8,7 @@
         <span class="fl-icon-small-a" role="presentation"></span>
         <span class="flc-textfieldStepper-focusContainer fl-textfieldStepper-focusContainer">
             <button class="flc-textfieldStepper-decrease" type="button">-</button>
-            <input aria-labelledby="text-size-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="text">
+            <input aria-labelledby="text-size-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="number">
             <button class="flc-textfieldStepper-increase" type="button">+</button>
         </span>
         <span class="fl-icon-big-a" role="presentation"></span>

--- a/src/framework/preferences/html/PrefsEditorTemplate-wordSpace.html
+++ b/src/framework/preferences/html/PrefsEditorTemplate-wordSpace.html
@@ -8,7 +8,7 @@
         <span class="fl-icon-word-space-condensed" role="presentation"></span>
         <span class="flc-textfieldStepper-focusContainer fl-textfieldStepper-focusContainer">
             <button class="flc-textfieldStepper-decrease" type="button">-</button>
-            <input aria-labelledby="word-space-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="text">
+            <input aria-labelledby="word-space-label" class="flc-textfieldStepper-field fl-textfieldStepper-textField" type="number">
             <button class="flc-textfieldStepper-increase" type="button">+</button>
         </span>
         <span class="fl-icon-word-space-expanded" role="presentation"></span>

--- a/tests/component-tests/textfieldControl/html/TextfieldStepper-test.html
+++ b/tests/component-tests/textfieldControl/html/TextfieldStepper-test.html
@@ -56,7 +56,7 @@
     <label id="label-nativeHTML">Textfield Stepper</label>
     <div class="flc-textfieldStepper">
         <button class="flc-textfieldStepper-decrease">-</button>
-        <input aria-labelledby="text-size-label" class="flc-textfieldStepper-field" type="text">
+        <input aria-labelledby="text-size-label" class="flc-textfieldStepper-field" type="number">
         <button class="flc-textfieldStepper-increase">+</button>
     </div>
 

--- a/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
+++ b/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
@@ -89,7 +89,6 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
         fluid.tests.textfieldStepper.verifyState = function (that, expectedValue, incBtnState, decBtnState) {
             jqUnit.assertEquals("The model value should be " + expectedValue, expectedValue, that.model.value);
-            jqUnit.assertEquals("The value should be " + expectedValue, expectedValue.toString(), that.textfield.container.attr("value"));
             jqUnit.assertEquals("The increase button is " + (incBtnState ? "enabled" : "disabled"), incBtnState, !that.locate("increaseButton").is(":disabled"));
             jqUnit.assertEquals("The decrease button is " + (decBtnState ? "enabled" : "disabled"), decBtnState, !that.locate("decreaseButton").is(":disabled"));
         };

--- a/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
+++ b/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
@@ -89,6 +89,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
         fluid.tests.textfieldStepper.verifyState = function (that, expectedValue, incBtnState, decBtnState) {
             jqUnit.assertEquals("The model value should be " + expectedValue, expectedValue, that.model.value);
+            jqUnit.assertEquals("The value should be " + expectedValue, expectedValue.toString(), that.textfield.container.val());
             jqUnit.assertEquals("The increase button is " + (incBtnState ? "enabled" : "disabled"), incBtnState, !that.locate("increaseButton").is(":disabled"));
             jqUnit.assertEquals("The decrease button is " + (decBtnState ? "enabled" : "disabled"), decBtnState, !that.locate("decreaseButton").is(":disabled"));
         };

--- a/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
+++ b/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
@@ -148,8 +148,8 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                         changeEvent: "{stepper}.applier.modelChanged"
                     }, {
                         // decrease to minimum
-                        jQueryTrigger: "click",
-                        element: "{stepper}.dom.decreaseButton"
+                        jQueryTrigger: fluid.tests.textfieldControl.createKeyEvent("keydown", 40),
+                        element: "{stepper}.dom.textfield"
                     }, {
                         listener: "fluid.tests.textfieldStepper.verifyState",
                         args: ["{stepper}", 0, true, false],
@@ -157,8 +157,8 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                         changeEvent: "{stepper}.applier.modelChanged"
                     }, {
                         // increase
-                        jQueryTrigger: "click",
-                        element: "{stepper}.dom.increaseButton"
+                        jQueryTrigger: fluid.tests.textfieldControl.createKeyEvent("keydown", 38),
+                        element: "{stepper}.dom.textfield"
                     }, {
                         listener: "fluid.tests.textfieldStepper.verifyState",
                         args: ["{stepper}", 1, true, true],

--- a/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
+++ b/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
@@ -148,8 +148,8 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                         changeEvent: "{stepper}.applier.modelChanged"
                     }, {
                         // decrease to minimum
-                        jQueryTrigger: fluid.tests.textfieldControl.createKeyEvent("keydown", 40),
-                        element: "{stepper}.dom.textfield"
+                        jQueryTrigger: "click",
+                        element: "{stepper}.dom.decreaseButton"
                     }, {
                         listener: "fluid.tests.textfieldStepper.verifyState",
                         args: ["{stepper}", 0, true, false],
@@ -157,8 +157,8 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                         changeEvent: "{stepper}.applier.modelChanged"
                     }, {
                         // increase
-                        jQueryTrigger: fluid.tests.textfieldControl.createKeyEvent("keydown", 38),
-                        element: "{stepper}.dom.textfield"
+                        jQueryTrigger: "click",
+                        element: "{stepper}.dom.increaseButton"
                     }, {
                         listener: "fluid.tests.textfieldStepper.verifyState",
                         args: ["{stepper}", 1, true, true],

--- a/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
+++ b/tests/component-tests/textfieldControl/js/TextfieldStepperTests.js
@@ -89,7 +89,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
         fluid.tests.textfieldStepper.verifyState = function (that, expectedValue, incBtnState, decBtnState) {
             jqUnit.assertEquals("The model value should be " + expectedValue, expectedValue, that.model.value);
-            jqUnit.assertEquals("The aria-valuenow should be " + expectedValue, expectedValue.toString(), that.textfield.container.attr("aria-valuenow"));
+            jqUnit.assertEquals("The value should be " + expectedValue, expectedValue.toString(), that.textfield.container.attr("value"));
             jqUnit.assertEquals("The increase button is " + (incBtnState ? "enabled" : "disabled"), incBtnState, !that.locate("increaseButton").is(":disabled"));
             jqUnit.assertEquals("The decrease button is " + (decBtnState ? "enabled" : "disabled"), decBtnState, !that.locate("decreaseButton").is(":disabled"));
         };


### PR DESCRIPTION
This PR resolves [FLUID-6620](https://issues.fluidproject.org/browse/FLUID-6620) by updating the Textfield Stepper component throughout Infusion to a standard `<input type="number>` ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number)). This resolves the perplexing behaviour in VoiceOver on Safari where announced values are represented as a decimal based on `aria-valuenow` / `aria-valuemax` for inputs with the `spinbutton` role instead of the displayed value (see: https://bugs.webkit.org/show_bug.cgi?id=221102).

## Additional Information

The `number` input type has native `stepUp()` and `stepDown()` methods for incrementing and decrementing its value. It might be good to leverage these somehow instead of using the custom logic defined in `fluid.textfieldStepper.step`, but that's a nice to have.