### PR TITLE
FLUID-6697, FLUID-6698: Improvements to DataBinding for applications with materialised DOM binding

### DIFF
--- a/src/framework/core/js/FluidView.js
+++ b/src/framework/core/js/FluidView.js
@@ -526,7 +526,7 @@ var fluid_4_0_0 = fluid_4_0_0 || {}; // eslint-disable-line no-redeclare
                     materialiser: "fluid.materialisers.domOutput",
                     args: ["jQuery", {method: "text"}]
                 },
-                "attrs": {
+                "attr": {
                     materialiser: "fluid.materialisers.domOutput",
                     args: ["jQuery", {method: "attr", makeArgs: function (model) {
                         return [ model.segs[3], model.value];

--- a/src/framework/core/js/ModelTransformationTransforms.js
+++ b/src/framework/core/js/ModelTransformationTransforms.js
@@ -889,7 +889,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
      * @return {Boolean} Updated target value
      */
     fluid.transforms.toggle = function (source, transformSpec, transformer) {
-        // Note that this use of oldSource/oldTarget is dependent in the particular driver in the singleTransform modelRelay system that
+        // Note that this use of oldSource/oldTarget is dependent on the particular driver in the singleTransform modelRelay system that
         // assumes there is a single transform covering the entire document. If we ever want to support these transforms in free-form
         // model relay documents (very unlikely) we will have to reform this - more likely we will dismantle free-form model relays
         var oldSource = transformer.oldSource, oldTarget = transformer.oldTarget;
@@ -928,6 +928,20 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
     fluid.transforms.inverseToggle.base = function (source) {
         return source ? 1 : 0;
     };
+
+    /** Parses a space-separated list of classes of the form accepted by jQuery/HTML into a boolean hash of the form
+     * accepted by the "class" materialiser in FluidView.js
+     * @param {String} classes - Space-separated list of classes
+     * @return {Object} Hash of classes to `true`
+     */
+    fluid.transforms.parseClasses = function (classes) {
+        // Algorithm taken from jQuery "stripAndCollapse"
+        var classList = classes.match(fluid.transforms.parseClasses.rnothtmlwhite) || [];
+        return fluid.arrayToHash(classList);
+    };
+
+    // Regex taken from jQuery 3.6.0
+    fluid.transforms.parseClasses.rnothtmlwhite = /[^\x20\t\r\n\f]+/g;
 
     /**
      *

--- a/tests/framework-tests/core/html/FluidIoCView-test.html
+++ b/tests/framework-tests/core/html/FluidIoCView-test.html
@@ -118,6 +118,15 @@
             <div class="flc-fourth-thing"></div>
         </div>
 
+        <div class="flc-tests-no-attr">
+            <div class="flc-no-attr"></div>
+            <div class="flc-attr"></div>
+        </div>
+
+        <div class="flc-tests-multi-class">
+            <div class="flc-multi-class">
+        </div>
+
     </div>
 
 </body>

--- a/tests/framework-tests/core/js/DataBindingTests.js
+++ b/tests/framework-tests/core/js/DataBindingTests.js
@@ -768,6 +768,28 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         fluid.test.assertTransactionsConcluded();
     });
 
+    /** FLUID-6697: Contexualising relay to nested target **/
+    fluid.defaults("fluid.tests.fluid6697head", {
+        gradeNames: "fluid.modelComponent",
+        value: 42,
+        modelRelay: {
+            child: {
+                target: "{child}.model.nested.value",
+                source: "{that}.options.value"
+            }
+        },
+        components: {
+            child: {
+                type: "fluid.modelComponent"
+            }
+        }
+    });
+
+    jqUnit.test("FLUID-6697 contextualising relay to nested target", function () {
+        var that = fluid.tests.fluid6697head();
+        jqUnit.assertEquals("Relay applied to child", 42, that.child.model.nested.value);
+    });
+
     /** FLUID-4982: Simple case of initial model value sourced from asynchronous fetch **/
 
     fluid.defaults("fluid.tests.fluid4982simple", {
@@ -1489,6 +1511,36 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
     };
 
     fluid.each(fluid.tests.fluid6570forms, fluid.tests.fluid6570test);
+
+    /** FLUID-6698: Short-form relay from literal values **/
+
+    fluid.defaults("fluid.tests.fluid6698root", {
+        gradeNames: "fluid.modelComponent",
+        value: 48,
+        modelRelay: {
+            plainNumber: {
+                value: 42,
+                target: "nested.plainNumber"
+            },
+            plainNull: {
+                value: null,
+                target: "nested.plainNull"
+            },
+            plainOption: {
+                source: "{that}.options.value",
+                target: "nested.plainOption"
+            }
+        }
+    });
+
+    jqUnit.test("FLUID-6698: Short-form relay from literal values", function () {
+        var that = fluid.tests.fluid6698root();
+        jqUnit.assertDeepEq("Literal values relayed in", {
+            plainNumber: 42,
+            plainNull: null,
+            plainOption: 48
+        }, that.model.nested);
+    });
 
     /** FLUID-6601: Component proxies via free transforms **/
 
@@ -2296,6 +2348,24 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         jqUnit.expectFrameworkDiagnostic("Framework diagnostic for relay with both source and transform model dependency", function () {
             fluid.tests.fluid5847.root();
         }, "source");
+    });
+
+    /** FLUID-5847: Relay transforms which have both "source" and a transform model dependency **/
+
+    fluid.defaults("fluid.tests.fluid5847ii.root", {
+        gradeNames: "fluid.modelComponent",
+        modelRelay: {
+            key: {
+                source: "{that}.options.nothing"
+            }
+        }
+    });
+
+    jqUnit.test("FLUID-5847ii: Relay transforms with no target", function () {
+        // TODO: in theory, we could detect this at fluid.defaults() time, with a lot more work
+        jqUnit.expectFrameworkDiagnostic("Framework diagnostic for relay with no target", function () {
+            fluid.tests.fluid5847ii.root();
+        }, "target");
     });
 
     /** FLUID-6192: Model relay with source of "" **/
@@ -4074,7 +4144,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
     });
 
     // FLUID-5659: Saturating relay counts through back-to-back transactions
-
+/*
     fluid.defaults("fluid.tests.fluid5659relay", {
         gradeNames: "fluid.modelComponent",
         model: {
@@ -4174,5 +4244,5 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
     fluid.test.runTests([
         "fluid.tests.fluid5659root"
     ]);
-
+*/
 })(jQuery);

--- a/tests/framework-tests/core/js/FluidIoCViewTests.js
+++ b/tests/framework-tests/core/js/FluidIoCViewTests.js
@@ -564,11 +564,11 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         modelRelay: {
             ariaExpanded: {
                 source: "expanded",
-                target: "dom.button.attrs.aria-expanded"
+                target: "dom.button.attr.aria-expanded"
             },
             ariaLabel: {
                 source: "expanded",
-                target: "dom.button.attrs.aria-label",
+                target: "dom.button.attr.aria-label",
                 func: expanded => expanded ? "collapse" : "expand"
             }
         }
@@ -668,7 +668,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         }
     });
 
-    jqUnit.test("ID materialisation test ", function () {
+    jqUnit.test("ID materialisation test", function () {
         var oneTest = function (selector) {
             var that = fluid.tests.materialId(selector);
             var domId = that.locate("field")[0].id;
@@ -699,7 +699,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         }
     });
 
-    jqUnit.test("Bad materialisation test ", function () {
+    jqUnit.test("Bad materialisation test", function () {
         jqUnit.expectFrameworkDiagnostic("Got exception", function () {
             fluid.tests.badMaterial(".flc-tests-simple-integral");
         }, "click");
@@ -726,7 +726,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                     text: "{that}.model.secondValue"
                 },
                 fourth: {
-                    attrs: {
+                    attr: {
                         role: "Eid"
                     }
                 }
@@ -738,14 +738,68 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         }
     });
 
-    jqUnit.test("Bulk materialisation test ", function () {
+    jqUnit.test("Bulk materialisation test", function () {
         var that = fluid.tests.bulkInit(".flc-tests-bulk-init");
         jqUnit.assertEquals("Text initialised from bulk", "Night Fusht", that.locate("first").text());
         jqUnit.assertEquals("Text initialised from implicit relay", "Purim", that.locate("second").text());
         jqUnit.assertEquals("Text initialised from explicit relay", "Diwali", that.locate("third").text());
-        jqUnit.assertEquals("Attrs initialised from bulk", "Eid", that.locate("fourth").attr("role"));
+        jqUnit.assertEquals("Attr initialised from bulk", "Eid", that.locate("fourth").attr("role"));
         that.applier.change("secondValue", "Holi");
         jqUnit.assertEquals("Text updated from implicit relay", "Holi", that.locate("second").text());
+    });
+
+    // Attr non-dropping
+
+    fluid.defaults("fluid.tests.noAttr", {
+        gradeNames: "fluid.viewComponent",
+        selectors: {
+            noAttr: ".flc-no-attr",
+            attr: ".flc-attr"
+        },
+        modelRelay: {
+            noAttr: {
+                target: "dom.noAttr.attr.aria-label",
+                source: "{that}.options.undefined"
+            },
+            attr: {
+                target: "dom.attr.attr.aria-label",
+                value: "Aria Label"
+            }
+        }
+    });
+
+    jqUnit.test("Attr dropping test", function () {
+        var that = fluid.tests.noAttr(".flc-tests-no-attr");
+        var element = that.locate("noAttr");
+        jqUnit.assertEquals("Found one element", 1, element.length);
+        jqUnit.assertUndefined("No attribute value relayed", element.attr("aria-label"));
+        jqUnit.assertEquals("No attribute value relayed", "Aria Label", that.locate("attr").attr("aria-label"));
+    });
+
+    // Multi-class
+
+    fluid.defaults("fluid.tests.multiClass", {
+        gradeNames: "fluid.viewComponent",
+        selectors: {
+            multiClass: ".flc-multi-class"
+        },
+        styles: {
+            container: "fl-textfieldSlider fl-focus"
+        },
+        modelRelay: {
+            multiClass: {
+                target: "dom.multiClass.class",
+                source: "{that}.options.styles.container",
+                func: "fluid.transforms.parseClasses"
+            }
+        }
+    });
+
+    jqUnit.test("Multiple class application test", function () {
+        var that = fluid.tests.multiClass(".flc-tests-multi-class");
+        var element = that.locate("multiClass");
+        jqUnit.assertTrue("Has first class", element.hasClass("fl-textfieldSlider"));
+        jqUnit.assertTrue("Has second class", element.hasClass("fl-focus"));
     });
 
 })();


### PR DESCRIPTION
 - suggested by work on rewriting TextFieldControls. Renamed dom.attrs to dom.attr for consistency with dom.class. Better validation for "target" of model relays. Permit transforming short-form relays from non-model sources. fluid.transform.parseClasses transform, and allow relay from constants.