### PR TITLE
FLUID-6654: Use default selection highlighting when not set by theme

### DIFF
--- a/src/framework/preferences/css/sass/utils/_themes.scss
+++ b/src/framework/preferences/css/sass/utils/_themes.scss
@@ -96,8 +96,8 @@
 
     &::selection,
     ::selection {
-        background-color: var(--fl-selectedBgColor) !important;
-        color: var(--fl-selectedFgColor) !important;
+        background-color: var(--fl-selectedBgColor, highlight) !important;
+        color: var(--fl-selectedFgColor, highlighttext) !important;
     }
 
     iframe {
@@ -308,8 +308,8 @@
 
         &::selection,
         ::selection {
-            background-color: var(--fl-selectedFgColor) !important;
-            color: var(--fl-selectedBgColor) !important;
+            background-color: var(--fl-selectedFgColor, highlight) !important;
+            color: var(--fl-selectedBgColor, highlighttext) !important;
         }
 
         iframe {


### PR DESCRIPTION
https://issues.fluidproject.org/browse/FLUID-6654

This change restores the previous behaviour of using the default selection highlighting when the theme doesn't explicitly set it. Another option was to use a custom set selection highlighting styles based on the contrast theme. For binary this would be an inversion of the foreground/background colours. However, Safari blends the selections background-colour with the background-colour of the text being highlighted. This results in a lower contrast ratio. Try highlighting the text in this [example](https://codepen.io/jobara/full/mdmVYqG) and notice how the background affects the selection background colour. In most cases the contrast is still quite high, although not the same. In the low contrast theme (light-grey-dark-grey) the contrast drops significantly.