### PR TITLE
FLUID-6703, FLUID-6704, FLUID-6706: Fixes supporting prefs framework rewrite

### DIFF
--- a/src/framework/core/js/FluidView.js
+++ b/src/framework/core/js/FluidView.js
@@ -461,8 +461,13 @@ var fluid_4_0_0 = fluid_4_0_0 || {}; // eslint-disable-line no-redeclare
     fluid.materialisers.id = function (that, segs) {
         that.events.onDomBind.addListener(function () {
             var element = that.dom.locate(segs[1])[0];
-            var id = fluid.allocateSimpleId(element);
-            that.applier.change(segs, id, "ADD", "DOM");
+            var modelValue = fluid.getImmediate(that.model, segs);
+            if (modelValue === undefined) {
+                var id = fluid.allocateSimpleId(element);
+                that.applier.change(segs, id, "ADD", "DOM");
+            } else {
+                element.id = modelValue;
+            }
             var modelListener = function (value) {
                 if (value !== undefined) {
                     element.id = value;

--- a/src/framework/core/js/NewViewSupport.js
+++ b/src/framework/core/js/NewViewSupport.js
@@ -88,7 +88,7 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
             global: {
                 fetchTemplates: {
                     funcName: "fluid.renderer.fetchTemplates",
-                    priority: "first"
+                    priority: "after:resolveResourceModel" // Resolve FLUID-6705 by allowing localised resources
                 }
             }
         }

--- a/src/framework/core/js/ResourceLoader.js
+++ b/src/framework/core/js/ResourceLoader.js
@@ -733,6 +733,10 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
     fluid.resourceLoader.loaders.resourceText.noPath = true;
 
+    // Implementation note: Whilst there will not be a type error if the user writes a non-promise return, there will
+    // be a race failure as the "resource" initialiser in fluid.resourceFromRecord loses to the transformEvent listener,
+    // overwriting its result with the FetchOne value as, e.g. fluid.getForComponent resolves synchronously. As a result
+    // we have to say we can't support synchronous "early" resources.
     /** A generalised 'promise' `OneResourceLoader` that allows some arbitrary asynchronous process to be
      * interpolated into the loader. The function `promiseFunc` is invoked with
      * arguments `promiseArg` yielding a promise representing successful or unsuccessful loading of the resource value
@@ -882,7 +886,8 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
                     args: ["{that}", "{that}.options.resources", "{that}.options.resourceOptions", "{that}.transformResourceURL"]
                 }
             }/*,
-            // These arrive dynamically by means of the framework's workflow function
+            // If these are demanded early, they will be resolved as instances of FetchOne by means of the framework's fluid.resourceFromRecord record mounter,
+            // but are then overwritten by the resolved resourceSpec value by the noteComponentResource listener to the resource's transformEvent
             resources: {}
             */
         },

--- a/src/framework/core/js/ResourceLoader.js
+++ b/src/framework/core/js/ResourceLoader.js
@@ -733,16 +733,13 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
 
     fluid.resourceLoader.loaders.resourceText.noPath = true;
 
-    // Implementation note: Whilst there will not be a type error if the user writes a non-promise return, there will
-    // be a race failure as the "resource" initialiser in fluid.resourceFromRecord loses to the transformEvent listener,
-    // overwriting its result with the FetchOne value as, e.g. fluid.getForComponent resolves synchronously. As a result
-    // we have to say we can't support synchronous "early" resources.
-    /** A generalised 'promise' `OneResourceLoader` that allows some arbitrary asynchronous process to be
+    /** A generalised 'promise' `OneResourceLoader` that allows some arbitrary asynchronous or synchronous process to be
      * interpolated into the loader. The function `promiseFunc` is invoked with
-     * arguments `promiseArg` yielding a promise representing successful or unsuccessful loading of the resource value
+     * arguments `promiseArg` yielding a promise representing successful or unsuccessful loading of the resource value.
      * @param {ResourceSpec} resourceSpec - A `ResourceSpec` for which the `promiseFunc` field has already been filled in to hold
      * a function returning a promise
-     * @return {Promise} The result of invoking `promiseFunc` with `promiseArgs`
+     * @return {Promise|Any} The result of invoking `promiseFunc` with `promiseArgs` - this function may also synchronously resolve
+     * with a direct, non-promise value.
      */
     fluid.resourceLoader.loaders.promiseFunc = function (resourceSpec) {
         var promiseFunc = fluid.event.resolveListener(resourceSpec.promiseFunc);

--- a/tests/framework-tests/core/js/FluidIoCViewTests.js
+++ b/tests/framework-tests/core/js/FluidIoCViewTests.js
@@ -738,18 +738,40 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
         }
     });
 
+    fluid.tests.materialIdTest = function (creator, selector) {
+        var that = fluid.invokeGlobalFunction(creator, [selector]);
+        var domId = that.locate("field")[0].id;
+        jqUnit.assertValue("Id allocated to field ", domId);
+        jqUnit.assertEquals("Dom id and model id agree", domId, that.model.fieldId);
+        return that;
+    };
+
     jqUnit.test("ID materialisation test", function () {
-        var oneTest = function (selector) {
-            var that = fluid.tests.materialId(selector);
-            var domId = that.locate("field")[0].id;
-            jqUnit.assertValue("Id allocated to field ", domId);
-            jqUnit.assertEquals("Dom id and model id agree", domId, that.model.fieldId);
-            return that;
-        };
-        oneTest(".flc-tests-simple-integral");
-        var that = oneTest(".flc-tests-with-id");
+        fluid.tests.materialIdTest("fluid.tests.materialId", ".flc-tests-simple-integral");
+        var that = fluid.tests.materialIdTest("fluid.tests.materialId", ".flc-tests-with-id");
         jqUnit.assertEquals("Original id was undisturbed", "original-id", that.model.fieldId);
 
+    });
+
+    fluid.defaults("fluid.tests.FLUID6703materialId", {
+        gradeNames: "fluid.viewComponent",
+        selectors: {
+            field: ".flc-tests-simple-field"
+        },
+        model: {
+            fieldId: "model-id"
+        },
+        modelRelay: {
+            relayId: {
+                source: "fieldId",
+                target: "dom.field.id"
+            }
+        }
+    });
+
+    jqUnit.test("FLUID-6703 ID materialisation test", function () {
+        var that = fluid.tests.materialIdTest("fluid.tests.FLUID6703materialId", ".flc-tests-with-id");
+        jqUnit.assertEquals("Original id was overwritten", "model-id", that.model.fieldId);
     });
 
     // Bad materialisation test

--- a/tests/framework-tests/core/js/NewViewSupportTests.js
+++ b/tests/framework-tests/core/js/NewViewSupportTests.js
@@ -126,6 +126,23 @@ https://github.com/fluid-project/infusion/raw/main/Infusion-LICENSE.txt
             });
         });
 
+        /** Synchronously resolved template is corrupted **/
+
+        fluid.defaults("fluid.tests.FLUID6706test", {
+            gradeNames: ["fluid.templateResourceFetcher"],
+            resources: {
+                template: {
+                    promiseFunc: "fluid.identity",
+                    promiseArgs: "<div></div>"
+                }
+            }
+        });
+
+        jqUnit.test("Synchronously resolved template is corrupted", function () {
+            var that = fluid.tests.FLUID6706test();
+            jqUnit.assertEquals("Resolved template synchronously", "<div></div>", that.resources.template.resourceText);
+        });
+
         /** "CollectionSpace-style" rendering test with nested containers with their own template resources **/
 
         fluid.defaults("fluid.tests.nestedTemplateRenderingView", {


### PR DESCRIPTION
FLUID-6703: Fix and test case for id materialisation precedence
FLUID-6704: Move priority of template fetch to after model resolution
FLUID-6706: Support synchronous template fetches