### PR TITLE
FLUID-6736: fix self voicing in safari

### DIFF
--- a/src/components/textToSpeech/js/MockTTS.js
+++ b/src/components/textToSpeech/js/MockTTS.js
@@ -159,6 +159,8 @@ fluid.mock.textToSpeech.stubs.resume = function (that) {
     }
 };
 
+// This function returns actual speech synthesis voices instead of mocked voices because fluid.textToSpeech.utterance
+// was not mocked enough to accept non-SpeechSynthesisVoice objects.
 fluid.mock.textToSpeech.stubs.getVoices = function () {
     return speechSynthesis.getVoices();
 };

--- a/src/components/textToSpeech/js/MockTTS.js
+++ b/src/components/textToSpeech/js/MockTTS.js
@@ -89,6 +89,9 @@ fluid.defaults("fluid.mock.textToSpeech", {
             funcName: "fluid.mock.textToSpeech.recordEvent",
             args: ["{that}.eventRecord", "{arguments}.0"]
         },
+        getVoices: {
+            funcName: "fluid.mock.textToSpeech.stubs.getVoices"
+        },
         // override the speak invoker to return the utterance component instead of the SpeechSynthesisUtterance instance
         speak: {
             funcName: "fluid.mock.textToSpeech.speakOverride",
@@ -156,13 +159,8 @@ fluid.mock.textToSpeech.stubs.resume = function (that) {
     }
 };
 
-fluid.mock.textToSpeech.voices =  [
-    {voiceURI: "Alex", name: "Alex", lang: "en-US", localService: true, default: true},
-    {voiceURI: "Alice", name: "Alice", lang: "it-IT", localService: true, default: false}
-];
-
 fluid.mock.textToSpeech.stubs.getVoices = function () {
-    return fluid.mock.textToSpeech.voices;
+    return speechSynthesis.getVoices();
 };
 
 fluid.mock.textToSpeech.recordEvent = function (eventRecord, name) {

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -197,7 +197,7 @@ fluid.defaults("fluid.textToSpeech", {
         },
         getVoiceByLang: {
             funcName: "fluid.textToSpeech.getVoiceByLang",
-            args: ["{that}", "{arguments}.0"]
+            args: ["{that}.voices", "{that}.options.defaultLanguage", "{arguments}.0"]
         },
         speak: {
             func: "{that}.invokeSpeechSynthesisFunc",
@@ -288,23 +288,29 @@ fluid.textToSpeech.handleEnd = function (that) {
     }
 };
 
-// Find the voice by the language code
-// 1. If the language code is not provided, use the default language;
-// 2. If the voice for the language code is not found, fall back to the first voice that supports the same country
-// code;
-// 3. If the voice is still not found, return the voice of options.defaultLanguage.
-fluid.textToSpeech.getVoiceByLang = function (that, lang) {
-    lang = lang || that.options.defaultLanguage;
+/**
+ * Find the voice by the language code.
+ * 1. If the language code is not provided, use the default language;
+ * 2. If the voice for the language code is not found, fall back to the first voice that supports the same country
+ * code;
+ * 3. If the voice is still not found, return the first voice in the voice list.
+ * @param {Array} voices - An array of voices returned by speechSynthesis API getVoices()
+ * @param {String} defaultLanguage - the default language to fall back
+ * @param {String} lang - the language code to find a voice for
+ * @return {SpeechSynthesisVoice} - return a voice for the language code
+ */
+fluid.textToSpeech.getVoiceByLang = function (voices, defaultLanguage, lang) {
+    lang = lang || defaultLanguage;
 
-    var voiceTogo = that.voices.find(voice => voice.lang === lang);
+    var voiceTogo = voices.find(voice => voice.lang === lang);
 
     if (!voiceTogo) {
         // find the first voice that matches the country code
         var indexOfSeparator = lang.indexOf("-");
         var countryCode = indexOfSeparator > 0 ? lang.substring(0, indexOfSeparator) : lang;
-        voiceTogo = that.voices.find(voice => voice.lang.startsWith(countryCode));
+        voiceTogo = voices.find(voice => voice.lang.startsWith(countryCode));
     }
-    return voiceTogo ? voiceTogo : that.voices.find(voice => voice.lang === that.options.defaultLanguage);
+    return voiceTogo ? voiceTogo : voices[0];
 };
 
 /**

--- a/src/components/textToSpeech/js/TextToSpeech.js
+++ b/src/components/textToSpeech/js/TextToSpeech.js
@@ -62,6 +62,7 @@ fluid.textToSpeech.isSupported = function () {
 fluid.defaults("fluid.textToSpeech", {
     gradeNames: ["fluid.modelComponent", "fluid.resolveRootSingle"],
     singleRootType: "fluid.textToSpeech",
+    defaultLanguage: navigator.language,
     events: {
         onStart: null,
         onStop: null,
@@ -267,7 +268,6 @@ fluid.textToSpeech.requestControl = function (that, control, change) {
 };
 
 fluid.textToSpeech.getVoiceByLang = function (that, lang) {
-    lang = lang || "en-US";
     var voices = that.getVoices() || [];
     return voices.find(voice => voice.lang === lang);
 };
@@ -325,7 +325,7 @@ fluid.textToSpeech.queueSpeech = function (that, text, interrupt, options) {
     }
 
     options = options || {};
-    options.voice = that.getVoiceByLang(options.lang);
+    options.voice = options.voice || that.getVoiceByLang(options.lang || that.options.defaultLanguage);
     var utteranceOpts = $.extend({}, that.model.utteranceOpts, options, {text: text});
 
     // The setTimeout is needed for Safari to fully cancel out the previous speech.

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -587,28 +587,31 @@ fluid.tests.textToSpeech.contextAwareTestRunner();
  *********************************************************************************************/
 
 jqUnit.test("Test fluid.textToSpeech.getVoiceByLang()", function () {
+    var defaultLanguage = "en-US";
+    var voices = [
+        {voiceURI: "Alice", name: "Alice", lang: "it-IT", localService: true, default: false},
+        {voiceURI: "Alex", name: "Alex", lang: "en-US", localService: true, default: true}
+    ];
     var testCases = [{
         message: "When the language code is not provided, return the voice of the default language",
         lang: null,
-        expectedLang: navigator.language
+        expectedLang: defaultLanguage
     }, {
         message: "When a voice for the language code is found, return the voice",
-        lang: "fr-CA",
-        expectedLang: "fr-CA"
+        lang: "en-US",
+        expectedLang: "en-US"
     }, {
         message: "When a voice for the language code is not found, return the voice that matches the country code",
-        lang: "fr-random",
-        expectedLang: "fr-CA"
+        lang: "en-CA",
+        expectedLang: "en-US"
     }, {
         message: "When a voice for both the language code and the country code is not found, return the voice of the default language",
         lang: "random",
-        expectedLang: navigator.language
+        expectedLang: "it-IT"
     }];
 
-    var that = fluid.tests.textToSpeech();
-
     fluid.each(testCases, function (testCase) {
-        var voice = fluid.textToSpeech.getVoiceByLang(that, testCase.lang);
+        var voice = fluid.textToSpeech.getVoiceByLang(voices, defaultLanguage, testCase.lang);
         jqUnit.assertEquals(testCase.message, testCase.expectedLang, voice.lang);
     });
 });

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -136,8 +136,8 @@ fluid.defaults("fluid.tests.textToSpeech.ttsTester", {
             [{
                 task: "{tts}.queueSpeech",
                 args: "Testing queueSpeech promise",
-                resolve: "jqUnit.assert",
-                resolveArgs: ["The queueSpeech promise resolved"]
+                resolve: "jqUnit.assertNotNull",
+                resolveArgs: ["utterance.voice value is assigned", "{arguments}.0.utterance.voice"]
             }]
         }]
     }]

--- a/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
+++ b/tests/component-tests/textToSpeech/js/TextToSpeechTests.js
@@ -581,3 +581,34 @@ fluid.defaults("fluid.tests.textToSpeech.contextAwareTestRunner.supportsPauseRes
 });
 
 fluid.tests.textToSpeech.contextAwareTestRunner();
+
+/*********************************************************************************************
+ * Unit test
+ *********************************************************************************************/
+
+jqUnit.test("Test fluid.textToSpeech.getVoiceByLang()", function () {
+    var testCases = [{
+        message: "When the language code is not provided, return the voice of the default language",
+        lang: null,
+        expectedLang: navigator.language
+    }, {
+        message: "When a voice for the language code is found, return the voice",
+        lang: "fr-CA",
+        expectedLang: "fr-CA"
+    }, {
+        message: "When a voice for the language code is not found, return the voice that matches the country code",
+        lang: "fr-random",
+        expectedLang: "fr-CA"
+    }, {
+        message: "When a voice for both the language code and the country code is not found, return the voice of the default language",
+        lang: "random",
+        expectedLang: navigator.language
+    }];
+
+    var that = fluid.tests.textToSpeech();
+
+    fluid.each(testCases, function (testCase) {
+        var voice = fluid.textToSpeech.getVoiceByLang(that, testCase.lang);
+        jqUnit.assertEquals(testCase.message, testCase.expectedLang, voice.lang);
+    });
+});


### PR DESCRIPTION
To resolve [FLUID-6736](https://issues.fluidproject.org/browse/FLUID-6736)

The self voicing stops working in Safari because `voice` is not provided when creating `SpeechSynthesisUtterance` instances at speaking. Before, when the `voice` value is missing, browsers will use the default voice. This is no longer supported in Safari.

The fix is to find the corresponding voice for the language of the speech. When the language is not given, use "en-US" as default.