### PR TITLE
FLUID-6632: Fix tests failing in Safari

### DIFF
--- a/tests/framework-tests/preferences/js/IntegrationTestsCommon.js
+++ b/tests/framework-tests/preferences/js/IntegrationTestsCommon.js
@@ -136,6 +136,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                 fluid.tests.prefs.checkModelSelections("model from original (correct state after reset and cancel)",
                     (resetShouldSave ? initialModel : fluid.tests.prefs.bwSkin), prefsEditor.model);
 
+                prefsEditorLoader.destroy();
                 jqUnit.start();
             }
 

--- a/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
+++ b/tests/framework-tests/preferences/js/SeparatedPanelPrefsEditorTests.js
@@ -40,6 +40,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         listeners: {
             "onDestroy.clearStore": "fluid.tests.prefs.clearStore"
         },
+        markupFixture: ".flc-prefsEditor-separatedPanel",
         components: {
             separatedPanel: {
                 type: "fluid.prefs.separatedPanel",
@@ -226,6 +227,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
     fluid.defaults("fluid.tests.prefs.separatedPanelMungingIntegration", {
         gradeNames: ["fluid.test.testEnvironment"],
+        markupFixture: ".flc-prefsEditor-separatedPanel",
         components: {
             separatedPanel: {
                 type: "fluid.prefs.separatedPanel",
@@ -307,6 +309,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
     fluid.defaults("fluid.tests.prefs.separatedPanelConditionalPanelIntegration", {
         gradeNames: ["fluid.test.testEnvironment"],
+        markupFixture: ".flc-prefsEditor-separatedPanel",
         components: {
             prefsEditor: {
                 type: "fluid.tests.composite.separatedPanel.prefsEditor",
@@ -380,6 +383,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
     fluid.defaults("fluid.tests.prefs.separatedPanelLazyLoadIntegration", {
         gradeNames: ["fluid.test.testEnvironment"],
+        markupFixture: ".flc-prefsEditor-separatedPanel",
         components: {
             prefsEditor: {
                 type: "fluid.tests.composite.separatedPanel.lazyLoad.prefsEditor",

--- a/tests/framework-tests/preferences/js/UIEnhancerTests.js
+++ b/tests/framework-tests/preferences/js/UIEnhancerTests.js
@@ -249,7 +249,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
         var child1emHeight = child1El.height() - 1; // adjusted to account for rounding by jQuery
         var child2emHeight = child2El.height();
-        jqUnit.assertTrue("The line height of the 2em child should be close to twice the size of the 1em child", 2 * child1emHeight < child2emHeight);
+        jqUnit.assertTrue("The line height of the 2em child should be close to twice the size of the 1em child", 2 * child1emHeight <= child2emHeight);
     };
 
     fluid.defaults("fluid.tests.lineHeightUnitTester", {


### PR DESCRIPTION
This is a blocker for Infusion 3.0

https://issues.fluidproject.org/browse/FLUID-6632