### PR TITLE
FLUID-6783: styling selection highlights in contrast themes

### DIFF
--- a/src/framework/preferences/css/sass/Contrast_base.scss
+++ b/src/framework/preferences/css/sass/Contrast_base.scss
@@ -24,8 +24,8 @@
     --_fl-linkBgColor: #fff;
     --_fl-disabledFgColor: #000;
     --_fl-disabledBgColor: #fff;
-    --_fl-selectedFgColor: revert;
-    --_fl-selectedBgColor: revert;
+    --_fl-selectedFgColor: #fff;
+    --_fl-selectedBgColor: #000;
     --_fl-buttonFgColor: #000;
     --_fl-buttonBgColor: #fff;
 }
@@ -37,8 +37,8 @@
     --_fl-linkBgColor: #000;
     --_fl-disabledFgColor: #fff;
     --_fl-disabledBgColor: #000;
-    --_fl-selectedFgColor: revert;
-    --_fl-selectedBgColor: revert;
+    --_fl-selectedFgColor: #000;
+    --_fl-selectedBgColor: #fff;
     --_fl-buttonFgColor: #fff;
     --_fl-buttonBgColor: #000;
 }
@@ -50,8 +50,8 @@
     --_fl-linkBgColor: #000;
     --_fl-disabledFgColor: #ff0;
     --_fl-disabledBgColor: #000;
-    --_fl-selectedFgColor: revert;
-    --_fl-selectedBgColor: revert;
+    --_fl-selectedFgColor: #000;
+    --_fl-selectedBgColor: #ff0;
     --_fl-buttonFgColor: #ff0;
     --_fl-buttonBgColor: #000;
 }
@@ -63,8 +63,8 @@
     --_fl-linkBgColor: #ff0;
     --_fl-disabledFgColor: #000;
     --_fl-disabledBgColor: #ff0;
-    --_fl-selectedFgColor: revert;
-    --_fl-selectedBgColor: revert;
+    --_fl-selectedFgColor: #ff0;
+    --_fl-selectedBgColor: #000;
     --_fl-buttonFgColor: #000;
     --_fl-buttonBgColor: #ff0;
 }
@@ -76,8 +76,8 @@
     --_fl-linkBgColor: #555;
     --_fl-disabledFgColor: #bdbdbb;
     --_fl-disabledBgColor: #555;
-    --_fl-selectedFgColor: revert;
-    --_fl-selectedBgColor: revert;
+    --_fl-selectedFgColor: #555;
+    --_fl-selectedBgColor: #bdbdbb;
     --_fl-buttonFgColor: #bdbdbb;
     --_fl-buttonBgColor: #555;
 }

--- a/tests/manual-tests/framework/preferences/baseStyles/css/styles.css
+++ b/tests/manual-tests/framework/preferences/baseStyles/css/styles.css
@@ -1,3 +1,8 @@
+::selection {
+    background-color: var(--fl-selectedBgColor, highlight);
+    color: var(--fl-selectedFgColor, highlighttext);
+}
+
 body {
     background-color: var(--fl-bgColor, #f3f6f7);
     color: var(--fl-fgColor, #131c2a);


### PR DESCRIPTION
 - Adds values for selection colours for all contrast themes
 - Updates the baseStyles demo to make use of selection contrast values

_**NOTE:** Requires #1110; whose changes are currently included in this PR_