### PR TITLE
NOJIRA: (ci) replace deprecated workflows with current versions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,30 +18,30 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - name: Prepare git
-      run: git config --global core.autocrlf false
+      - name: Prepare git
+        run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Get npm cache directory		
-      id: npm-cache		
-      run: |		
-        echo "::set-output name=dir::$(npm config get cache)"		
-		
-    - uses: actions/cache@v4	
-      with:		
-        path: ${{ steps.npm-cache.outputs.dir }}		
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}		
-        restore-keys: |		
-          ${{ runner.os }}-node-
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
 
-    - name: Install Node.js dependencies
-      run: npm install
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-    - name: Run browser bundle tests
-      run: npm run test:bundles
+      - name: Install Node.js dependencies
+        run: npm install
+
+      - name: Run browser bundle tests
+        run: npm run test:bundles

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,18 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+
+    - name: Get npm cache directory		
+      id: npm-cache		
+      run: |		
+        echo "::set-output name=dir::$(npm config get cache)"		
+		
+    - uses: actions/cache@v4	
+      with:		
+        path: ${{ steps.npm-cache.outputs.dir }}		
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}		
+        restore-keys: |		
+          ${{ runner.os }}-node-
 
     - name: Install Node.js dependencies
       run: npm install

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,24 +21,13 @@ jobs:
     - name: Prepare git
       run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - uses: actions/cache@v2
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: 'npm'
 
     - name: Install Node.js dependencies
       run: npm install

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,18 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 20.x
-        cache: 'npm'
+
+    - name: Get npm cache directory		
+      id: npm-cache		
+      run: |		
+        echo "::set-output name=dir::$(npm config get cache)"		
+		
+    - uses: actions/cache@v4	
+      with:		
+        path: ${{ steps.npm-cache.outputs.dir }}		
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}		
+        restore-keys: |		
+          ${{ runner.os }}-node-
 
     - name: Install Node.js dependencies
       run: npm install

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -8,30 +8,30 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Prepare git
-      run: git config --global core.autocrlf false
+      - name: Prepare git
+        run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js 20
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.x
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
 
-    - name: Get npm cache directory		
-      id: npm-cache		
-      run: |		
-        echo "::set-output name=dir::$(npm config get cache)"		
-		
-    - uses: actions/cache@v4	
-      with:		
-        path: ${{ steps.npm-cache.outputs.dir }}		
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}		
-        restore-keys: |		
-          ${{ runner.os }}-node-
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
 
-    - name: Install Node.js dependencies
-      run: npm install
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-    - name: Run code linter
-      run: npm run lint
+      - name: Install Node.js dependencies
+        run: npm install
+
+      - name: Run code linter
+        run: npm run lint

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -5,31 +5,19 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     timeout-minutes: 20
 
     steps:
     - name: Prepare git
       run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Use Node.js 20
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
-
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - uses: actions/cache@v2
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: 'npm'
 
     - name: Install Node.js dependencies
       run: npm install

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,26 +3,26 @@ name: Automated tests
 on:
   push:
     paths:
-        - '.nycrc'
-        - 'package.json'
-        - 'buildModules.js'
-        - 'src/**/*.html'
-        - 'src/**/*.js'
-        - 'src/**/*.json'
-        - 'tests/**/*.html'
-        - 'tests/**/*.js'
-        - 'tests/**/*.json'
+      - ".nycrc"
+      - "package.json"
+      - "buildModules.js"
+      - "src/**/*.html"
+      - "src/**/*.js"
+      - "src/**/*.json"
+      - "tests/**/*.html"
+      - "tests/**/*.js"
+      - "tests/**/*.json"
   pull_request:
     paths:
-        - '.nycrc'
-        - 'package.json'
-        - 'buildModules.js'
-        - 'src/**/*.html'
-        - 'src/**/*.js'
-        - 'src/**/*.json'
-        - 'tests/**/*.html'
-        - 'tests/**/*.js'
-        - 'tests/**/*.json'
+      - ".nycrc"
+      - "package.json"
+      - "buildModules.js"
+      - "src/**/*.html"
+      - "src/**/*.js"
+      - "src/**/*.json"
+      - "tests/**/*.html"
+      - "tests/**/*.js"
+      - "tests/**/*.json"
 
 defaults:
   run:
@@ -42,43 +42,43 @@ jobs:
       HEADLESS: true
 
     steps:
-    - name: Prepare git
-      run: git config --global core.autocrlf false
+      - name: Prepare git
+        run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-       
-    - name: Get npm cache directory		
-      id: npm-cache		
-      run: |		
-        echo "::set-output name=dir::$(npm config get cache)"		
-		
-    - uses: actions/cache@v4	
-      with:		
-        path: ${{ steps.npm-cache.outputs.dir }}		
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}		
-        restore-keys: |		
-          ${{ runner.os }}-node-
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Install Node.js dependencies
-      run: npm install
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
 
-    - name: Run browser tests
-      run: npm run test:browser
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-    - name: Run Node.js tests
-      run: npm run test:node
+      - name: Install Node.js dependencies
+        run: npm install
 
-    - name: Update code coverage
-      run: npm run posttest
+      - name: Run browser tests
+        run: npm run test:browser
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        files: ./reports/coverage-final.json
-        flags: unit-tests
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run Node.js tests
+        run: npm run test:node
+
+      - name: Update code coverage
+        run: npm run posttest
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./reports/coverage-final.json
+          flags: unit-tests
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -51,7 +51,18 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+       
+    - name: Get npm cache directory		
+      id: npm-cache		
+      run: |		
+        echo "::set-output name=dir::$(npm config get cache)"		
+		
+    - uses: actions/cache@v4	
+      with:		
+        path: ${{ steps.npm-cache.outputs.dir }}		
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}		
+        restore-keys: |		
+          ${{ runner.os }}-node-
 
     - name: Install Node.js dependencies
       run: npm install

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -66,7 +66,8 @@ jobs:
       run: npm run posttest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v5
       with:
         files: ./reports/coverage-final.json
         flags: unit-tests
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -31,7 +31,6 @@ defaults:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-
     timeout-minutes: 20
 
     strategy:
@@ -46,24 +45,13 @@ jobs:
     - name: Prepare git
       run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - uses: actions/cache@v2
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: 'npm'
 
     - name: Install Node.js dependencies
       run: npm install


### PR DESCRIPTION
Many of the workflows in use (e.g. `actions/checkout@v2`) are about to be deprecated. This PR updates them accordingly and configures the required token for `codecov/codecov-action@v5`. Also note that this PR is unable to switch to using the NPM caching provided by the `setup-node` action because the `package-lock.json` file is not committed to Git. We may want to reconsider this.