### PR TITLE
FLUID-6764: Fix to jquery.standalone for use with AudioWorklets.

### DIFF
--- a/src/framework/core/js/jquery.standalone.js
+++ b/src/framework/core/js/jquery.standalone.js
@@ -33,7 +33,7 @@ var fluid = fluid || {}; // eslint-disable-line no-redeclare
     var hasOwn = Object.prototype.hasOwnProperty;
     var globalScope = typeof window !== "undefined" ? window :
         typeof self !== "undefined" ? self :
-        typeof global !== "undefined" ? global : {};
+            typeof global !== "undefined" ? global : {};
     // Map over jQuery in case of overwrite
     var _jQuery = globalScope.jQuery;
     // Map over the $ in case of overwrite

--- a/src/framework/core/js/jquery.standalone.js
+++ b/src/framework/core/js/jquery.standalone.js
@@ -32,7 +32,8 @@ var fluid = fluid || {}; // eslint-disable-line no-redeclare
     var toString = Object.prototype.toString;
     var hasOwn = Object.prototype.hasOwnProperty;
     var globalScope = typeof window !== "undefined" ? window :
-        typeof self !== "undefined" ? self : global;
+        typeof self !== "undefined" ? self :
+        typeof global !== "undefined" ? global : {};
     // Map over jQuery in case of overwrite
     var _jQuery = globalScope.jQuery;
     // Map over the $ in case of overwrite


### PR DESCRIPTION
This PR updates the global scope detection code in jquery.standalone.js to support use within an AudioWorkletGlobalScope, which is a super-minimal environment that provides no references to the global scope at all.

I haven't included any tests for this fix, because AudioWorkletGlobalScope doesn't even provide a means to import or load scripts, so we'd have to prepare a specialized build just for this purpose, which would include a custom AudioProcessor class and wrap everything in an ES6 module. I did, however, confirm that all the current unit tests continue to pass.