### PR TITLE
FLUID-6776: update URLs related to GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: Bug Report and Feature Requests
-    url: https://issues.fluidproject.org/projects/FLUID/
+    url: https://fluidproject.atlassian.net/jira/software/c/projects/FLUID/issues
     about: Please file issues and feature requests in the JIRA issue tracker.
   - name: Community Support
-    url: https://wiki.fluidproject.org/display/fluid/Get+Involved
+    url: https://fluidproject.atlassian.net/wiki/spaces/fluid/pages/11547481/Get+Involved
     about: Please see the Get Involved page for information about participating and communicating in the community.
   - name: Security Issues
     url: https://github.com/fluid-project/.github/blob/main/SECURITY.md


### PR DESCRIPTION
Updates the URLs presented when trying to create a new issue from the GitHub. This updates the URLs that changed when Atalassian products were moved to cloud hosting.